### PR TITLE
Version Aware SonarQube detection, and isolated codebase for those parts.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 import { Command } from 'commander';
 import { loadConfig, requireProjectKeys } from './config/loader.js';
-import { SonarQubeClient } from './sonarqube/api-client.js';
+import { VersionAwareSonarQubeClient as SonarQubeClient } from './sonarqube/version-aware-client.js';
 import { SonarCloudClient } from './sonarcloud/api-client.js';
 import { StateTracker } from './state/tracker.js';
 import logger from './utils/logger.js';

--- a/src/migrate-pipeline.js
+++ b/src/migrate-pipeline.js
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { mkdir, rm, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { SonarQubeClient } from './sonarqube/api-client.js';
+import { VersionAwareSonarQubeClient as SonarQubeClient } from './sonarqube/version-aware-client.js';
 import { resolvePerformanceConfig, collectEnvironmentInfo } from './utils/concurrency.js';
 import logger from './utils/logger.js';
 import { writeAllReports } from './reports/index.js';

--- a/src/pipeline/org-migration.js
+++ b/src/pipeline/org-migration.js
@@ -1,6 +1,6 @@
 import { writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { SonarQubeClient } from '../sonarqube/api-client.js';
+import { VersionAwareSonarQubeClient as SonarQubeClient } from '../sonarqube/version-aware-client.js';
 import { SonarCloudClient } from '../sonarcloud/api-client.js';
 import { migrateQualityGates } from '../sonarcloud/migrators/quality-gates.js';
 import { migrateQualityProfiles } from '../sonarcloud/migrators/quality-profiles.js';
@@ -11,7 +11,7 @@ import { migratePortfolios } from '../sonarcloud/migrators/portfolios.js';
 import { mapProjectsToOrganizations, mapResourcesToOrganizations } from '../mapping/org-mapper.js';
 import { generateMappingCsvs } from '../mapping/csv-generator.js';
 import logger from '../utils/logger.js';
-import { parseSonarQubeVersion, hasCleanCodeTaxonomy } from '../utils/version.js';
+import { hasCleanCodeTaxonomy } from '../utils/version.js';
 import { buildRuleEnrichmentMap } from '../sonarcloud/rule-enrichment.js';
 import { migrateOrgProjects, resolveProjectKey } from './project-migration.js';
 
@@ -158,10 +158,8 @@ export async function migrateOneOrganization(assignment, extractedData, resource
 
   const sqClient = new SonarQubeClient({ url: ctx.sonarqubeConfig.url, token: ctx.sonarqubeConfig.token });
 
-  // Detect SQ version and build rule enrichment map once per org (for SQ 9.9 compat)
-  const sqVersionStr = extractedData.serverInfo?.system?.version || await sqClient.getServerVersion();
-  const sqVersion = parseSonarQubeVersion(sqVersionStr);
-  logger.info(`SonarQube server version: ${sqVersion.raw}`);
+  // Use cached version or detect now (VersionAwareSonarQubeClient handles caching)
+  const sqVersion = sqClient.parsedVersion || await sqClient.detectVersion();
 
   if (!hasCleanCodeTaxonomy(sqVersion) && !ctx.ruleEnrichmentMap) {
     logger.warn(`SonarQube ${sqVersion.raw} does not support Clean Code taxonomy. Building enrichment map from SonarCloud...`);

--- a/src/pipeline/project-migration.js
+++ b/src/pipeline/project-migration.js
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { SonarQubeClient } from '../sonarqube/api-client.js';
+import { VersionAwareSonarQubeClient as SonarQubeClient } from '../sonarqube/version-aware-client.js';
 import { SonarCloudClient } from '../sonarcloud/api-client.js';
 import { transferProject } from '../transfer-pipeline.js';
 import { extractHotspots } from '../sonarqube/extractors/hotspots.js';

--- a/src/sonarqube/version-aware-client.js
+++ b/src/sonarqube/version-aware-client.js
@@ -1,0 +1,110 @@
+/**
+ * Version-aware SonarQube client that adapts API calls based on the
+ * detected server version.  Extends the base SonarQubeClient without
+ * modifying it — all backward-compatibility logic lives here.
+ *
+ * Supports: SonarQube 9.9 LTS, 10.x, and 2025.1+
+ */
+
+import { SonarQubeClient } from './api-client.js';
+import { parseSonarQubeVersion, isAtLeast } from '../utils/version.js';
+import logger from '../utils/logger.js';
+
+// Pre-10.4 lifecycle + 10.4+ lifecycle combined.
+// SonarQube ignores unknown status values, so this is safe for 9.9 and ≤10.3.
+const LEGACY_STATUSES = 'OPEN,CONFIRMED,REOPENED,RESOLVED,CLOSED,FALSE_POSITIVE,ACCEPTED,FIXED';
+
+// 10.4+ uses the `issueStatuses` parameter with a reduced set
+// (REOPENED, RESOLVED, CLOSED no longer exist in the new lifecycle).
+const MODERN_ISSUE_STATUSES = 'OPEN,CONFIRMED,FALSE_POSITIVE,ACCEPTED,FIXED';
+
+export class VersionAwareSonarQubeClient extends SonarQubeClient {
+  constructor(config) {
+    super(config);
+    this._parsedVersion = null;
+  }
+
+  /**
+   * Detect, parse, and cache the SonarQube server version.
+   * Safe to call multiple times — returns the cached result after the first call.
+   * @returns {Promise<{ major: number, minor: number, patch: number, raw: string }>}
+   */
+  async detectVersion() {
+    if (this._parsedVersion) return this._parsedVersion;
+    const versionStr = await this.getServerVersion();
+    this._parsedVersion = parseSonarQubeVersion(versionStr);
+    logger.info(`SonarQube server version: ${this._parsedVersion.raw} (${this._compatModeLabel()})`);
+    return this._parsedVersion;
+  }
+
+  get parsedVersion() {
+    return this._parsedVersion;
+  }
+
+  // ── Overrides: version-aware issue fetching ──────────────────────
+
+  /**
+   * Fetch issues using the correct status parameter for the detected version.
+   * - SQ < 10.4  → uses `statuses` (legacy)
+   * - SQ ≥ 10.4  → uses `issueStatuses` (modern, avoids deprecation warnings)
+   * Falls back to legacy when version has not been detected yet.
+   */
+  async getIssues(filters = {}) {
+    const params = { componentKeys: this.projectKey, ...this._buildStatusParams(), ...filters };
+    logger.info(`Fetching issues for project: ${this.projectKey}`);
+    return await this.getPaginated('/api/issues/search', params, 'issues');
+  }
+
+  async getIssuesWithComments(filters = {}) {
+    const params = {
+      componentKeys: this.projectKey,
+      additionalFields: 'comments',
+      ...this._buildStatusParams(),
+      ...filters
+    };
+    logger.info(`Fetching issues with comments for project: ${this.projectKey}`);
+    return await this.getPaginated('/api/issues/search', params, 'issues');
+  }
+
+  // ── Overrides: defensive wrappers ────────────────────────────────
+
+  /**
+   * Fetch user groups with a try/catch guard.
+   * The /api/user_groups/search endpoint is being migrated to Web API V2
+   * and may be removed in future SonarQube versions.
+   */
+  async getGroups() {
+    try {
+      return await super.getGroups();
+    } catch (error) {
+      logger.warn(`Failed to fetch user groups (endpoint may be unavailable in this SQ version): ${error.message}`);
+      return [];
+    }
+  }
+
+  /**
+   * Test connection and also detect + log the server version.
+   */
+  async testConnection() {
+    const result = await super.testConnection();
+    await this.detectVersion();
+    return result;
+  }
+
+  // ── Internal helpers ─────────────────────────────────────────────
+
+  _buildStatusParams() {
+    if (this._parsedVersion && isAtLeast(this._parsedVersion, 10, 4)) {
+      return { issueStatuses: MODERN_ISSUE_STATUSES };
+    }
+    return { statuses: LEGACY_STATUSES };
+  }
+
+  _compatModeLabel() {
+    const v = this._parsedVersion;
+    if (!v || v.major === 0) return 'unknown version';
+    if (v.major < 10) return 'legacy 9.x — pre-Clean Code taxonomy';
+    if (!isAtLeast(v, 10, 4)) return '10.0-10.3 — Clean Code taxonomy, legacy issue statuses';
+    return 'modern 10.4+ issue statuses';
+  }
+}

--- a/src/transfer-pipeline.js
+++ b/src/transfer-pipeline.js
@@ -1,11 +1,11 @@
-import { SonarQubeClient } from './sonarqube/api-client.js';
+import { VersionAwareSonarQubeClient as SonarQubeClient } from './sonarqube/version-aware-client.js';
 import { SonarCloudClient } from './sonarcloud/api-client.js';
 import { DataExtractor } from './sonarqube/extractors/index.js';
 import { ProtobufBuilder } from './protobuf/builder.js';
 import { ProtobufEncoder } from './protobuf/encoder.js';
 import { ReportUploader } from './sonarcloud/uploader.js';
 import { StateTracker } from './state/tracker.js';
-import { parseSonarQubeVersion, hasCleanCodeTaxonomy } from './utils/version.js';
+import { hasCleanCodeTaxonomy } from './utils/version.js';
 import { buildRuleEnrichmentMap } from './sonarcloud/rule-enrichment.js';
 import logger from './utils/logger.js';
 
@@ -105,10 +105,8 @@ export async function transferProject({ sonarqubeConfig, sonarcloudConfig, trans
   logger.info('Fetching SonarCloud rule repositories...');
   const sonarCloudRepos = await sonarCloudClient.getRuleRepositories();
 
-  // Detect SonarQube version and build rule enrichment map if needed
-  const sqVersionStr = await sonarQubeClient.getServerVersion();
-  const sqVersion = parseSonarQubeVersion(sqVersionStr);
-  logger.info(`SonarQube server version: ${sqVersion.raw}`);
+  // Use cached version from testConnection() / detectVersion(), or detect now
+  const sqVersion = sonarQubeClient.parsedVersion || await sonarQubeClient.detectVersion();
 
   let ruleEnrichmentMap = prebuiltEnrichmentMap || new Map();
   if (!prebuiltEnrichmentMap && !hasCleanCodeTaxonomy(sqVersion)) {

--- a/src/utils/version.js
+++ b/src/utils/version.js
@@ -30,3 +30,16 @@ export function parseSonarQubeVersion(versionStr) {
 export function hasCleanCodeTaxonomy(version) {
   return version.major >= 10;
 }
+
+/**
+ * Check if the parsed SQ version is at least major.minor.
+ * Works for both old numbering (9.9, 10.4) and 2025.x scheme.
+ * @param {{ major: number, minor: number }} version
+ * @param {number} major
+ * @param {number} [minor=0]
+ * @returns {boolean}
+ */
+export function isAtLeast(version, major, minor = 0) {
+  if (version.major !== major) return version.major > major;
+  return version.minor >= minor;
+}

--- a/src/verification/verify-pipeline.js
+++ b/src/verification/verify-pipeline.js
@@ -1,5 +1,5 @@
 import { mkdir } from 'node:fs/promises';
-import { SonarQubeClient } from '../sonarqube/api-client.js';
+import { VersionAwareSonarQubeClient as SonarQubeClient } from '../sonarqube/version-aware-client.js';
 import { SonarCloudClient } from '../sonarcloud/api-client.js';
 import { resolvePerformanceConfig, collectEnvironmentInfo } from '../utils/concurrency.js';
 import { mapProjectsToOrganizations } from '../mapping/org-mapper.js';


### PR DESCRIPTION
## Version-Aware SonarQube Client

### What it does

The `VersionAwareSonarQubeClient` is a subclass of `SonarQubeClient` that automatically detects which SonarQube server version it's connected to and adapts its API calls for backward and forward compatibility.

### Why it's needed

CloudVoyager needs to support three SonarQube version ranges that have different API behaviors:

| Version | Issue Status Param | Issue Statuses | Clean Code Fields |
|---------|-------------------|----------------|-------------------|
| **9.9 LTS** | `statuses` | `OPEN,CONFIRMED,REOPENED,RESOLVED,CLOSED,FALSE_POSITIVE,ACCEPTED,FIXED` | Not available |
| **10.0–10.3** | `statuses` | Same as above | Available |
| **10.4+ / 2025.1** | `issueStatuses` | `OPEN,CONFIRMED,FALSE_POSITIVE,ACCEPTED,FIXED` | Available |

Using the wrong parameter triggers deprecation warnings on newer versions and may break entirely when the old `statuses` param is removed in a future release.

### How it works

1. On `testConnection()`, the client auto-detects and caches the SonarQube server version
2. Every subsequent `getIssues()` / `getIssuesWithComments()` call checks the cached version and selects the correct API parameter:
   - **SQ < 10.4** → uses legacy `statuses` param
   - **SQ ≥ 10.4** → uses modern `issueStatuses` param
3. `getGroups()` is wrapped in a try/catch since `/api/user_groups/search` is being migrated to the V2 API in newer versions
4. If version detection was never run (e.g. connection test was skipped), it falls back to legacy behavior — so nothing breaks

### What gets logged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how issues (and potentially groups) are fetched from SonarQube based on detected version, which can affect migration/verification results if detection or parameter selection is wrong, though the logic is isolated to the new client with conservative fallbacks.
> 
> **Overview**
> Adds a new `VersionAwareSonarQubeClient` that detects and caches the connected SonarQube server version, logs the compatibility mode, and adjusts issue search requests to use `statuses` (legacy) vs `issueStatuses` (10.4+) while gracefully handling missing `/api/user_groups/search`.
> 
> Updates the transfer, migrate, and verify pipelines to use this version-aware client and to reuse cached version detection instead of re-parsing the version in multiple places, and adds a shared `isAtLeast()` helper to `utils/version.js` for version comparisons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71179d4bd5fdb0d18af4d8df9476363a1447d55d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->