### PR TITLE
Incremental Migrations with Pause/Resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ CloudVoyager copies everything — projects, code issues, security hotspots, qua
 ./cloudvoyager verify -c migrate-config.json --verbose
 ```
 
+<!-- Updated: 2026-03-10 -->
+## 🔄 Pause and Resume
+
+All migrations support **automatic checkpointing**. If a migration is interrupted (CTRL+C, crash, network failure), simply re-run the same command to resume from where it left off. No data is lost or duplicated.
+
+```bash
+# Transfer was interrupted — just re-run to resume
+./cloudvoyager transfer -c config.json --verbose
+
+# Check progress without running
+./cloudvoyager transfer -c config.json --show-progress
+```
+
+See the [Configuration Reference](docs/configuration.md#checkpoint-settings) for checkpoint options.
+
 <!-- Updated: 2026-03-09 -->
 ## 🔄 SonarQube Version Compatibility
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,83 @@ Initial release of CloudVoyager — a CLI tool for migrating data from self-host
 
 ---
 
+### 2026-03-10 — Incremental Migrations with Pause/Resume
+
+#### New Feature: Checkpoint Journal System
+- Added a **write-ahead checkpoint journal** that tracks phase-by-phase progress for both `transfer` and `migrate` commands, enabling true pause/resume across all migration workflows
+- Interrupted migrations (CTRL+C, crashes, network failures) can now be resumed from the exact point of interruption — no re-processing of completed work
+- The journal stores a session fingerprint (SonarQube version, URL, project key) and validates it on resume, warning on version mismatches
+
+#### Graceful Shutdown (SIGINT/SIGTERM)
+- First CTRL+C: finishes the current atomic operation, saves progress to the journal, releases the lock, and exits cleanly
+- Second CTRL+C: forces immediate exit
+- Cleanup handlers are registered for saving state, releasing locks, and flushing logs
+
+#### Concurrent Run Prevention
+- Advisory lock file (`<stateFile>.lock`) prevents two instances from running on the same state file simultaneously
+- Stale lock detection: auto-releases locks from dead processes (PID check) or locks older than 6 hours
+- Different-hostname locks require `--force-unlock` for NFS safety
+
+#### Extraction Caching
+- Extraction results are cached to disk as gzipped JSON files, so resumed runs skip already-completed extraction phases
+- Cache files auto-purge after 7 days (configurable via `transfer.checkpoint.cacheMaxAgeDays`)
+- Corrupt cache files are handled gracefully (phase re-executes)
+
+#### Upload Deduplication
+- Before re-uploading after a crash, checks `/api/ce/activity` for existing CE tasks from the current session
+- Prevents duplicate CE tasks — the most dangerous edge case in crash-during-upload scenarios
+
+#### Migration Journal (Multi-Project)
+- Per-organization and per-project completion tracking for the `migrate` command
+- On resume: completed orgs and projects are skipped, in-progress projects resume from their last completed step
+- Output directory is preserved on resume (no longer wiped)
+
+#### Atomic State Writes
+- State files now use write-to-temp, `fsync`, then atomic rename — prevents corruption on crash
+- Backup rotation: current state is copied to `.backup` before each save
+- Safe load with fallback: tries main file, then `.backup`, then returns null
+- Disk space pre-check (10MB minimum) before writing
+
+#### New CLI Flags
+- `--force-restart` — Discard checkpoint/migration journal and start from scratch (`transfer`, `migrate`)
+- `--force-fresh-extract` — Discard extraction caches and re-extract everything (`transfer`)
+- `--force-unlock` — Force release a stale lock file from a previous run (`transfer`, `migrate`)
+- `--show-progress` — Display checkpoint progress table and exit (`transfer`)
+
+#### New Config Options
+- `transfer.checkpoint.enabled` — Enable/disable checkpoint journal (default: `true`)
+- `transfer.checkpoint.cacheExtractions` — Enable/disable extraction caching (default: `true`)
+- `transfer.checkpoint.cacheMaxAgeDays` — Max age of cache files in days (default: `7`)
+- `transfer.checkpoint.strictResume` — Fail on SonarQube version mismatch when resuming (default: `false`)
+
+#### Enhanced Commands
+- `status` command now shows checkpoint journal progress (phases, branches, completion %) when a journal exists
+- `reset` command now clears checkpoint journals, lock files, and extraction caches in addition to state files
+
+#### Files Added
+- **New:** `src/state/lock.js` — Advisory lock file with PID-based stale detection
+- **New:** `src/utils/shutdown.js` — Graceful SIGINT/SIGTERM coordination
+- **New:** `src/state/checkpoint.js` — Phase-level checkpoint journal
+- **New:** `src/state/extraction-cache.js` — Gzipped disk cache for extraction results
+- **New:** `src/state/migration-journal.js` — Multi-project migration progress tracking
+- **New:** `src/utils/progress.js` — Progress display for checkpoint and migration journals
+
+#### Files Modified
+- **Modified:** `src/state/storage.js` — Atomic save with backup rotation and disk space checks
+- **Modified:** `src/state/tracker.js` — Lock file integration and per-branch save
+- **Modified:** `src/utils/errors.js` — Added `GracefulShutdownError`, `LockError`, `StaleResumeError`
+- **Modified:** `src/sonarqube/extractors/index.js` — Checkpoint-aware extraction with journal + cache
+- **Modified:** `src/sonarcloud/uploader.js` — Upload deduplication via CE activity check
+- **Modified:** `src/transfer-pipeline.js` — Full journal/lock/shutdown integration
+- **Modified:** `src/migrate-pipeline.js` — Migration journal and conditional output-dir preservation
+- **Modified:** `src/pipeline/project-migration.js` — Per-step checkpoints in migration journal
+- **Modified:** `src/config/schema.js` — Added `transfer.checkpoint` config block
+- **Modified:** `src/commands/transfer.js` — New CLI flags, shutdown coordinator
+- **Modified:** `src/commands/migrate.js` — New CLI flags, shutdown coordinator
+- **Modified:** `src/index.js` — Enhanced `status` and `reset` commands
+
+---
+
 ### 2026-03-10 — User Mapping CSV for Issue Assignment
 
 #### New Feature: User Mapping

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,13 @@ Used by: `transfer`, `test`, `validate`, `status`, `reset`
     "stateFile": "./.cloudvoyager-state.json",
     "batchSize": 100,
     "syncAllBranches": true,
-    "excludeBranches": []
+    "excludeBranches": [],
+    "checkpoint": {
+      "enabled": true,
+      "cacheExtractions": true,
+      "cacheMaxAgeDays": 7,
+      "strictResume": false
+    }
   }
 }
 ```
@@ -130,6 +136,18 @@ Used by `migrate`, `sync-metadata`. Instead of a single org, you provide an arra
 | `batchSize` | `100` | Number of items per batch (1–500) |
 | `syncAllBranches` | `true` | Sync all branches of every project. Set to `false` to only sync the main branch |
 | `excludeBranches` | `[]` | Branch names to exclude from sync when `syncAllBranches` is `true` |
+| `checkpoint` | `{}` | Checkpoint and resume settings (see below) |
+
+### Checkpoint Settings
+
+The `transfer.checkpoint` block controls the pause/resume behavior. All settings are optional — defaults provide safe, automatic checkpointing.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `true` | Enable checkpoint journal for pause/resume support |
+| `cacheExtractions` | `true` | Cache extraction results to disk for faster resume |
+| `cacheMaxAgeDays` | `7` | Maximum age of extraction cache files in days before auto-purge |
+| `strictResume` | `false` | Fail on SonarQube version mismatch when resuming (default: warn only) |
 
 <!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
 ### Migrate Settings
@@ -217,6 +235,10 @@ Controls CPU, memory, and concurrency tuning. Add a `performance` section to any
 | `--max-memory <mb>` | Set max heap size in MB | `transfer`, `migrate`, `sync-metadata`, `verify` |
 | `--project-concurrency <n>` | Max concurrent project migrations | `migrate` |
 | `--skip-all-branch-sync` | Only sync the main branch (skip non-main branches). Equivalent to setting `syncAllBranches: false` in the `transfer` section | `transfer`, `migrate`, `sync-metadata` |
+| `--force-restart` | Discard checkpoint journal and start a fresh transfer | `transfer` |
+| `--force-fresh-extract` | Discard extraction caches and re-extract all data | `transfer` |
+| `--force-unlock` | Force release a stale lock file from a previous run | `transfer`, `migrate` |
+| `--show-progress` | Display checkpoint progress table and exit | `transfer` |
 
 **Selective migration flag:**
 
@@ -247,6 +269,10 @@ Multiple components can be combined: `--only scan-data,quality-gates,permissions
 |------|-------------|-------------|
 | `--wait` | Wait for analysis to complete before returning (default: does not wait) | `transfer`, `migrate` |
 | `--output-dir <path>` | Output directory for verification reports (default: `./verification-output`) | `verify` |
+| `--force-restart` | Discard checkpoint journal and start a fresh transfer | `transfer`, `migrate` |
+| `--force-fresh-extract` | Discard extraction caches and re-extract all data | `transfer` |
+| `--force-unlock` | Force release a stale lock file from a previous run | `transfer`, `migrate` |
+| `--show-progress` | Display checkpoint progress table and exit | `transfer` |
 
 **Example: high-performance migration:**
 
@@ -301,6 +327,7 @@ All CLI flags work identically in both modes. The table below shows every availa
 | Sync only issue metadata | `npm run sync-metadata:skip-hotspot-metadata` | `./cloudvoyager sync-metadata -c migrate-config.json --verbose --skip-hotspot-metadata-sync` |
 | Sync only hotspot metadata | `npm run sync-metadata:skip-issue-metadata` | `./cloudvoyager sync-metadata -c migrate-config.json --verbose --skip-issue-metadata-sync` |
 | Sync metadata, skip quality profiles | `npm run sync-metadata:skip-quality-profiles` | `./cloudvoyager sync-metadata -c migrate-config.json --verbose --skip-quality-profile-sync` |
+| Show transfer checkpoint progress | `npm run transfer:show-progress` | `./cloudvoyager transfer -c config.json --show-progress` |
 | Transfer single project (auto-tuned) | `npm run transfer:auto-tune` | `./cloudvoyager transfer -c config.json --verbose --auto-tune` |
 | Full migration (auto-tuned) | `npm run migrate:auto-tune` | `./cloudvoyager migrate -c migrate-config.json --verbose --auto-tune` |
 | Migrate without metadata (auto-tuned) | `npm run migrate:skip-all-metadata:auto-tune` | `./cloudvoyager migrate -c migrate-config.json --verbose --skip-issue-metadata-sync --skip-hotspot-metadata-sync --auto-tune` |
@@ -403,7 +430,24 @@ When using incremental mode, the tool:
 
 To force a full transfer, use the `reset` command to clear the state.
 
-<!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
+### Checkpoint Journal (Pause/Resume)
+
+The `transfer` command automatically maintains a **checkpoint journal** that tracks progress at the phase level. If a transfer is interrupted (CTRL+C, crash, network failure), you can resume from where it left off by simply running the same command again.
+
+The journal records:
+- Which extraction phases have completed (metrics, issues, sources, etc.)
+- Per-branch transfer status (completed, in-progress, pending)
+- Upload deduplication data (prevents duplicate CE tasks after crashes)
+- Session fingerprint (SonarQube version, URL, project key) for resume validation
+
+**Key behaviors:**
+- **Automatic resume**: Running the same `transfer` command after an interruption automatically resumes from the last checkpoint
+- **Graceful shutdown**: CTRL+C triggers a clean save of the journal before exiting (press twice to force-quit)
+- **Concurrent run prevention**: A lock file prevents two instances from running simultaneously against the same state file
+- **Extraction caching**: Completed extraction phases are cached to disk (gzipped JSON) so they don't need to be re-fetched on resume
+
+Use `--force-restart` to discard the checkpoint journal and start from scratch. Use `--force-fresh-extract` to clear extraction caches while keeping the journal.
+
 ### State File
 
 The state file (`.cloudvoyager-state.json` by default) contains:
@@ -411,6 +455,12 @@ The state file (`.cloudvoyager-state.json` by default) contains:
 - List of processed issue keys
 - Completed branches (used to skip already-synced branches in incremental mode)
 - Sync history (last 10 entries)
+
+Additional files created during transfer:
+- `<stateFile>.journal` — Checkpoint journal for pause/resume
+- `<stateFile>.journal.backup` — Backup of the checkpoint journal
+- `<stateFile>.lock` — Advisory lock file for concurrent run prevention
+- `cache/` directory — Extraction cache files (gzipped JSON)
 
 ## 📚 Further Reading
 
@@ -425,6 +475,7 @@ The state file (`.cloudvoyager-state.json` by default) contains:
 ## Change Log
 | Date | Section | Change |
 |------|---------|--------|
+| 2026-03-10 | Transfer Settings, Checkpoint, CLI overrides, Incremental Transfers | Added checkpoint/resume config and documentation |
 | 2026-02-28 | Migration Config, CLI overrides, npm Scripts | Added verify command references |
 | 2026-02-20 | Migration Config, Multi-Org Settings | Enterprise config for V2 portfolio API |
 | 2026-02-19 | npm Scripts | Expanded script table with all commands |

--- a/docs/key-capabilities.md
+++ b/docs/key-capabilities.md
@@ -25,12 +25,13 @@ A comprehensive overview of CloudVoyager's engineering, architecture, and capabi
 14. [Build Pipeline Optimizations](#14-build-pipeline-optimizations)
 15. [Rate Limiting and API Resilience](#15-rate-limiting-and-api-resilience)
 16. [Incremental and Stateful Transfers](#16-incremental-and-stateful-transfers)
-17. [Comprehensive Reporting Suite](#17-comprehensive-reporting-suite)
-18. [Configuration System and Schema Validation](#18-configuration-system-and-schema-validation)
-19. [CLI Design and Operational Modes](#19-cli-design-and-operational-modes)
-20. [Error Handling Architecture](#20-error-handling-architecture)
-21. [Migration Verification Pipeline](#21-migration-verification-pipeline)
-22. [Engineering Summary](#22-engineering-summary)
+17. [Checkpoint Journal and Pause/Resume](#17-checkpoint-journal-and-pauseresume)
+18. [Comprehensive Reporting Suite](#18-comprehensive-reporting-suite)
+19. [Configuration System and Schema Validation](#19-configuration-system-and-schema-validation)
+20. [CLI Design and Operational Modes](#20-cli-design-and-operational-modes)
+21. [Error Handling Architecture](#21-error-handling-architecture)
+22. [Migration Verification Pipeline](#22-migration-verification-pipeline)
+23. [Engineering Summary](#23-engineering-summary)
 
 ---
 
@@ -674,8 +675,76 @@ When set to `"full"`, all data is re-extracted and re-transferred regardless of 
 
 ---
 
+<!-- Updated: Mar 10, 2026 -->
+## 17. Checkpoint Journal and Pause/Resume
+
+CloudVoyager's checkpoint system enables true pause/resume for all migration commands. Progress is saved at the phase level, so interrupted transfers resume from the last completed step rather than starting over.
+
+### Architecture
+
+The checkpoint system consists of five cooperating components:
+
+| Component | File | Purpose |
+|-----------|------|---------|
+| **Checkpoint Journal** | `src/state/checkpoint.js` | Write-ahead journal tracking phase completion, branch status, upload dedup |
+| **Extraction Cache** | `src/state/extraction-cache.js` | Disk-backed cache (gzipped JSON) of extraction results per phase |
+| **Lock File** | `src/state/lock.js` | Advisory lock preventing concurrent runs (PID + hostname + stale detection) |
+| **Shutdown Coordinator** | `src/utils/shutdown.js` | SIGINT/SIGTERM handler ensuring clean journal save before exit |
+| **Migration Journal** | `src/state/migration-journal.js` | Per-org, per-project completion tracking for the `migrate` command |
+| **Atomic Storage** | `src/state/storage.js` | Write-to-temp, fsync, rename pattern with backup rotation |
+
+### Checkpoint Journal Structure
+
+```json
+{
+  "version": 2,
+  "sessionFingerprint": {
+    "sonarQubeVersion": "10.8.0",
+    "sonarQubeUrl": "https://sq.example.com",
+    "projectKey": "my-project",
+    "startedAt": "2026-03-10T10:00:00Z"
+  },
+  "status": "in_progress",
+  "phases": {
+    "connection_test": { "status": "completed" },
+    "extract:issues": { "status": "completed", "cacheFile": "..." },
+    "extract:sources": { "status": "in_progress" },
+    "build_protobuf": { "status": "pending" },
+    "upload": { "status": "pending" }
+  },
+  "branches": {
+    "main": { "status": "completed", "ceTaskId": "AY..." },
+    "develop": { "status": "in_progress", "currentPhase": "extract:issues" }
+  },
+  "uploadedCeTasks": {
+    "main": { "taskId": "AY...", "submittedAt": "...", "status": "SUCCESS" }
+  }
+}
+```
+
+### Key Behaviors
+
+- **Automatic resume**: Running the same command after interruption resumes from the last checkpoint
+- **Graceful shutdown**: First CTRL+C saves journal and exits cleanly; second CTRL+C forces immediate exit
+- **Concurrent run prevention**: Lock file with PID and hostname prevents two instances from corrupting state
+- **Stale lock detection**: Dead-process locks are auto-released; cross-machine locks require `--force-unlock`
+- **Upload deduplication**: Before re-uploading after a crash, checks CE activity to prevent duplicate tasks
+- **Session fingerprint validation**: Warns (or blocks with `strictResume`) on SonarQube version changes between runs
+- **Atomic state writes**: Write-to-temp + fsync + rename prevents corruption from mid-write crashes
+
+### CLI Flags
+
+| Flag | Command | Description |
+|------|---------|-------------|
+| `--force-restart` | `transfer`, `migrate` | Discard checkpoint/migration journal and start fresh |
+| `--force-fresh-extract` | `transfer` | Clear extraction caches, re-extract all data |
+| `--force-unlock` | `transfer`, `migrate` | Force release a stale lock file |
+| `--show-progress` | `transfer` | Display checkpoint progress and exit |
+
+---
+
 <!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
-## 17. Comprehensive Reporting Suite
+## 18. Comprehensive Reporting Suite
 
 The migration pipeline generates reports in **6 formats** across **3 report types**:
 
@@ -719,7 +788,7 @@ A specialized JSON report (`quality-profile-diff.json`) compares active rules pe
 ---
 
 <!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
-## 18. Configuration System and Schema Validation
+## 19. Configuration System and Schema Validation
 
 <!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
 ### Schema-Validated Configuration
@@ -754,7 +823,7 @@ Performance and rate-limit schemas are shared across all configuration types, en
 ---
 
 <!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
-## 19. CLI Design and Operational Modes
+## 20. CLI Design and Operational Modes
 
 <!-- Updated: Feb 21, 2026 at 10:30:00 AM -->
 ### Command Suite
@@ -790,7 +859,7 @@ Winston-based logging with:
 ---
 
 <!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
-## 20. Error Handling Architecture
+## 21. Error Handling Architecture
 
 <!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
 ### Custom Error Hierarchy
@@ -823,7 +892,7 @@ API client errors include specific diagnostics based on the underlying network e
 ---
 
 <!-- Updated: Feb 28, 2026 at 12:00:00 PM -->
-## 21. Migration Verification Pipeline
+## 22. Migration Verification Pipeline
 
 After migration, CloudVoyager can **verify** that all data was transferred correctly by exhaustively comparing SonarQube and SonarCloud. The `verify` command performs read-only checks and generates a detailed pass/fail report.
 
@@ -876,7 +945,7 @@ This ensures the verification is comparing exactly the same pairs that were sync
 ---
 
 <!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
-## 22. Engineering Summary
+## 23. Engineering Summary
 
 <!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
 ### By the Numbers
@@ -931,6 +1000,7 @@ This ensures the verification is comparing exactly the same pairs that were sync
 ## Change Log
 | Date | Section | Change |
 |------|---------|--------|
+| 2026-03-10 | Checkpoint Journal (new section 17) | Added pause/resume capability documentation |
 | 2026-03-04 | Verification Pipeline | Added issue status history (changelog) verification |
 | 2026-02-28 | Verification Pipeline, CLI, Summary | Added migration verification capability |
 | 2026-02-20 | Permissions/Governance, Portfolio | V2 Enterprise API for portfolios |

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -234,6 +234,10 @@ This section documents every command and flag available in CloudVoyager. The exa
 | `--max-memory <mb>` | — | No | Integer | Set the max heap size in MB; auto-restarts the process with increased heap if the current heap is too small |
 | `--auto-tune` | — | No | — | Auto-detect hardware (CPU cores, available memory) and set optimal concurrency and memory values |
 | `--skip-all-branch-sync` | — | No | — | Only sync the main branch (skip non-main branches). Equivalent to setting `transfer.syncAllBranches: false` in config |
+| `--force-restart` | — | No | — | Discard checkpoint journal and start a fresh transfer from scratch |
+| `--force-fresh-extract` | — | No | — | Discard extraction caches and re-extract all data from SonarQube |
+| `--force-unlock` | — | No | — | Force release a stale lock file from a previous run |
+| `--show-progress` | — | No | — | Display checkpoint progress status table and exit |
 
 <!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
 #### Examples
@@ -289,6 +293,21 @@ This section documents every command and flag available in CloudVoyager. The exa
 
 # Transfer with verbose, auto-tune, and max-memory override
 ./cloudvoyager transfer -c config.json --verbose --auto-tune --max-memory 8192
+
+# Show checkpoint progress without running a transfer
+./cloudvoyager transfer -c config.json --show-progress
+
+# Resume a previously interrupted transfer (automatic — just re-run)
+./cloudvoyager transfer -c config.json --verbose
+
+# Force restart from scratch (discard checkpoint journal)
+./cloudvoyager transfer -c config.json --verbose --force-restart
+
+# Re-extract all data but keep checkpoint journal
+./cloudvoyager transfer -c config.json --verbose --force-fresh-extract
+
+# Force release a stale lock from a crashed run
+./cloudvoyager transfer -c config.json --verbose --force-unlock
 ```
 
 ---
@@ -313,6 +332,8 @@ This section documents every command and flag available in CloudVoyager. The exa
 | `--auto-tune` | — | No | — | Auto-detect hardware and set optimal concurrency, memory, and project-concurrency values |
 | `--skip-all-branch-sync` | — | No | — | Only sync the main branch of each project (skip non-main branches). Equivalent to setting `transfer.syncAllBranches: false` in config |
 | `--only <components>` | — | No | Comma-separated list | Only migrate specific components. Valid values: `scan-data`, `scan-data-all-branches`, `portfolios`, `quality-gates`, `quality-profiles`, `permission-templates`, `permissions`, `issue-metadata`, `hotspot-metadata`, `project-settings` |
+| `--force-restart` | — | No | — | Discard migration journal and start a fresh migration from scratch |
+| `--force-unlock` | — | No | — | Force release a stale lock file from a previous run |
 
 <!-- Updated: Feb 21, 2026 at 10:30:00 AM -->
 #### Examples
@@ -458,6 +479,15 @@ This section documents every command and flag available in CloudVoyager. The exa
 
 # Selective migration with project concurrency
 ./cloudvoyager migrate -c migrate-config.json --verbose --project-concurrency 3 --only scan-data
+
+# Resume a previously interrupted migration (automatic — just re-run)
+./cloudvoyager migrate -c migrate-config.json --verbose
+
+# Force restart migration from scratch (discard migration journal)
+./cloudvoyager migrate -c migrate-config.json --verbose --force-restart
+
+# Force release a stale lock from a crashed migration
+./cloudvoyager migrate -c migrate-config.json --verbose --force-unlock
 ```
 
 ---
@@ -684,6 +714,7 @@ The following npm scripts are available for building, testing, and linting:
 | Reset state | `npm run reset` |
 | Transfer single project | `npm run transfer` |
 | Transfer single project (auto-tune) | `npm run transfer:auto-tune` |
+| Show transfer checkpoint progress | `npm run transfer:show-progress` |
 | Full migration | `npm run migrate` |
 | Full migration (dry-run) | `npm run migrate:dry-run` |
 | Full migration (auto-tune) | `npm run migrate:auto-tune` |
@@ -738,6 +769,7 @@ The following npm scripts are available for building, testing, and linting:
 ## Change Log
 | Date | Section | Change |
 |------|---------|--------|
+| 2026-03-10 | transfer, migrate, npm Scripts | Added checkpoint/resume CLI flags |
 | 2026-02-28 | verify command, npm Scripts | Added verify CLI reference and npm scripts |
 | 2026-02-21 | Bun Compile | Fixed dependency type: optionalDependency not devDependency |
 | 2026-02-19 | Building, CLI Reference, Tests, npm Scripts | API expansion, test suite, bun builds |

--- a/docs/scenario-multi-org.md
+++ b/docs/scenario-multi-org.md
@@ -181,6 +181,8 @@ This performs read-only checks comparing SonarQube and SonarCloud data and gener
 ./cloudvoyager verify -c migrate-config.json --verbose --only quality-gates,quality-profiles
 ```
 
+> **Resume after interruption:** If the migration is interrupted (CTRL+C, crash, network failure), simply re-run the same command. The migration journal tracks per-org and per-project completion, so already-completed organizations and projects are skipped on resume. Use `--force-restart` to discard the journal and start fresh.
+
 ---
 
 <!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
@@ -279,6 +281,8 @@ When you run `./cloudvoyager verify`, reports are written to `./verification-out
 | `--max-memory <mb>` | Set max heap size in MB |
 | `--wait` | Wait for analysis to complete before returning (default: does not wait) |
 | `--skip-all-branch-sync` | Only sync the main branch (skip non-main branches) |
+| `--force-restart` | Discard migration journal and start fresh |
+| `--force-unlock` | Release a stale lock file from a crashed run |
 
 ---
 
@@ -304,6 +308,7 @@ When you run `./cloudvoyager verify`, reports are written to `./verification-out
 ## Change Log
 | Date | Section | Change |
 |------|---------|--------|
+| 2026-03-10 | CLI Flags, Resume | Added checkpoint/resume flags and resume note |
 | 2026-02-28 | Step 3d Verify | Added verify as recommended final step |
 | 2026-02-18 | Performance, Output Files, CLI Flags | Auto-tune, reports, --wait flag |
 | 2026-02-17 | All | Initial multi-org migration scenario |

--- a/docs/scenario-single-org.md
+++ b/docs/scenario-single-org.md
@@ -166,6 +166,8 @@ This performs read-only checks comparing SonarQube and SonarCloud data and gener
 ./cloudvoyager verify -c migrate-config.json --verbose --only quality-gates,quality-profiles
 ```
 
+> **Resume after interruption:** If the migration is interrupted (CTRL+C, crash, network failure), simply re-run the same command. The migration journal tracks per-org and per-project completion, so already-completed projects are skipped on resume. Use `--force-restart` to discard the journal and start fresh.
+
 ---
 
 <!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
@@ -264,6 +266,8 @@ When you run `./cloudvoyager verify`, reports are written to `./verification-out
 | `--max-memory <mb>` | Set max heap size in MB |
 | `--wait` | Wait for analysis to complete before returning (default: does not wait) |
 | `--skip-all-branch-sync` | Only sync the main branch (skip non-main branches) |
+| `--force-restart` | Discard migration journal and start fresh |
+| `--force-unlock` | Release a stale lock file from a crashed run |
 
 ---
 
@@ -289,6 +293,7 @@ When you run `./cloudvoyager verify`, reports are written to `./verification-out
 ## Change Log
 | Date | Section | Change |
 |------|---------|--------|
+| 2026-03-10 | CLI Flags, Resume | Added checkpoint/resume flags and resume note |
 | 2026-02-28 | Step 3d Verify | Added verify as recommended final step |
 | 2026-02-18 | Performance, Output Files, CLI Flags | Auto-tune, reports, --wait flag |
 | 2026-02-17 | All | Initial single org migration scenario |

--- a/docs/scenario-single-project.md
+++ b/docs/scenario-single-project.md
@@ -178,6 +178,29 @@ See the [Configuration Reference](configuration.md#performance-settings) for all
 
 ---
 
+## 🔄 Pause and Resume
+
+Transfers are automatically checkpointed. If a transfer is interrupted (CTRL+C, crash, network failure), simply re-run the same command to resume from where it left off:
+
+```bash
+# Resume an interrupted transfer (just re-run the same command)
+./cloudvoyager transfer -c config.json --verbose
+```
+
+Use `--show-progress` to see the current checkpoint status without running a transfer:
+
+```bash
+./cloudvoyager transfer -c config.json --show-progress
+```
+
+To discard progress and start fresh, use `--force-restart`:
+
+```bash
+./cloudvoyager transfer -c config.json --verbose --force-restart
+```
+
+---
+
 <!-- Updated: Feb 22, 2026 at 10:30:00 AM -->
 ## 🚩 All CLI Flags
 
@@ -189,6 +212,10 @@ See the [Configuration Reference](configuration.md#performance-settings) for all
 | `--max-memory <mb>` | Set max heap size in MB |
 | `--wait` | Wait for analysis to complete before returning (default: does not wait) |
 | `--skip-all-branch-sync` | Only sync the main branch (skip non-main branches) |
+| `--force-restart` | Discard checkpoint journal and start fresh |
+| `--force-fresh-extract` | Re-extract all data (discard extraction caches) |
+| `--force-unlock` | Release a stale lock file from a crashed run |
+| `--show-progress` | Show checkpoint progress and exit |
 
 ---
 
@@ -213,6 +240,7 @@ See the [Configuration Reference](configuration.md#performance-settings) for all
 ## Change Log
 | Date | Section | Change |
 |------|---------|--------|
+| 2026-03-10 | Pause and Resume, CLI Flags | Added checkpoint/resume workflow and new flags |
 | 2026-02-22 | CLI Flags | Removed duplicate --skip-all-branch-sync entry |
 | 2026-02-21 | CLI Flags, Limitations | Added --skip-all-branch-sync flag |
 | 2026-02-18 | CLI Flags | Added --wait and --auto-tune flags |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -131,6 +131,67 @@ The migration can be re-run safely. Projects that already exist in SonarCloud wi
 
 ---
 
+## 🔄 Checkpoint and Resume Issues
+
+### Stale Lock File ("Another instance is running")
+
+If a previous run crashed without releasing the lock file, you may see an error about another instance running. Use `--force-unlock` to release the stale lock:
+
+```bash
+./cloudvoyager transfer -c config.json --verbose --force-unlock
+```
+
+The tool automatically detects stale locks from dead processes on the same machine. If the lock was created by a different machine (e.g., NFS-shared state file), manual intervention with `--force-unlock` is required.
+
+### Corrupt Checkpoint Journal
+
+If the checkpoint journal becomes corrupt (e.g., due to a system crash during a write), the tool falls back to the `.journal.backup` file. If both are corrupt:
+
+```bash
+# Discard the journal and start fresh
+./cloudvoyager transfer -c config.json --verbose --force-restart
+```
+
+### SonarQube Version Mismatch on Resume
+
+If you upgrade SonarQube between pause and resume, the tool warns about a version mismatch in the session fingerprint. By default, this is a warning only — the transfer continues. To enforce strict version matching:
+
+```json
+{
+  "transfer": {
+    "checkpoint": {
+      "strictResume": true
+    }
+  }
+}
+```
+
+With `strictResume: true`, a version mismatch will fail the transfer and require `--force-restart` to proceed.
+
+### Source Code Changed Between Pause and Resume
+
+If source code in SonarQube changes between pause and resume (e.g., new analysis uploaded), already-cached extraction phases will use stale data. Use `--force-fresh-extract` to re-extract all data while keeping the checkpoint journal:
+
+```bash
+./cloudvoyager transfer -c config.json --verbose --force-fresh-extract
+```
+
+### Clearing All Checkpoint State
+
+The `reset` command now clears checkpoint journals, lock files, and extraction caches in addition to the state file:
+
+```bash
+./cloudvoyager reset -c config.json --yes
+```
+
+This removes:
+- State file (`.cloudvoyager-state.json`)
+- Checkpoint journal (`.journal`, `.journal.backup`, `.journal.tmp`)
+- Lock file (`.lock`)
+- Extraction cache directory (`cache/`)
+
+---
+
 <!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
 ## 🔐 Authentication Errors
 - Verify your tokens have the correct permissions
@@ -414,6 +475,7 @@ You can verify specific components to save time:
 ## Change Log
 | Date | Section | Change |
 |------|---------|--------|
+| 2026-03-10 | Checkpoint and Resume | Added checkpoint/resume troubleshooting section |
 | 2026-03-10 | Issue Assignment | Added user mapping troubleshooting section |
 | 2026-02-28 | Verification Reports | Added verification report troubleshooting |
 | 2026-02-18 | Debugging, Reports, Memory, Performance | Report-based debugging, auto-tune, memory management |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudvoyager",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A CLI tool to migrate all projects from SonarQube Server to SonarCloud.io",
   "main": "src/index.js",
   "bin": {
@@ -11,6 +11,7 @@
     "start": "node src/index.js",
     "transfer": "node src/index.js transfer -c config.json --verbose",
     "transfer:auto-tune": "node src/index.js transfer -c config.json --verbose --auto-tune",
+    "transfer:show-progress": "node src/index.js transfer -c config.json --show-progress",
     "validate": "node src/index.js validate -c config.json",
     "test:connection": "node src/index.js test -c config.json",
     "status": "node src/index.js status -c config.json",
@@ -68,7 +69,9 @@
     "sonarqube-9.9",
     "sonarqube-10",
     "sonarqube-2025",
-    "user-mapping"
+    "user-mapping",
+    "checkpoint",
+    "pause-resume"
   ],
   "sonarqubeCompatibility": {
     "minimum": "9.9",

--- a/src/commands/migrate.js
+++ b/src/commands/migrate.js
@@ -2,7 +2,8 @@ import { loadMigrateConfig } from '../config/loader.js';
 import { migrateAll } from '../migrate-pipeline.js';
 import { resolvePerformanceConfig, logSystemInfo, ensureHeapSize } from '../utils/concurrency.js';
 import logger, { enableFileLogging } from '../utils/logger.js';
-import { CloudVoyagerError } from '../utils/errors.js';
+import { CloudVoyagerError, GracefulShutdownError } from '../utils/errors.js';
+import { ShutdownCoordinator } from '../utils/shutdown.js';
 
 export const VALID_ONLY_COMPONENTS = [
   'scan-data', 'scan-data-all-branches', 'portfolios', 'quality-gates',
@@ -27,7 +28,12 @@ export function registerMigrateCommand(program) {
     .option('--project-concurrency <n>', 'Max concurrent project migrations', Number.parseInt)
     .option('--auto-tune', 'Auto-detect hardware and set optimal performance values')
     .option('--skip-all-branch-sync', 'Only sync the main branch of each project (skip non-main branches)')
+    .option('--force-restart', 'Discard migration journal and start from scratch')
+    .option('--force-unlock', 'Force release a stale lock file from a previous run')
     .action(async (options) => {
+      const shutdownCoordinator = new ShutdownCoordinator();
+      shutdownCoordinator.bind();
+
       try {
         if (options.verbose) logger.level = 'debug';
         enableFileLogging('migrate');
@@ -36,6 +42,7 @@ export function registerMigrateCommand(program) {
         const config = await loadMigrateConfig(options.config);
         const migrateConfig = config.migrate || {};
         if (options.dryRun) migrateConfig.dryRun = true;
+        if (options.forceRestart) migrateConfig.forceRestart = true;
         if (options.skipIssueMetadataSync) migrateConfig.skipIssueMetadataSync = true;
         if (options.skipHotspotMetadataSync) migrateConfig.skipHotspotMetadataSync = true;
         if (options.skipQualityProfileSync) migrateConfig.skipQualityProfileSync = true;
@@ -89,7 +96,10 @@ export function registerMigrateCommand(program) {
         logger.info('=== Migration completed successfully ===');
         process.exit(0);
       } catch (error) {
-        if (error instanceof CloudVoyagerError) {
+        if (error instanceof GracefulShutdownError) {
+          logger.info('Migration interrupted gracefully. Resume by running the same command again.');
+          process.exit(0);
+        } else if (error instanceof CloudVoyagerError) {
           logger.error(`Migration failed: ${error.message}`);
         } else {
           logger.error(`Unexpected error: ${error.message}`);

--- a/src/commands/transfer.js
+++ b/src/commands/transfer.js
@@ -2,7 +2,9 @@ import { loadConfig, requireProjectKeys } from '../config/loader.js';
 import { transferProject } from '../transfer-pipeline.js';
 import { resolvePerformanceConfig, logSystemInfo, ensureHeapSize } from '../utils/concurrency.js';
 import logger, { enableFileLogging } from '../utils/logger.js';
-import { CloudVoyagerError } from '../utils/errors.js';
+import { CloudVoyagerError, GracefulShutdownError } from '../utils/errors.js';
+import { ShutdownCoordinator } from '../utils/shutdown.js';
+import { ProgressTracker } from '../utils/progress.js';
 
 export function registerTransferCommand(program) {
   program
@@ -15,16 +17,31 @@ export function registerTransferCommand(program) {
     .option('--max-memory <mb>', 'Max heap size in MB (auto-restarts with increased heap if needed)', Number.parseInt)
     .option('--auto-tune', 'Auto-detect hardware and set optimal performance values')
     .option('--skip-all-branch-sync', 'Only sync the main branch (skip non-main branches)')
+    .option('--force-restart', 'Discard checkpoint journal and start from scratch')
+    .option('--force-fresh-extract', 'Discard extraction caches and re-extract everything')
+    .option('--force-unlock', 'Force release a stale lock file from a previous run')
+    .option('--show-progress', 'Display checkpoint progress and exit')
     .action(async (options) => {
+      const shutdownCoordinator = new ShutdownCoordinator();
+      shutdownCoordinator.bind();
+
       try {
         if (options.verbose) logger.level = 'debug';
         enableFileLogging('transfer');
 
-        logger.info('=== CloudVoyager Migration ===');
-        logger.info('Starting data transfer from SonarQube to SonarCloud...');
-
         const config = await loadConfig(options.config);
         requireProjectKeys(config);
+
+        // Handle --show-progress: display checkpoint status and exit
+        if (options.showProgress) {
+          const stateFile = config.transfer?.stateFile || './.cloudvoyager-state.json';
+          const progressTracker = new ProgressTracker(stateFile);
+          await progressTracker.displayStatus();
+          return;
+        }
+
+        logger.info('=== CloudVoyager Migration ===');
+        logger.info('Starting data transfer from SonarQube to SonarCloud...');
 
         const transferConfig = config.transfer || {};
         if (options.skipAllBranchSync) transferConfig.syncAllBranches = false;
@@ -44,12 +61,19 @@ export function registerTransferCommand(program) {
           sonarcloudConfig: config.sonarcloud,
           transferConfig,
           performanceConfig: perfConfig,
-          wait: options.wait || false
+          wait: options.wait || false,
+          shutdownCoordinator,
+          forceRestart: options.forceRestart || false,
+          forceFreshExtract: options.forceFreshExtract || false,
+          forceUnlock: options.forceUnlock || false
         });
 
         logger.info('=== Transfer completed successfully ===');
       } catch (error) {
-        if (error instanceof CloudVoyagerError) {
+        if (error instanceof GracefulShutdownError) {
+          logger.info('Transfer interrupted gracefully. Resume by running the same command again.');
+          process.exit(0);
+        } else if (error instanceof CloudVoyagerError) {
           logger.error(`Transfer failed: ${error.message}`);
         } else {
           logger.error(`Unexpected error: ${error.message}`);

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -33,7 +33,18 @@ export const configSchema = {
         stateFile: { type: 'string', default: './.cloudvoyager-state.json', description: 'Path to state file for incremental transfers' },
         batchSize: { type: 'integer', minimum: 1, maximum: 500, default: 100, description: 'Number of items to process in each batch' },
         syncAllBranches: { type: 'boolean', default: true, description: 'Sync all branches of every project (default: true). Set to false to only sync the main branch.' },
-        excludeBranches: { type: 'array', items: { type: 'string' }, default: [], description: 'Branch names to exclude from sync when syncAllBranches is true' }
+        excludeBranches: { type: 'array', items: { type: 'string' }, default: [], description: 'Branch names to exclude from sync when syncAllBranches is true' },
+        checkpoint: {
+          type: 'object',
+          description: 'Checkpoint and resume settings for incremental migrations',
+          properties: {
+            enabled: { type: 'boolean', default: true, description: 'Enable checkpoint journal for pause/resume support' },
+            cacheExtractions: { type: 'boolean', default: true, description: 'Cache extraction results to disk for faster resume' },
+            cacheMaxAgeDays: { type: 'integer', default: 7, minimum: 1, description: 'Maximum age of extraction cache files in days' },
+            strictResume: { type: 'boolean', default: false, description: 'Fail on SonarQube version mismatch when resuming (default: warn only)' }
+          },
+          additionalProperties: false
+        }
       },
       additionalProperties: false
     },

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+import { existsSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import { Command } from 'commander';
 import { loadConfig, requireProjectKeys } from './config/loader.js';
 import { VersionAwareSonarQubeClient as SonarQubeClient } from './sonarqube/version-aware-client.js';
@@ -10,6 +13,7 @@ import { registerTransferCommand } from './commands/transfer.js';
 import { registerMigrateCommand } from './commands/migrate.js';
 import { registerSyncMetadataCommand } from './commands/sync-metadata.js';
 import { registerVerifyCommand } from './commands/verify.js';
+import { ProgressTracker } from './utils/progress.js';
 
 const program = new Command();
 
@@ -51,7 +55,8 @@ program
   .action(async (options) => {
     try {
       const config = await loadConfig(options.config);
-      const stateTracker = new StateTracker(config.transfer.stateFile);
+      const stateFile = config.transfer?.stateFile || './.cloudvoyager-state.json';
+      const stateTracker = new StateTracker(stateFile);
       await stateTracker.initialize();
       const summary = stateTracker.getSummary();
       logger.info('=== Synchronization Status ===');
@@ -63,6 +68,14 @@ program
         summary.completedBranches.forEach(branch => logger.info(`  - ${branch}`));
       }
       logger.info(`Sync history entries: ${summary.syncHistoryCount}`);
+
+      // Show checkpoint journal status if it exists
+      const progressTracker = new ProgressTracker(stateFile);
+      const journalPath = `${stateFile}.journal`;
+      if (existsSync(journalPath)) {
+        logger.info('');
+        await progressTracker.displayStatus();
+      }
     } catch (error) {
       logger.error(`Failed to get status: ${error.message}`);
       process.exit(1);
@@ -78,14 +91,41 @@ program
     try {
       const config = await loadConfig(options.config);
       if (!options.yes) {
-        logger.warn('This will clear all sync state and history.');
-        logger.warn('The next transfer will be a full sync.');
+        logger.warn('This will clear all sync state, checkpoint journals, and extraction caches.');
+        logger.warn('The next transfer will be a full sync from scratch.');
         logger.warn('Use --yes to skip this confirmation.');
         process.exit(0);
       }
-      const stateTracker = new StateTracker(config.transfer.stateFile);
+      const stateFile = config.transfer?.stateFile || './.cloudvoyager-state.json';
+      const stateTracker = new StateTracker(stateFile);
       await stateTracker.reset();
-      logger.info('State reset successfully');
+      logger.info('State file reset successfully');
+
+      // Clear checkpoint journal files
+      const journalPath = `${stateFile}.journal`;
+      for (const suffix of ['', '.backup', '.tmp']) {
+        const f = `${journalPath}${suffix}`;
+        if (existsSync(f)) {
+          await rm(f, { force: true });
+          logger.info(`Removed checkpoint journal: ${f}`);
+        }
+      }
+
+      // Clear lock file
+      const lockPath = `${stateFile}.lock`;
+      if (existsSync(lockPath)) {
+        await rm(lockPath, { force: true });
+        logger.info(`Removed lock file: ${lockPath}`);
+      }
+
+      // Clear extraction cache directory
+      const cacheDir = join(dirname(stateFile), 'cache');
+      if (existsSync(cacheDir)) {
+        await rm(cacheDir, { recursive: true, force: true });
+        logger.info(`Removed extraction cache: ${cacheDir}`);
+      }
+
+      logger.info('Full reset complete — all state, journals, and caches cleared');
     } catch (error) {
       logger.error(`Failed to reset state: ${error.message}`);
       process.exit(1);

--- a/src/migrate-pipeline.js
+++ b/src/migrate-pipeline.js
@@ -11,6 +11,7 @@ import { generateOrgMappings, saveServerInfo, migrateOneOrganization, migrateEnt
 import { loadMappingCsvs } from './mapping/csv-reader.js';
 import { applyCsvOverrides } from './mapping/csv-applier.js';
 import { extractUniqueAssignees, enrichAssigneeDetails } from './sonarqube/extractors/users.js';
+import { MigrationJournal } from './state/migration-journal.js';
 
 export async function migrateAll(options) {
   const {
@@ -64,12 +65,37 @@ export async function migrateAll(options) {
     }
   }
 
-  logger.info(`Cleaning output directory: ${outputDir}`);
-  await rm(outputDir, { recursive: true, force: true });
-  await mkdir(outputDir, { recursive: true });
-  await mkdir(join(outputDir, 'state'), { recursive: true });
-  await mkdir(join(outputDir, 'quality-profiles'), { recursive: true });
-  await mkdir(join(outputDir, 'logs'), { recursive: true });
+  // Check for existing migration journal (resume scenario)
+  const migrationJournalPath = join(outputDir, 'state', 'migration.journal');
+  const migrationJournal = new MigrationJournal(migrationJournalPath);
+  const forceRestart = migrateConfig.forceRestart || false;
+
+  let isResume = false;
+  if (!dryRun && !forceRestart && existsSync(migrationJournalPath)) {
+    isResume = true;
+    logger.info('=== RESUME MODE: Detected previous migration journal ===');
+    logger.info('Will skip completed organizations and projects. Use --force-restart to start fresh.');
+  }
+
+  if (isResume) {
+    // Do NOT wipe outputDir on resume — preserve existing state files and cache
+    await mkdir(outputDir, { recursive: true });
+    await mkdir(join(outputDir, 'state'), { recursive: true });
+    await mkdir(join(outputDir, 'quality-profiles'), { recursive: true });
+    await mkdir(join(outputDir, 'logs'), { recursive: true });
+  } else {
+    logger.info(`Cleaning output directory: ${outputDir}`);
+    await rm(outputDir, { recursive: true, force: true });
+    await mkdir(outputDir, { recursive: true });
+    await mkdir(join(outputDir, 'state'), { recursive: true });
+    await mkdir(join(outputDir, 'quality-profiles'), { recursive: true });
+    await mkdir(join(outputDir, 'logs'), { recursive: true });
+  }
+
+  // Initialize migration journal (creates or loads)
+  if (!dryRun) {
+    await migrationJournal.initialize();
+  }
 
   const results = createEmptyResults();
   results.environment = collectEnvironmentInfo();
@@ -94,7 +120,7 @@ export async function migrateAll(options) {
   const ctx = {
     sonarqubeConfig, sonarcloudOrgs, enterpriseConfig, transferConfig, rateLimitConfig,
     perfConfig, outputDir, dryRun, skipIssueSync, skipHotspotSync, skipQualityProfileSync, skipProjectConfig, wait,
-    onlyComponents, projectBranchIncludes: new Map()
+    onlyComponents, projectBranchIncludes: new Map(), migrationJournal: dryRun ? null : migrationJournal
   };
 
   try {
@@ -215,6 +241,11 @@ export async function migrateAll(options) {
       await migrateEnterprisePortfolios(effectiveExtractedData, mergedProjectKeyMap, results, ctx);
     } else {
       logger.info('Skipping enterprise portfolio migration (not included in --only)');
+    }
+
+    // Mark migration as completed in journal
+    if (!dryRun && migrationJournal) {
+      await migrationJournal.markCompleted();
     }
 
     logMigrationSummary(results, outputDir);

--- a/src/pipeline/project-migration.js
+++ b/src/pipeline/project-migration.js
@@ -19,12 +19,28 @@ import { finalizeProjectResult, recordProjectOutcome } from './results.js';
 export async function migrateOrgProjects(projects, org, scClient, gateMapping, extractedData, results, ctx, builtInProfileMapping) {
   const projectKeyMap = new Map();
   const projectKeyWarnings = [];
+  const migrationJournal = ctx.migrationJournal || null;
+
   for (let i = 0; i < projects.length; i++) {
     const project = projects[i];
+
+    // Check if project already completed in migration journal
+    if (migrationJournal && migrationJournal.getProjectStatus(org.key, project.key) === 'completed') {
+      logger.info(`\n--- Project ${i + 1}/${projects.length}: ${project.key} — already completed, skipping ---`);
+      const { scProjectKey } = await resolveProjectKey(project, org, scClient);
+      projectKeyMap.set(project.key, scProjectKey);
+      continue;
+    }
+
     const { scProjectKey, warning } = await resolveProjectKey(project, org, scClient);
     if (warning) projectKeyWarnings.push(warning);
     projectKeyMap.set(project.key, scProjectKey);
     logger.info(`\n--- Project ${i + 1}/${projects.length}: ${project.key} -> ${scProjectKey} ---`);
+
+    if (migrationJournal) {
+      await migrationJournal.startProject(org.key, project.key);
+    }
+
     const projectResult = await migrateOneProject({ project, scProjectKey, org, gateMapping, extractedData, results, ctx, builtInProfileMapping });
     results.projects.push(projectResult);
     if (projectResult.linesOfCode > 0) {
@@ -32,6 +48,15 @@ export async function migrateOrgProjects(projects, org, scClient, gateMapping, e
       results.projectLinesOfCode.push({ projectKey: project.key, linesOfCode: projectResult.linesOfCode });
     }
     recordProjectOutcome(project, projectResult, results);
+
+    // Update migration journal
+    if (migrationJournal) {
+      if (projectResult.status === 'success') {
+        await migrationJournal.markProjectCompleted(org.key, project.key);
+      } else {
+        await migrationJournal.markProjectFailed(org.key, project.key, projectResult.errors?.[0] || 'Unknown error');
+      }
+    }
   }
   return { projectKeyMap, projectKeyWarnings };
 }
@@ -59,6 +84,19 @@ async function migrateOneProject({ project, scProjectKey, org, gateMapping, extr
     organization: org.key, projectKey: scProjectKey, rateLimit: ctx.rateLimitConfig
   });
 
+  // Migration journal for per-step checkpointing
+  const migrationJournal = ctx.migrationJournal || null;
+  const STEP_ORDER = [
+    'upload_scanner_report', 'sync_issues', 'sync_hotspots',
+    'project_settings', 'project_tags', 'project_links', 'new_code_definitions',
+    'devops_binding', 'assign_quality_gate', 'assign_quality_profiles', 'project_permissions'
+  ];
+  const isStepDone = (step) =>
+    migrationJournal && migrationJournal.isProjectStepCompleted(org?.key, project.key, step, STEP_ORDER);
+  const recordStep = async (step) => {
+    if (migrationJournal) await migrationJournal.completeProjectStep(org?.key, project.key, step);
+  };
+
   // Scanner report upload
   const wantsScanData = shouldRun('scan-data') || shouldRun('scan-data-all-branches');
   let reportUploadOk = false;
@@ -73,7 +111,14 @@ async function migrateOneProject({ project, scProjectKey, org, gateMapping, extr
         syncAllBranchesOverride = false; // main branch only
       }
     }
-    reportUploadOk = await uploadScannerReport(project, scProjectKey, org, projectResult, ctx, syncAllBranchesOverride);
+    if (isStepDone('upload_scanner_report')) {
+      logger.info(`Scanner report upload for ${project.key} — already completed, skipping`);
+      reportUploadOk = true;
+      projectResult.steps.push({ step: 'Upload scanner report', status: 'skipped', detail: 'Completed in previous run', durationMs: 0 });
+    } else {
+      reportUploadOk = await uploadScannerReport(project, scProjectKey, org, projectResult, ctx, syncAllBranchesOverride);
+      if (reportUploadOk) await recordStep('upload_scanner_report');
+    }
   } else if (only) {
     projectResult.steps.push({ step: 'Upload scanner report', status: 'skipped', detail: 'Not included in --only', durationMs: 0 });
     // Verify project exists in SonarCloud before attempting downstream operations
@@ -90,14 +135,26 @@ async function migrateOneProject({ project, scProjectKey, org, gateMapping, extr
 
   // Issue metadata sync
   if (shouldRun('issue-metadata')) {
-    await syncProjectIssues(projectResult, results, reportUploadOk, ctx, scProjectKey, projectSqClient, projectScClient);
+    if (isStepDone('sync_issues')) {
+      logger.info(`Issue sync for ${project.key} — already completed, skipping`);
+      projectResult.steps.push({ step: 'Sync issues', status: 'skipped', detail: 'Completed in previous run', durationMs: 0 });
+    } else {
+      await syncProjectIssues(projectResult, results, reportUploadOk, ctx, scProjectKey, projectSqClient, projectScClient);
+      await recordStep('sync_issues');
+    }
   } else if (only) {
     projectResult.steps.push({ step: 'Sync issues', status: 'skipped', detail: 'Not included in --only', durationMs: 0 });
   }
 
   // Hotspot metadata sync
   if (shouldRun('hotspot-metadata')) {
-    await syncProjectHotspots(projectResult, results, reportUploadOk, ctx, scProjectKey, projectSqClient, projectScClient);
+    if (isStepDone('sync_hotspots')) {
+      logger.info(`Hotspot sync for ${project.key} — already completed, skipping`);
+      projectResult.steps.push({ step: 'Sync hotspots', status: 'skipped', detail: 'Completed in previous run', durationMs: 0 });
+    } else {
+      await syncProjectHotspots(projectResult, results, reportUploadOk, ctx, scProjectKey, projectSqClient, projectScClient);
+      await recordStep('sync_hotspots');
+    }
   } else if (only) {
     projectResult.steps.push({ step: 'Sync hotspots', status: 'skipped', detail: 'Not included in --only', durationMs: 0 });
   }

--- a/src/sonarcloud/uploader.js
+++ b/src/sonarcloud/uploader.js
@@ -330,6 +330,38 @@ export class ReportUploader {
   }
 
   /**
+   * Check if a CE task already exists for this project from the current session.
+   * Used for upload deduplication on resume — prevents uploading twice after crash.
+   *
+   * @param {string} sessionStartTime - ISO timestamp of when the journal session started
+   * @returns {Promise<object|null>} Existing CE task or null
+   */
+  async checkExistingUpload(sessionStartTime) {
+    try {
+      const task = await this.client.getMostRecentCeTask();
+      if (!task) return null;
+
+      const taskSubmittedAt = task.submittedAt ? new Date(task.submittedAt).getTime() : 0;
+      const sessionStart = new Date(sessionStartTime).getTime();
+
+      if (taskSubmittedAt >= sessionStart) {
+        const status = task.status || 'UNKNOWN';
+        if (status === 'SUCCESS' || status === 'IN_PROGRESS' || status === 'PENDING') {
+          logger.info(`Found existing CE task ${task.id} (status: ${status}) from current session — skipping re-upload`);
+          return { id: task.id, status };
+        }
+        // FAILED or CANCELED — safe to re-upload
+        logger.info(`Found CE task ${task.id} with status ${status} — will re-upload`);
+      }
+
+      return null;
+    } catch (error) {
+      logger.debug(`Could not check for existing upload: ${error.message}`);
+      return null;
+    }
+  }
+
+  /**
    * Validate report before upload
    */
   validateReport(encodedReport) {

--- a/src/sonarqube/extractors/index.js
+++ b/src/sonarqube/extractors/index.js
@@ -10,6 +10,7 @@ import { extractSymbols } from './symbols.js';
 import { extractSyntaxHighlighting } from './syntax-highlighting.js';
 import { extractHotspotsAsIssues } from './hotspots-to-issues.js';
 import { extractDuplications } from './duplications.js';
+import { checkShutdown } from '../../utils/shutdown.js';
 
 /**
  * Main extractor orchestrator
@@ -237,5 +238,403 @@ export class DataExtractor {
     logger.info(`Components: ${data.components.length}`);
     logger.info(`Source Files: ${data.sources.length}`);
     logger.info('=========================');
+  }
+
+  /**
+   * Extract all data with checkpoint support for pause/resume.
+   *
+   * Each extraction step is guarded by the journal: completed phases are loaded
+   * from cache, in-progress phases are re-executed, and shutdown checks run
+   * between phases for graceful interruption.
+   *
+   * @param {import('../../state/checkpoint.js').CheckpointJournal} journal
+   * @param {import('../../state/extraction-cache.js').ExtractionCache} cache
+   * @param {Function} shutdownCheck - () => boolean
+   * @returns {Promise<object>} Extracted data (same shape as extractAll)
+   */
+  async extractAllWithCheckpoints(journal, cache, shutdownCheck) {
+    logger.info('Starting checkpoint-aware data extraction from SonarQube...');
+
+    const startTime = Date.now();
+    const maxFiles = Number.parseInt(process.env.MAX_SOURCE_FILES || '0', 10);
+    const sourceConcurrency = this.performanceConfig.sourceExtraction?.concurrency || 10;
+    const dupConcurrency = this.performanceConfig.sourceExtraction?.concurrency || 5;
+
+    // Accumulated context that phases can read from and write to
+    const ctx = {
+      project: null,
+      metrics: [],
+      metricKeys: [],
+      components: [],
+      sourceFilesList: [],
+      activeRules: [],
+      issues: [],
+      hotspotIssues: [],
+      measures: {},
+      sources: [],
+      duplications: new Map(),
+      changesets: new Map(),
+      symbols: new Map(),
+      syntaxHighlightings: new Map(),
+      scmRevisionId: null,
+    };
+
+    const phases = [
+      {
+        name: 'extract:project_metadata',
+        label: 'Step 1: Extracting project data',
+        fn: async () => {
+          ctx.project = await extractProjectData(this.client);
+          const scmRevision = await this.client.getLatestAnalysisRevision();
+          if (scmRevision) ctx.scmRevisionId = scmRevision;
+          return { project: ctx.project, scmRevisionId: ctx.scmRevisionId };
+        },
+        restore: (data) => { ctx.project = data.project; ctx.scmRevisionId = data.scmRevisionId; },
+      },
+      {
+        name: 'extract:metrics',
+        label: 'Step 2: Extracting metrics',
+        fn: async () => {
+          ctx.metrics = await extractMetrics(this.client);
+          ctx.metricKeys = getCommonMetricKeys(ctx.metrics);
+          return { metrics: ctx.metrics, metricKeys: ctx.metricKeys };
+        },
+        restore: (data) => { ctx.metrics = data.metrics; ctx.metricKeys = data.metricKeys; },
+      },
+      {
+        name: 'extract:components',
+        label: 'Step 3: Extracting component measures',
+        fn: async () => {
+          ctx.components = await extractComponentMeasures(this.client, ctx.metricKeys);
+          return ctx.components;
+        },
+        restore: (data) => { ctx.components = data; },
+      },
+      {
+        name: 'extract:source_file_list',
+        label: 'Step 3b: Extracting source file list',
+        fn: async () => {
+          ctx.sourceFilesList = await this.client.getSourceFiles();
+          return ctx.sourceFilesList;
+        },
+        restore: (data) => { ctx.sourceFilesList = data; },
+      },
+      {
+        name: 'extract:rules',
+        label: 'Step 4: Extracting active rules',
+        fn: async () => {
+          ctx.activeRules = await extractActiveRules(this.client, ctx.sourceFilesList);
+          return ctx.activeRules;
+        },
+        restore: (data) => { ctx.activeRules = data; },
+      },
+      {
+        name: 'extract:issues',
+        label: 'Step 5: Extracting issues',
+        fn: async () => {
+          ctx.issues = await extractIssues(this.client, this.state);
+          return ctx.issues;
+        },
+        restore: (data) => { ctx.issues = data; },
+      },
+      {
+        name: 'extract:hotspots',
+        label: 'Step 5b: Extracting security hotspots',
+        fn: async () => {
+          ctx.hotspotIssues = await extractHotspotsAsIssues(this.client);
+          return ctx.hotspotIssues;
+        },
+        restore: (data) => { ctx.hotspotIssues = data; },
+      },
+      {
+        name: 'extract:measures',
+        label: 'Step 6: Extracting project measures',
+        fn: async () => {
+          ctx.measures = await extractMeasures(this.client, ctx.metricKeys);
+          return ctx.measures;
+        },
+        restore: (data) => { ctx.measures = data; },
+      },
+      {
+        name: 'extract:sources',
+        label: 'Step 7: Extracting source code',
+        fn: async () => {
+          ctx.sources = await extractSources(this.client, null, maxFiles, { concurrency: sourceConcurrency });
+          return ctx.sources;
+        },
+        restore: (data) => { ctx.sources = data; },
+      },
+      {
+        name: 'extract:duplications',
+        label: 'Step 7b: Extracting duplications',
+        fn: async () => {
+          ctx.duplications = await extractDuplications(this.client, ctx.components, null, { concurrency: dupConcurrency });
+          return ctx.duplications;
+        },
+        restore: (data) => { ctx.duplications = data; },
+      },
+      {
+        name: 'extract:changesets',
+        label: 'Step 8: Extracting changesets',
+        fn: async () => {
+          ctx.changesets = await extractChangesets(this.client, ctx.sourceFilesList, ctx.components);
+          return ctx.changesets;
+        },
+        restore: (data) => { ctx.changesets = data; },
+      },
+      {
+        name: 'extract:symbols',
+        label: 'Step 9: Extracting symbols',
+        fn: async () => {
+          ctx.symbols = await extractSymbols(this.client, ctx.sourceFilesList);
+          return ctx.symbols;
+        },
+        restore: (data) => { ctx.symbols = data; },
+      },
+      {
+        name: 'extract:syntax_highlighting',
+        label: 'Step 10: Extracting syntax highlighting',
+        fn: async () => {
+          ctx.syntaxHighlightings = await extractSyntaxHighlighting(this.client, ctx.sourceFilesList);
+          return ctx.syntaxHighlightings;
+        },
+        restore: (data) => { ctx.syntaxHighlightings = data; },
+      },
+    ];
+
+    for (const phase of phases) {
+      checkShutdown(shutdownCheck);
+
+      if (journal.isPhaseCompleted(phase.name)) {
+        // Load from cache
+        logger.info(`${phase.label} — cached, loading from disk`);
+        const cached = await cache.load(phase.name, 'main');
+        if (cached !== null) {
+          phase.restore(cached);
+          continue;
+        }
+        // Cache miss — re-extract
+        logger.warn(`Cache miss for ${phase.name}, re-extracting`);
+      }
+
+      logger.info(`${phase.label}...`);
+      await journal.startPhase(phase.name);
+      try {
+        const result = await phase.fn();
+        await cache.save(phase.name, 'main', result);
+        await journal.completePhase(phase.name);
+      } catch (error) {
+        await journal.failPhase(phase.name, error.message);
+        throw error;
+      }
+    }
+
+    // Merge hotspots into issues
+    if (ctx.hotspotIssues.length > 0) {
+      ctx.issues = ctx.issues.concat(ctx.hotspotIssues);
+      logger.info(`Added ${ctx.hotspotIssues.length} hotspots to issue list (total: ${ctx.issues.length})`);
+    }
+
+    const duration = ((Date.now() - startTime) / 1000).toFixed(2);
+    logger.info(`Checkpoint-aware extraction completed in ${duration}s`);
+
+    const extractedData = {
+      project: ctx.project,
+      metrics: ctx.metrics,
+      issues: ctx.issues,
+      measures: ctx.measures,
+      components: ctx.components,
+      sources: ctx.sources,
+      activeRules: ctx.activeRules,
+      duplications: ctx.duplications,
+      changesets: ctx.changesets,
+      symbols: ctx.symbols,
+      syntaxHighlightings: ctx.syntaxHighlightings,
+      metadata: {
+        extractedAt: new Date().toISOString(),
+        mode: this.config.transfer.mode,
+        ...(ctx.scmRevisionId ? { scmRevisionId: ctx.scmRevisionId } : {}),
+      },
+    };
+
+    this.logExtractionSummary(extractedData);
+    return extractedData;
+  }
+
+  /**
+   * Extract data for a specific branch with checkpoint support.
+   *
+   * @param {string} branch - Branch name
+   * @param {object} mainData - Data from main branch extraction
+   * @param {import('../../state/checkpoint.js').CheckpointJournal} journal
+   * @param {import('../../state/extraction-cache.js').ExtractionCache} cache
+   * @param {Function} shutdownCheck - () => boolean
+   * @returns {Promise<object>} Extracted data (same shape as extractAll)
+   */
+  async extractBranchWithCheckpoints(branch, mainData, journal, cache, shutdownCheck) {
+    logger.info(`Checkpoint-aware extraction for branch: ${branch}`);
+
+    const startTime = Date.now();
+    const metricKeys = getCommonMetricKeys(mainData.metrics);
+    const maxFiles = Number.parseInt(process.env.MAX_SOURCE_FILES || '0', 10);
+    const sourceConcurrency = this.performanceConfig.sourceExtraction?.concurrency || 10;
+    const dupConcurrency = this.performanceConfig.sourceExtraction?.concurrency || 5;
+
+    const ctx = {
+      components: [],
+      sourceFilesList: [],
+      issues: [],
+      hotspotIssues: [],
+      measures: {},
+      sources: [],
+      duplications: new Map(),
+      changesets: new Map(),
+      symbols: new Map(),
+      syntaxHighlightings: new Map(),
+    };
+
+    const phases = [
+      {
+        name: 'extract:components',
+        label: `[${branch}] Extracting component measures`,
+        fn: async () => {
+          ctx.components = await extractComponentMeasures(this.client, metricKeys, branch);
+          return ctx.components;
+        },
+        restore: (data) => { ctx.components = data; },
+      },
+      {
+        name: 'extract:source_file_list',
+        label: `[${branch}] Extracting source file list`,
+        fn: async () => {
+          ctx.sourceFilesList = await this.client.getSourceFiles(branch);
+          return ctx.sourceFilesList;
+        },
+        restore: (data) => { ctx.sourceFilesList = data; },
+      },
+      {
+        name: 'extract:issues',
+        label: `[${branch}] Extracting issues`,
+        fn: async () => {
+          ctx.issues = await extractIssues(this.client, this.state, branch);
+          return ctx.issues;
+        },
+        restore: (data) => { ctx.issues = data; },
+      },
+      {
+        name: 'extract:hotspots',
+        label: `[${branch}] Extracting security hotspots`,
+        fn: async () => {
+          ctx.hotspotIssues = await extractHotspotsAsIssues(this.client, branch);
+          return ctx.hotspotIssues;
+        },
+        restore: (data) => { ctx.hotspotIssues = data; },
+      },
+      {
+        name: 'extract:measures',
+        label: `[${branch}] Extracting project measures`,
+        fn: async () => {
+          ctx.measures = await extractMeasures(this.client, metricKeys, branch);
+          return ctx.measures;
+        },
+        restore: (data) => { ctx.measures = data; },
+      },
+      {
+        name: 'extract:sources',
+        label: `[${branch}] Extracting source code`,
+        fn: async () => {
+          ctx.sources = await extractSources(this.client, branch, maxFiles, { concurrency: sourceConcurrency });
+          return ctx.sources;
+        },
+        restore: (data) => { ctx.sources = data; },
+      },
+      {
+        name: 'extract:duplications',
+        label: `[${branch}] Extracting duplications`,
+        fn: async () => {
+          ctx.duplications = await extractDuplications(this.client, ctx.components, branch, { concurrency: dupConcurrency });
+          return ctx.duplications;
+        },
+        restore: (data) => { ctx.duplications = data; },
+      },
+      {
+        name: 'extract:changesets',
+        label: `[${branch}] Extracting changesets`,
+        fn: async () => {
+          ctx.changesets = await extractChangesets(this.client, ctx.sourceFilesList, ctx.components);
+          return ctx.changesets;
+        },
+        restore: (data) => { ctx.changesets = data; },
+      },
+      {
+        name: 'extract:symbols',
+        label: `[${branch}] Extracting symbols`,
+        fn: async () => {
+          ctx.symbols = await extractSymbols(this.client, ctx.sourceFilesList);
+          return ctx.symbols;
+        },
+        restore: (data) => { ctx.symbols = data; },
+      },
+      {
+        name: 'extract:syntax_highlighting',
+        label: `[${branch}] Extracting syntax highlighting`,
+        fn: async () => {
+          ctx.syntaxHighlightings = await extractSyntaxHighlighting(this.client, ctx.sourceFilesList);
+          return ctx.syntaxHighlightings;
+        },
+        restore: (data) => { ctx.syntaxHighlightings = data; },
+      },
+    ];
+
+    for (const phase of phases) {
+      checkShutdown(shutdownCheck);
+
+      if (journal.isBranchPhaseCompleted(branch, phase.name)) {
+        logger.info(`${phase.label} — cached, loading from disk`);
+        const cached = await cache.load(phase.name, branch);
+        if (cached !== null) {
+          phase.restore(cached);
+          continue;
+        }
+        logger.warn(`Cache miss for ${phase.name} on branch '${branch}', re-extracting`);
+      }
+
+      logger.info(`${phase.label}...`);
+      await journal.startBranchPhase(branch, phase.name);
+      try {
+        const result = await phase.fn();
+        await cache.save(phase.name, branch, result);
+        await journal.completeBranchPhase(branch, phase.name);
+      } catch (error) {
+        throw error;
+      }
+    }
+
+    // Merge hotspots into issues
+    if (ctx.hotspotIssues.length > 0) {
+      ctx.issues.push(...ctx.hotspotIssues);
+      logger.info(`[${branch}] Added ${ctx.hotspotIssues.length} hotspots to issue list (total: ${ctx.issues.length})`);
+    }
+
+    const duration = ((Date.now() - startTime) / 1000).toFixed(2);
+    logger.info(`[${branch}] Checkpoint-aware branch extraction completed in ${duration}s — ${ctx.issues.length} issues, ${ctx.components.length} components, ${ctx.sources.length} sources`);
+
+    return {
+      project: mainData.project,
+      metrics: mainData.metrics,
+      activeRules: mainData.activeRules,
+      issues: ctx.issues,
+      measures: ctx.measures,
+      components: ctx.components,
+      sources: ctx.sources,
+      duplications: ctx.duplications,
+      changesets: ctx.changesets,
+      symbols: ctx.symbols,
+      syntaxHighlightings: ctx.syntaxHighlightings,
+      metadata: {
+        extractedAt: new Date().toISOString(),
+        mode: this.config.transfer.mode,
+      },
+    };
   }
 }

--- a/src/state/checkpoint.js
+++ b/src/state/checkpoint.js
@@ -1,0 +1,384 @@
+import logger from '../utils/logger.js';
+import { StateStorage } from './storage.js';
+import { StaleResumeError } from '../utils/errors.js';
+
+const JOURNAL_VERSION = 2;
+
+/**
+ * Phase-level checkpoint journal for pause/resume support.
+ *
+ * Records progress at each major pipeline phase. On resume, the journal
+ * tells us exactly where we stopped and which phases can be skipped.
+ */
+export class CheckpointJournal {
+  constructor(journalPath) {
+    this.journalPath = journalPath;
+    this.storage = new StateStorage(journalPath);
+    this.journal = null;
+  }
+
+  /**
+   * Create a new journal or load an existing one for resume.
+   * @param {object} fingerprint - Session fingerprint
+   * @param {string} fingerprint.sonarQubeVersion
+   * @param {string} fingerprint.sonarQubeUrl
+   * @param {string} fingerprint.projectKey
+   * @param {string} fingerprint.cloudvoyagerVersion
+   * @returns {Promise<boolean>} true if resuming from existing journal
+   */
+  async initialize(fingerprint) {
+    const existing = await this.storage.load();
+
+    if (existing && existing.status !== 'completed') {
+      this.journal = existing;
+      logger.info(`Resuming from checkpoint journal (status: ${existing.status})`);
+
+      // Validate fingerprint
+      await this.validateFingerprint(fingerprint);
+
+      // Reset interrupted phases to pending (they need re-execution)
+      for (const [name, phase] of Object.entries(this.journal.phases || {})) {
+        if (phase.status === 'in_progress') {
+          logger.info(`Phase '${name}' was interrupted — will re-execute`);
+          phase.status = 'pending';
+          delete phase.startedAt;
+        }
+      }
+
+      // Reset in-progress branches
+      for (const [name, branch] of Object.entries(this.journal.branches || {})) {
+        if (branch.status === 'in_progress') {
+          logger.info(`Branch '${name}' was interrupted — will re-execute`);
+          branch.status = 'pending';
+          // Reset branch phases too
+          branch.phases = {};
+        }
+      }
+
+      this.journal.status = 'in_progress';
+      await this.save();
+      return true;
+    }
+
+    // Create fresh journal
+    this.journal = {
+      version: JOURNAL_VERSION,
+      cloudvoyagerVersion: fingerprint.cloudvoyagerVersion || 'unknown',
+      sessionFingerprint: {
+        ...fingerprint,
+        startedAt: new Date().toISOString(),
+      },
+      status: 'in_progress',
+      phases: {},
+      branches: {},
+      uploadedCeTasks: {},
+    };
+    await this.save();
+    return false;
+  }
+
+  /**
+   * Validate that the current session matches the stored journal fingerprint.
+   * @param {object} current - Current session fingerprint
+   */
+  async validateFingerprint(current) {
+    const stored = this.journal.sessionFingerprint;
+    if (!stored) return;
+
+    const warnings = [];
+
+    if (current.sonarQubeVersion && stored.sonarQubeVersion &&
+        current.sonarQubeVersion !== stored.sonarQubeVersion) {
+      warnings.push(
+        `SonarQube version changed: ${stored.sonarQubeVersion} → ${current.sonarQubeVersion}`
+      );
+    }
+
+    if (current.sonarQubeUrl && stored.sonarQubeUrl &&
+        current.sonarQubeUrl !== stored.sonarQubeUrl) {
+      warnings.push(
+        `SonarQube URL changed: ${stored.sonarQubeUrl} → ${current.sonarQubeUrl}`
+      );
+    }
+
+    if (current.projectKey && stored.projectKey &&
+        current.projectKey !== stored.projectKey) {
+      throw new StaleResumeError(
+        `Project key mismatch: journal has '${stored.projectKey}' but config has '${current.projectKey}'. ` +
+        'Use --force-restart to discard the journal and start fresh.'
+      );
+    }
+
+    if (current.cloudvoyagerVersion && this.journal.cloudvoyagerVersion &&
+        current.cloudvoyagerVersion !== this.journal.cloudvoyagerVersion) {
+      warnings.push(
+        `CloudVoyager version changed: ${this.journal.cloudvoyagerVersion} → ${current.cloudvoyagerVersion}`
+      );
+    }
+
+    for (const w of warnings) {
+      logger.warn(`Resume warning: ${w}`);
+    }
+  }
+
+  /**
+   * Check if the journal indicates we should use strict mode.
+   * @param {boolean} strictResume - Config flag
+   */
+  checkStrictResume(strictResume) {
+    if (!strictResume) return;
+    // In strict mode, validateFingerprint already logged warnings and threw on mismatches.
+    // If we reach here, the fingerprint is valid.
+    logger.info('Strict resume mode: fingerprint validation passed');
+  }
+
+  // --- Phase tracking ---
+
+  /**
+   * Check if a phase has been completed.
+   * @param {string} phaseName
+   * @returns {boolean}
+   */
+  isPhaseCompleted(phaseName) {
+    return this.journal.phases[phaseName]?.status === 'completed';
+  }
+
+  /**
+   * Mark a phase as in-progress.
+   * @param {string} phaseName
+   */
+  async startPhase(phaseName) {
+    this.journal.phases[phaseName] = {
+      status: 'in_progress',
+      startedAt: new Date().toISOString(),
+    };
+    await this.save();
+  }
+
+  /**
+   * Mark a phase as completed.
+   * @param {string} phaseName
+   * @param {object} [meta] - Additional metadata (e.g., cacheFile)
+   */
+  async completePhase(phaseName, meta = {}) {
+    this.journal.phases[phaseName] = {
+      status: 'completed',
+      completedAt: new Date().toISOString(),
+      ...(this.journal.phases[phaseName]?.startedAt
+        ? { startedAt: this.journal.phases[phaseName].startedAt }
+        : {}),
+      ...meta,
+    };
+    await this.save();
+  }
+
+  /**
+   * Mark a phase as failed.
+   * @param {string} phaseName
+   * @param {string} error - Error message
+   */
+  async failPhase(phaseName, error) {
+    this.journal.phases[phaseName] = {
+      ...this.journal.phases[phaseName],
+      status: 'failed',
+      failedAt: new Date().toISOString(),
+      error,
+    };
+    await this.save();
+  }
+
+  /**
+   * Get the first non-completed phase.
+   * @returns {string|null}
+   */
+  getResumePoint() {
+    for (const [name, phase] of Object.entries(this.journal.phases)) {
+      if (phase.status !== 'completed') return name;
+    }
+    return null;
+  }
+
+  // --- Branch tracking ---
+
+  /**
+   * Get branch status.
+   * @param {string} branchName
+   * @returns {string} 'completed' | 'in_progress' | 'pending' | 'failed' | undefined
+   */
+  getBranchStatus(branchName) {
+    return this.journal.branches[branchName]?.status;
+  }
+
+  /**
+   * Initialize a branch entry.
+   * @param {string} branchName
+   */
+  async startBranch(branchName) {
+    this.journal.branches[branchName] = {
+      status: 'in_progress',
+      startedAt: new Date().toISOString(),
+      phases: {},
+    };
+    await this.save();
+  }
+
+  /**
+   * Mark a branch as completed.
+   * @param {string} branchName
+   * @param {string} [ceTaskId] - CE task ID from upload
+   */
+  async markBranchCompleted(branchName, ceTaskId = null) {
+    this.journal.branches[branchName] = {
+      ...this.journal.branches[branchName],
+      status: 'completed',
+      completedAt: new Date().toISOString(),
+      ceTaskId,
+    };
+    await this.save();
+  }
+
+  /**
+   * Mark a branch as failed.
+   * @param {string} branchName
+   * @param {string} error
+   */
+  async markBranchFailed(branchName, error) {
+    this.journal.branches[branchName] = {
+      ...this.journal.branches[branchName],
+      status: 'failed',
+      failedAt: new Date().toISOString(),
+      error,
+    };
+    await this.save();
+  }
+
+  // --- Branch phase tracking (per-branch extraction phases) ---
+
+  /**
+   * Check if a branch phase is completed.
+   * @param {string} branchName
+   * @param {string} phaseName
+   * @returns {boolean}
+   */
+  isBranchPhaseCompleted(branchName, phaseName) {
+    return this.journal.branches[branchName]?.phases?.[phaseName]?.status === 'completed';
+  }
+
+  /**
+   * Mark a branch phase as started.
+   * @param {string} branchName
+   * @param {string} phaseName
+   */
+  async startBranchPhase(branchName, phaseName) {
+    if (!this.journal.branches[branchName]) {
+      await this.startBranch(branchName);
+    }
+    if (!this.journal.branches[branchName].phases) {
+      this.journal.branches[branchName].phases = {};
+    }
+    this.journal.branches[branchName].phases[phaseName] = {
+      status: 'in_progress',
+      startedAt: new Date().toISOString(),
+    };
+    await this.save();
+  }
+
+  /**
+   * Mark a branch phase as completed.
+   * @param {string} branchName
+   * @param {string} phaseName
+   */
+  async completeBranchPhase(branchName, phaseName) {
+    if (this.journal.branches[branchName]?.phases) {
+      this.journal.branches[branchName].phases[phaseName] = {
+        status: 'completed',
+        completedAt: new Date().toISOString(),
+      };
+      await this.save();
+    }
+  }
+
+  // --- Upload tracking ---
+
+  /**
+   * Record a successful upload for deduplication.
+   * @param {string} branchName
+   * @param {string} taskId - CE task ID
+   */
+  async recordUpload(branchName, taskId) {
+    this.journal.uploadedCeTasks[branchName] = {
+      taskId,
+      submittedAt: new Date().toISOString(),
+    };
+    await this.save();
+  }
+
+  /**
+   * Get previously uploaded CE task for a branch.
+   * @param {string} branchName
+   * @returns {object|null} { taskId, submittedAt } or null
+   */
+  getUploadedCeTask(branchName) {
+    return this.journal.uploadedCeTasks[branchName] || null;
+  }
+
+  // --- Session status ---
+
+  /**
+   * Get the session start time.
+   * @returns {string} ISO timestamp
+   */
+  get sessionStartTime() {
+    return this.journal.sessionFingerprint?.startedAt;
+  }
+
+  /**
+   * Mark the session as interrupted (called by shutdown handler).
+   */
+  async markInterrupted() {
+    if (this.journal) {
+      this.journal.status = 'interrupted';
+      await this.save();
+    }
+  }
+
+  /**
+   * Mark the session as completed.
+   */
+  async markCompleted() {
+    this.journal.status = 'completed';
+    this.journal.completedAt = new Date().toISOString();
+    await this.save();
+  }
+
+  /**
+   * Persist journal to disk.
+   */
+  async save() {
+    await this.storage.save(this.journal);
+  }
+
+  /**
+   * Check if a journal file exists on disk.
+   * @returns {boolean}
+   */
+  exists() {
+    return this.storage.exists();
+  }
+
+  /**
+   * Clear the journal file.
+   */
+  async clear() {
+    await this.storage.clear();
+    this.journal = null;
+  }
+
+  /**
+   * Get the full journal data (for status display).
+   * @returns {object}
+   */
+  getData() {
+    return this.journal;
+  }
+}

--- a/src/state/extraction-cache.js
+++ b/src/state/extraction-cache.js
@@ -1,0 +1,242 @@
+import { mkdir, rm, readdir, stat } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { createGzip, createGunzip } from 'node:zlib';
+import { pipeline } from 'node:stream/promises';
+import { Readable, Writable } from 'node:stream';
+import { createWriteStream, createReadStream } from 'node:fs';
+import logger from '../utils/logger.js';
+
+const DEFAULT_MAX_AGE_DAYS = 7;
+
+/**
+ * Disk-based extraction cache for pause/resume support.
+ *
+ * Caches serialized extraction results per phase per branch so that
+ * resumed runs can skip already-completed extraction steps.
+ */
+export class ExtractionCache {
+  /**
+   * @param {string} cacheDir - Root cache directory for this project
+   * @param {object} [options]
+   * @param {number} [options.maxAgeDays=7] - Auto-purge files older than this
+   */
+  constructor(cacheDir, options = {}) {
+    this.cacheDir = cacheDir;
+    this.maxAgeDays = options.maxAgeDays || DEFAULT_MAX_AGE_DAYS;
+  }
+
+  /**
+   * Ensure cache directory exists.
+   */
+  async _ensureDir(subDir = '') {
+    const dir = subDir ? join(this.cacheDir, subDir) : this.cacheDir;
+    if (!existsSync(dir)) {
+      await mkdir(dir, { recursive: true });
+    }
+    return dir;
+  }
+
+  /**
+   * Get the cache file path for a given phase and branch.
+   * @param {string} phaseName
+   * @param {string} branchName
+   * @returns {string}
+   */
+  _filePath(phaseName, branchName) {
+    const safeBranch = branchName.replace(/[^a-zA-Z0-9_-]/g, '_');
+    const safePhase = phaseName.replace(/[^a-zA-Z0-9_:-]/g, '_');
+    return join(this.cacheDir, `${safePhase}__${safeBranch}.json.gz`);
+  }
+
+  /**
+   * Save extraction result to disk (gzipped JSON).
+   * @param {string} phaseName
+   * @param {string} branchName
+   * @param {*} data - Data to serialize
+   */
+  async save(phaseName, branchName, data) {
+    await this._ensureDir();
+    const filePath = this._filePath(phaseName, branchName);
+
+    try {
+      const serializable = this._toSerializable(data);
+      const envelope = {
+        _meta: {
+          phaseName,
+          branchName,
+          cachedAt: new Date().toISOString(),
+          version: 1,
+        },
+        data: serializable,
+      };
+
+      const json = JSON.stringify(envelope);
+      const inputStream = Readable.from([json]);
+      const gzip = createGzip({ level: 6 });
+      const output = createWriteStream(filePath);
+
+      await pipeline(inputStream, gzip, output);
+      logger.debug(`Cached ${phaseName} for branch '${branchName}' (${(json.length / 1024).toFixed(0)}KB)`);
+    } catch (error) {
+      logger.debug(`Failed to cache ${phaseName}: ${error.message}`);
+      // Cache failures are non-fatal
+    }
+  }
+
+  /**
+   * Load extraction result from disk.
+   * @param {string} phaseName
+   * @param {string} branchName
+   * @returns {Promise<*|null>} Deserialized data or null if not found/corrupt
+   */
+  async load(phaseName, branchName) {
+    const filePath = this._filePath(phaseName, branchName);
+
+    if (!existsSync(filePath)) return null;
+
+    try {
+      const chunks = [];
+      const gunzip = createGunzip();
+      const input = createReadStream(filePath);
+      const collector = new Writable({
+        write(chunk, _encoding, cb) {
+          chunks.push(chunk);
+          cb();
+        },
+      });
+
+      await pipeline(input, gunzip, collector);
+      const json = Buffer.concat(chunks).toString('utf-8');
+      const envelope = JSON.parse(json);
+
+      if (!envelope._meta || !envelope.data) {
+        logger.warn(`Cache file corrupt (missing envelope): ${filePath}`);
+        return null;
+      }
+
+      const data = this._fromSerializable(envelope.data);
+      logger.debug(`Loaded cached ${phaseName} for branch '${branchName}'`);
+      return data;
+    } catch (error) {
+      logger.warn(`Failed to load cache for ${phaseName}: ${error.message}`);
+      return null;
+    }
+  }
+
+  /**
+   * Check if a cache file exists for a given phase and branch.
+   * @param {string} phaseName
+   * @param {string} branchName
+   * @returns {boolean}
+   */
+  exists(phaseName, branchName) {
+    return existsSync(this._filePath(phaseName, branchName));
+  }
+
+  /**
+   * Clear the entire cache directory.
+   */
+  async clear() {
+    if (existsSync(this.cacheDir)) {
+      await rm(this.cacheDir, { recursive: true, force: true });
+      logger.info('Extraction cache cleared');
+    }
+  }
+
+  /**
+   * Clear cache files for a specific branch.
+   * @param {string} branchName
+   */
+  async clearBranch(branchName) {
+    if (!existsSync(this.cacheDir)) return;
+
+    const safeBranch = branchName.replace(/[^a-zA-Z0-9_-]/g, '_');
+    try {
+      const files = await readdir(this.cacheDir);
+      for (const file of files) {
+        if (file.includes(`__${safeBranch}.json.gz`)) {
+          const filePath = join(this.cacheDir, file);
+          await rm(filePath, { force: true });
+          logger.debug(`Cleared cache: ${file}`);
+        }
+      }
+    } catch (error) {
+      logger.debug(`Failed to clear branch cache: ${error.message}`);
+    }
+  }
+
+  /**
+   * Purge cache files older than maxAgeDays.
+   */
+  async purgeStale() {
+    if (!existsSync(this.cacheDir)) return;
+
+    const maxAgeMs = this.maxAgeDays * 24 * 60 * 60 * 1000;
+    const now = Date.now();
+    let purgedCount = 0;
+
+    try {
+      const files = await readdir(this.cacheDir);
+      for (const file of files) {
+        const filePath = join(this.cacheDir, file);
+        const fileStat = await stat(filePath);
+        if (now - fileStat.mtimeMs > maxAgeMs) {
+          await rm(filePath, { force: true });
+          purgedCount++;
+        }
+      }
+      if (purgedCount > 0) {
+        logger.info(`Purged ${purgedCount} stale cache file(s) older than ${this.maxAgeDays} days`);
+      }
+    } catch (error) {
+      logger.debug(`Failed to purge stale cache: ${error.message}`);
+    }
+  }
+
+  /**
+   * Convert data to a JSON-serializable form.
+   * Handles Map objects by converting to arrays of entries.
+   * @param {*} data
+   * @returns {*}
+   */
+  _toSerializable(data) {
+    if (data instanceof Map) {
+      return { __type: 'Map', entries: [...data.entries()].map(([k, v]) => [k, this._toSerializable(v)]) };
+    }
+    if (Array.isArray(data)) {
+      return data.map(item => this._toSerializable(item));
+    }
+    if (data && typeof data === 'object' && data.constructor === Object) {
+      const result = {};
+      for (const [key, value] of Object.entries(data)) {
+        result[key] = this._toSerializable(value);
+      }
+      return result;
+    }
+    return data;
+  }
+
+  /**
+   * Convert serialized data back to its original form.
+   * Reconstructs Map objects from entries arrays.
+   * @param {*} data
+   * @returns {*}
+   */
+  _fromSerializable(data) {
+    if (data && typeof data === 'object' && data.__type === 'Map') {
+      return new Map(data.entries.map(([k, v]) => [k, this._fromSerializable(v)]));
+    }
+    if (Array.isArray(data)) {
+      return data.map(item => this._fromSerializable(item));
+    }
+    if (data && typeof data === 'object' && data.constructor === Object) {
+      const result = {};
+      for (const [key, value] of Object.entries(data)) {
+        result[key] = this._fromSerializable(value);
+      }
+      return result;
+    }
+    return data;
+  }
+}

--- a/src/state/lock.js
+++ b/src/state/lock.js
@@ -1,0 +1,157 @@
+import { readFile, unlink, open } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { hostname } from 'node:os';
+import { rename } from 'node:fs/promises';
+import logger from '../utils/logger.js';
+import { LockError } from '../utils/errors.js';
+
+const STALE_LOCK_HOURS = 6;
+
+/**
+ * Advisory lock file to prevent concurrent runs on the same state file.
+ */
+export class LockFile {
+  constructor(lockPath) {
+    this.lockPath = lockPath;
+    this.acquired = false;
+  }
+
+  /**
+   * Acquire the lock. Fails if already held by another live process.
+   * @param {boolean} forceUnlock - Force release of stale/foreign locks
+   */
+  async acquire(forceUnlock = false) {
+    if (existsSync(this.lockPath)) {
+      const existing = await this._readLock();
+
+      if (existing) {
+        if (existing.pid === process.pid) {
+          // Re-entrant: same process already holds lock
+          this.acquired = true;
+          return;
+        }
+
+        const stale = this._isStale(existing);
+        if (stale) {
+          logger.warn(
+            `Found stale lock from PID ${existing.pid} (started ${existing.startedAt}). Auto-releasing.`
+          );
+          await this.forceRelease();
+        } else if (forceUnlock) {
+          logger.warn(`Force-releasing lock held by PID ${existing.pid} on ${existing.hostname}`);
+          await this.forceRelease();
+        } else if (existing.hostname !== hostname()) {
+          throw new LockError(
+            `Lock held by another host (${existing.hostname}, PID ${existing.pid}). ` +
+            `Use --force-unlock to override, or manually delete: ${this.lockPath}`
+          );
+        } else {
+          throw new LockError(
+            `Another instance is running (PID ${existing.pid}, started ${existing.startedAt}). ` +
+            `If this is incorrect, delete ${this.lockPath} or use --force-unlock`
+          );
+        }
+      } else {
+        // Corrupt lock file — treat as stale
+        logger.warn('Found corrupt lock file, overwriting');
+      }
+    }
+
+    // Write lock file atomically
+    const lockData = {
+      pid: process.pid,
+      hostname: hostname(),
+      startedAt: new Date().toISOString(),
+      version: 1,
+    };
+
+    const tmpPath = `${this.lockPath}.tmp`;
+    const fd = await open(tmpPath, 'w');
+    try {
+      await fd.writeFile(JSON.stringify(lockData, null, 2), 'utf-8');
+      await fd.sync();
+    } finally {
+      await fd.close();
+    }
+    await rename(tmpPath, this.lockPath);
+
+    this.acquired = true;
+    logger.debug(`Lock acquired: ${this.lockPath}`);
+  }
+
+  /**
+   * Release the lock (only if we hold it).
+   */
+  async release() {
+    if (!this.acquired) return;
+
+    try {
+      if (existsSync(this.lockPath)) {
+        const existing = await this._readLock();
+        // Only release if we own it
+        if (existing && existing.pid === process.pid) {
+          await unlink(this.lockPath);
+          logger.debug(`Lock released: ${this.lockPath}`);
+        }
+      }
+    } catch (error) {
+      logger.debug(`Could not release lock: ${error.message}`);
+    }
+    this.acquired = false;
+  }
+
+  /**
+   * Force release the lock regardless of owner.
+   */
+  async forceRelease() {
+    try {
+      if (existsSync(this.lockPath)) {
+        await unlink(this.lockPath);
+        logger.debug(`Lock force-released: ${this.lockPath}`);
+      }
+    } catch (error) {
+      logger.debug(`Could not force-release lock: ${error.message}`);
+    }
+    this.acquired = false;
+  }
+
+  /**
+   * Check if the lock is stale (PID dead or too old).
+   * @param {object} lockData - Parsed lock file data
+   * @returns {boolean}
+   */
+  _isStale(lockData) {
+    // Check if PID is alive (same host only)
+    if (lockData.hostname === hostname()) {
+      try {
+        process.kill(lockData.pid, 0); // signal 0 = existence check
+        // PID is alive — not stale
+      } catch {
+        // PID is dead — stale
+        return true;
+      }
+    }
+
+    // Check age
+    const lockAge = Date.now() - new Date(lockData.startedAt).getTime();
+    const maxAge = STALE_LOCK_HOURS * 60 * 60 * 1000;
+    if (lockAge > maxAge) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Read and parse the lock file.
+   * @returns {Promise<object|null>}
+   */
+  async _readLock() {
+    try {
+      const content = await readFile(this.lockPath, 'utf-8');
+      return JSON.parse(content);
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/state/migration-journal.js
+++ b/src/state/migration-journal.js
@@ -1,0 +1,251 @@
+import logger from '../utils/logger.js';
+import { StateStorage } from './storage.js';
+
+const MIGRATION_JOURNAL_VERSION = 1;
+
+/**
+ * Migration journal for multi-project migrate-mode progress.
+ *
+ * Tracks per-organization and per-project completion status so that
+ * interrupted migrations can resume without re-processing completed work.
+ */
+export class MigrationJournal {
+  constructor(journalPath) {
+    this.journalPath = journalPath;
+    this.storage = new StateStorage(journalPath);
+    this.journal = null;
+  }
+
+  /**
+   * Initialize or load an existing migration journal.
+   * @returns {Promise<boolean>} true if resuming from existing journal
+   */
+  async initialize() {
+    const existing = await this.storage.load();
+
+    if (existing && existing.status !== 'completed') {
+      this.journal = existing;
+      logger.info(`Resuming migration from journal (status: ${existing.status})`);
+
+      // Reset interrupted items to pending
+      for (const [orgKey, org] of Object.entries(this.journal.organizations || {})) {
+        if (org.status === 'in_progress') {
+          for (const [projKey, proj] of Object.entries(org.projects || {})) {
+            if (proj.status === 'in_progress') {
+              logger.info(`Project '${projKey}' in org '${orgKey}' was interrupted — will re-execute from last completed step`);
+            }
+          }
+        }
+      }
+
+      this.journal.status = 'in_progress';
+      await this.save();
+      return true;
+    }
+
+    // Create fresh journal
+    this.journal = {
+      version: MIGRATION_JOURNAL_VERSION,
+      status: 'in_progress',
+      startedAt: new Date().toISOString(),
+      organizations: {},
+    };
+    await this.save();
+    return false;
+  }
+
+  // --- Organization tracking ---
+
+  /**
+   * Initialize an organization entry if it doesn't exist.
+   * @param {string} orgKey
+   */
+  async ensureOrg(orgKey) {
+    if (!this.journal.organizations[orgKey]) {
+      this.journal.organizations[orgKey] = {
+        status: 'pending',
+        orgWideResources: 'pending',
+        projects: {},
+      };
+      await this.save();
+    }
+  }
+
+  /**
+   * Check if org-wide resources (gates, profiles, groups, etc.) are completed.
+   * @param {string} orgKey
+   * @returns {boolean}
+   */
+  isOrgWideCompleted(orgKey) {
+    return this.journal.organizations[orgKey]?.orgWideResources === 'completed';
+  }
+
+  /**
+   * Mark org-wide resources as completed.
+   * @param {string} orgKey
+   */
+  async markOrgWideCompleted(orgKey) {
+    await this.ensureOrg(orgKey);
+    this.journal.organizations[orgKey].orgWideResources = 'completed';
+    this.journal.organizations[orgKey].status = 'in_progress';
+    await this.save();
+  }
+
+  /**
+   * Mark an organization as fully completed.
+   * @param {string} orgKey
+   */
+  async markOrgCompleted(orgKey) {
+    if (this.journal.organizations[orgKey]) {
+      this.journal.organizations[orgKey].status = 'completed';
+      this.journal.organizations[orgKey].completedAt = new Date().toISOString();
+      await this.save();
+    }
+  }
+
+  // --- Project tracking ---
+
+  /**
+   * Get a project's status within an organization.
+   * @param {string} orgKey
+   * @param {string} projectKey
+   * @returns {string|undefined}
+   */
+  getProjectStatus(orgKey, projectKey) {
+    return this.journal.organizations[orgKey]?.projects?.[projectKey]?.status;
+  }
+
+  /**
+   * Get the last completed step for an in-progress project.
+   * @param {string} orgKey
+   * @param {string} projectKey
+   * @returns {string|null}
+   */
+  getProjectLastStep(orgKey, projectKey) {
+    return this.journal.organizations[orgKey]?.projects?.[projectKey]?.lastCompletedStep || null;
+  }
+
+  /**
+   * Start tracking a project.
+   * @param {string} orgKey
+   * @param {string} projectKey
+   */
+  async startProject(orgKey, projectKey) {
+    await this.ensureOrg(orgKey);
+    this.journal.organizations[orgKey].projects[projectKey] = {
+      status: 'in_progress',
+      startedAt: new Date().toISOString(),
+      lastCompletedStep: null,
+    };
+    await this.save();
+  }
+
+  /**
+   * Record completion of a step within a project.
+   * @param {string} orgKey
+   * @param {string} projectKey
+   * @param {string} stepName
+   */
+  async completeProjectStep(orgKey, projectKey, stepName) {
+    if (this.journal.organizations[orgKey]?.projects?.[projectKey]) {
+      this.journal.organizations[orgKey].projects[projectKey].lastCompletedStep = stepName;
+      await this.save();
+    }
+  }
+
+  /**
+   * Check if a specific project step has already been completed.
+   * @param {string} orgKey
+   * @param {string} projectKey
+   * @param {string} stepName
+   * @param {string[]} stepOrder - Ordered list of step names
+   * @returns {boolean}
+   */
+  isProjectStepCompleted(orgKey, projectKey, stepName, stepOrder) {
+    const lastStep = this.getProjectLastStep(orgKey, projectKey);
+    if (!lastStep) return false;
+    const lastIdx = stepOrder.indexOf(lastStep);
+    const currentIdx = stepOrder.indexOf(stepName);
+    return currentIdx <= lastIdx;
+  }
+
+  /**
+   * Mark a project as completed.
+   * @param {string} orgKey
+   * @param {string} projectKey
+   */
+  async markProjectCompleted(orgKey, projectKey) {
+    if (this.journal.organizations[orgKey]?.projects?.[projectKey]) {
+      this.journal.organizations[orgKey].projects[projectKey].status = 'completed';
+      this.journal.organizations[orgKey].projects[projectKey].completedAt = new Date().toISOString();
+      await this.save();
+    }
+  }
+
+  /**
+   * Mark a project as failed.
+   * @param {string} orgKey
+   * @param {string} projectKey
+   * @param {string} error
+   */
+  async markProjectFailed(orgKey, projectKey, error) {
+    if (this.journal.organizations[orgKey]?.projects?.[projectKey]) {
+      this.journal.organizations[orgKey].projects[projectKey].status = 'failed';
+      this.journal.organizations[orgKey].projects[projectKey].error = error;
+      this.journal.organizations[orgKey].projects[projectKey].failedAt = new Date().toISOString();
+      await this.save();
+    }
+  }
+
+  // --- Session status ---
+
+  /**
+   * Mark the migration as interrupted.
+   */
+  async markInterrupted() {
+    if (this.journal) {
+      this.journal.status = 'interrupted';
+      await this.save();
+    }
+  }
+
+  /**
+   * Mark the migration as completed.
+   */
+  async markCompleted() {
+    this.journal.status = 'completed';
+    this.journal.completedAt = new Date().toISOString();
+    await this.save();
+  }
+
+  /**
+   * Persist journal to disk.
+   */
+  async save() {
+    await this.storage.save(this.journal);
+  }
+
+  /**
+   * Check if a journal file exists.
+   * @returns {boolean}
+   */
+  exists() {
+    return this.storage.exists();
+  }
+
+  /**
+   * Clear the journal file.
+   */
+  async clear() {
+    await this.storage.clear();
+    this.journal = null;
+  }
+
+  /**
+   * Get the full journal data (for status display).
+   * @returns {object}
+   */
+  getData() {
+    return this.journal;
+  }
+}

--- a/src/state/storage.js
+++ b/src/state/storage.js
@@ -1,10 +1,13 @@
-import { readFile, writeFile, unlink } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import { readFile, unlink, rename, copyFile, open } from 'node:fs/promises';
+import { existsSync, statfsSync } from 'node:fs';
+import { dirname } from 'node:path';
 import logger from '../utils/logger.js';
 import { StateError } from '../utils/errors.js';
 
+const MIN_DISK_SPACE_BYTES = 10 * 1024 * 1024; // 10MB
+
 /**
- * Persistent state storage
+ * Persistent state storage with atomic save and backup support
  */
 export class StateStorage {
   constructor(stateFilePath) {
@@ -12,65 +15,140 @@ export class StateStorage {
   }
 
   /**
-   * Load state from file
+   * Load state from file with fallback to backup
    * @returns {Promise<object|null>} State object or null if doesn't exist
    */
   async load() {
-    try {
-      if (!existsSync(this.filePath)) {
-        logger.debug('State file does not exist');
-        return null;
+    // Try main file first
+    const mainState = await this._tryLoadFile(this.filePath);
+    if (mainState !== null) return mainState;
+
+    // Fallback to backup file
+    const backupPath = `${this.filePath}.backup`;
+    if (existsSync(backupPath)) {
+      logger.warn(`Main state file missing or corrupt, falling back to backup: ${backupPath}`);
+      const backupState = await this._tryLoadFile(backupPath);
+      if (backupState !== null) {
+        // Restore backup as main file
+        try {
+          await copyFile(backupPath, this.filePath);
+          logger.info('Restored state from backup file');
+        } catch { /* best effort */ }
+        return backupState;
       }
+      logger.warn('Backup state file is also corrupt');
+    }
 
-      logger.debug(`Loading state from: ${this.filePath}`);
+    logger.debug('No valid state file found');
+    return null;
+  }
 
-      const content = await readFile(this.filePath, 'utf-8');
+  /**
+   * Try to load and parse a JSON file
+   * @param {string} filePath
+   * @returns {Promise<object|null>}
+   */
+  async _tryLoadFile(filePath) {
+    try {
+      if (!existsSync(filePath)) return null;
+      logger.debug(`Loading state from: ${filePath}`);
+      const content = await readFile(filePath, 'utf-8');
+      if (!content.trim()) return null;
       const state = JSON.parse(content);
-
-      logger.info(`Loaded state from ${this.filePath}`);
+      logger.info(`Loaded state from ${filePath}`);
       return state;
-
     } catch (error) {
       if (error instanceof SyntaxError) {
-        throw new StateError(`Invalid JSON in state file: ${error.message}`);
+        logger.warn(`Invalid JSON in state file ${filePath}: ${error.message}`);
+        return null;
       }
-      throw new StateError(`Failed to load state: ${error.message}`);
+      if (error.code === 'ENOENT') return null;
+      throw new StateError(`Failed to load state from ${filePath}: ${error.message}`);
     }
   }
 
   /**
-   * Save state to file
+   * Save state to file atomically (write-to-temp, fsync, rename)
    * @param {object} state - State object to save
    */
   async save(state) {
     try {
       logger.debug(`Saving state to: ${this.filePath}`);
 
+      // Check disk space
+      this._checkDiskSpace();
+
+      // Backup current file before overwriting
+      if (existsSync(this.filePath)) {
+        try {
+          await copyFile(this.filePath, `${this.filePath}.backup`);
+        } catch (err) {
+          logger.debug(`Could not create backup: ${err.message}`);
+        }
+      }
+
+      // Atomic write: write to temp, fsync, rename
+      const tmpPath = `${this.filePath}.tmp`;
       const content = JSON.stringify(state, null, 2);
-      await writeFile(this.filePath, content, 'utf-8');
+      const fd = await open(tmpPath, 'w');
+      try {
+        await fd.writeFile(content, 'utf-8');
+        await fd.sync();
+      } finally {
+        await fd.close();
+      }
+      await rename(tmpPath, this.filePath);
 
       logger.info(`Saved state to ${this.filePath}`);
-
     } catch (error) {
+      if (error instanceof StateError) throw error;
       throw new StateError(`Failed to save state: ${error.message}`);
     }
   }
 
   /**
-   * Clear state file
+   * Check available disk space before writing
+   * @throws {StateError} if insufficient disk space
    */
-  async clear() {
+  _checkDiskSpace() {
     try {
-      if (existsSync(this.filePath)) {
-        logger.info(`Clearing state file: ${this.filePath}`);
-        await unlink(this.filePath);
-        logger.info('State file cleared');
-      } else {
-        logger.debug('State file does not exist, nothing to clear');
+      const dir = dirname(this.filePath);
+      const stats = statfsSync(dir);
+      const availableBytes = stats.bavail * stats.bsize;
+      if (availableBytes < MIN_DISK_SPACE_BYTES) {
+        throw new StateError(
+          `Insufficient disk space: ${Math.round(availableBytes / 1024 / 1024)}MB available, need at least 10MB`
+        );
       }
     } catch (error) {
-      throw new StateError(`Failed to clear state: ${error.message}`);
+      if (error instanceof StateError) throw error;
+      // statfsSync may not be available on all platforms; proceed without check
+      logger.debug(`Could not check disk space: ${error.message}`);
     }
+  }
+
+  /**
+   * Clear state file and its backup/temp files
+   */
+  async clear() {
+    const filesToClear = [
+      this.filePath,
+      `${this.filePath}.backup`,
+      `${this.filePath}.tmp`,
+    ];
+
+    for (const file of filesToClear) {
+      try {
+        if (existsSync(file)) {
+          await unlink(file);
+          logger.debug(`Cleared: ${file}`);
+        }
+      } catch (error) {
+        logger.debug(`Could not clear ${file}: ${error.message}`);
+      }
+    }
+
+    logger.info('State file cleared');
   }
 
   /**

--- a/src/state/tracker.js
+++ b/src/state/tracker.js
@@ -1,12 +1,15 @@
 import logger from '../utils/logger.js';
 import { StateStorage } from './storage.js';
+import { LockFile } from './lock.js';
 
 /**
  * State tracker for incremental transfers
  */
 export class StateTracker {
   constructor(stateFilePath) {
+    this.stateFilePath = stateFilePath;
     this.storage = new StateStorage(stateFilePath);
+    this.lock = new LockFile(`${stateFilePath}.lock`);
     this.state = {
       lastSync: null,
       processedIssues: [],
@@ -17,9 +20,16 @@ export class StateTracker {
 
   /**
    * Initialize state (load from file if exists)
+   * @param {object} [options]
+   * @param {boolean} [options.acquireLock=false] - Acquire advisory lock on state file
+   * @param {boolean} [options.forceUnlock=false] - Force release stale/foreign locks
    */
-  async initialize() {
+  async initialize({ acquireLock = false, forceUnlock = false } = {}) {
     logger.info('Initializing state tracker...');
+
+    if (acquireLock) {
+      await this.lock.acquire(forceUnlock);
+    }
 
     const savedState = await this.storage.load();
 
@@ -124,6 +134,23 @@ export class StateTracker {
   }
 
   /**
+   * Save state after a branch completes (convenience for per-branch checkpointing).
+   * @param {string} branchName
+   */
+  async saveAfterBranch(branchName) {
+    this.markBranchCompleted(branchName);
+    await this.save();
+    logger.debug(`State saved after branch completion: ${branchName}`);
+  }
+
+  /**
+   * Release the advisory lock (call at end of pipeline or in cleanup).
+   */
+  async releaseLock() {
+    await this.lock.release();
+  }
+
+  /**
    * Clear state and reset
    */
   async reset() {
@@ -137,6 +164,7 @@ export class StateTracker {
     };
 
     await this.storage.clear();
+    await this.lock.release();
     logger.info('State reset complete');
   }
 

--- a/src/transfer-pipeline.js
+++ b/src/transfer-pipeline.js
@@ -5,8 +5,14 @@ import { ProtobufBuilder } from './protobuf/builder.js';
 import { ProtobufEncoder } from './protobuf/encoder.js';
 import { ReportUploader } from './sonarcloud/uploader.js';
 import { StateTracker } from './state/tracker.js';
+import { CheckpointJournal } from './state/checkpoint.js';
+import { ExtractionCache } from './state/extraction-cache.js';
+import { LockFile } from './state/lock.js';
 import { hasCleanCodeTaxonomy } from './utils/version.js';
 import { buildRuleEnrichmentMap } from './sonarcloud/rule-enrichment.js';
+import { checkShutdown } from './utils/shutdown.js';
+import { GracefulShutdownError } from './utils/errors.js';
+import { dirname, join } from 'node:path';
 import logger from './utils/logger.js';
 
 /**
@@ -27,16 +33,25 @@ import logger from './utils/logger.js';
  * @param {string} [options.projectName=null] - Human-readable project name from SonarQube
  * @returns {Promise<object>} Transfer result with stats
  */
-export async function transferProject({ sonarqubeConfig, sonarcloudConfig, transferConfig, performanceConfig = {}, wait = false, skipConnectionTest = false, projectName = null, ruleEnrichmentMap: prebuiltEnrichmentMap = null }) {
+export async function transferProject({ sonarqubeConfig, sonarcloudConfig, transferConfig, performanceConfig = {}, wait = false, skipConnectionTest = false, projectName = null, ruleEnrichmentMap: prebuiltEnrichmentMap = null, shutdownCoordinator = null, forceRestart = false, forceFreshExtract = false }) {
   const projectKey = sonarqubeConfig.projectKey;
   logger.info(`Starting transfer for project: ${projectKey}`);
+
+  const shutdownCheck = shutdownCoordinator ? shutdownCoordinator.shutdownCheck() : () => false;
+  const checkpointEnabled = transferConfig.checkpoint?.enabled !== false;
+  const isIncremental = transferConfig.mode === 'incremental';
 
   // Resolve branch sync settings (default: sync all branches)
   const syncAllBranches = transferConfig.syncAllBranches !== false;
   const excludeBranches = new Set(transferConfig.excludeBranches || []);
   const includeBranches = transferConfig.includeBranches || null; // Set<string> from CSV, or null = all
 
-  // Initialize state tracker
+  // --- Lock file (prevent concurrent runs) ---
+  const lockPath = `${transferConfig.stateFile}.lock`;
+  const lockFile = new LockFile(lockPath);
+  await lockFile.acquire();
+
+  // --- Initialize state tracker ---
   const stateTracker = new StateTracker(transferConfig.stateFile);
   await stateTracker.initialize();
 
@@ -46,181 +61,332 @@ export async function transferProject({ sonarqubeConfig, sonarcloudConfig, trans
     logger.info(`Previously processed: ${stateSummary.processedIssuesCount} issues`);
   }
 
-  // Create per-project API clients
-  const sonarQubeClient = new SonarQubeClient(sonarqubeConfig);
-  const sonarCloudClient = new SonarCloudClient(sonarcloudConfig);
+  // --- Initialize checkpoint journal ---
+  let journal = null;
+  let cache = null;
 
-  // Test connections (unless skipped)
-  if (!skipConnectionTest) {
-    await sonarQubeClient.testConnection();
-    await sonarCloudClient.testConnection();
-  }
+  if (checkpointEnabled) {
+    const journalPath = `${transferConfig.stateFile}.journal`;
 
-  // If no project name was provided, fetch it from SonarQube
-  if (!projectName) {
-    try {
-      const sqProject = await sonarQubeClient.getProject();
-      projectName = sqProject.name || null;
-    } catch (error) {
-      logger.warn(`Could not fetch project name from SonarQube: ${error.message}`);
+    if (forceRestart) {
+      const tmpJournal = new CheckpointJournal(journalPath);
+      if (tmpJournal.exists()) {
+        logger.info('--force-restart: clearing existing checkpoint journal');
+        await tmpJournal.clear();
+      }
     }
-  }
 
-  // Ensure SonarCloud project exists (with the original human-readable name)
-  await sonarCloudClient.ensureProject(projectName);
+    journal = new CheckpointJournal(journalPath);
 
-  // If CSV specifies branch includes, verify the main branch is included
-  if (includeBranches) {
-    // Peek at the SonarQube main branch name to check against the include set
-    const sqBranches = await sonarQubeClient.getBranches();
-    const sqMainBranch = sqBranches.find(b => b.isMain);
-    const sqMainBranchName = sqMainBranch?.name || 'main';
-    if (!includeBranches.has(sqMainBranchName)) {
-      logger.warn(`Main branch '${sqMainBranchName}' is excluded by CSV for project ${projectKey} — skipping entire project`);
-      return {
-        projectKey,
-        sonarCloudProjectKey: sonarcloudConfig.projectKey,
-        stats: { issuesTransferred: 0, componentsTransferred: 0, sourcesTransferred: 0, linesOfCode: 0, branchesTransferred: [] }
-      };
-    }
-  }
-
-  // Extract data from SonarQube (main branch)
-  logger.info('Starting data extraction from SonarQube (main branch)...');
-  const config = { sonarqube: sonarqubeConfig, sonarcloud: sonarcloudConfig, transfer: transferConfig };
-  const extractor = new DataExtractor(
-    sonarQubeClient,
-    config,
-    transferConfig.mode === 'incremental' ? stateTracker : null,
-    performanceConfig
-  );
-  const extractedData = await extractor.extractAll();
-
-  // Fetch SonarCloud quality profiles and main branch name
-  logger.info('Fetching SonarCloud quality profiles...');
-  const sonarCloudProfiles = await sonarCloudClient.getQualityProfiles();
-  const sonarCloudMainBranch = await sonarCloudClient.getMainBranchName();
-
-  // Fetch SonarCloud rule repositories for auto-detecting external issues
-  logger.info('Fetching SonarCloud rule repositories...');
-  const sonarCloudRepos = await sonarCloudClient.getRuleRepositories();
-
-  // Use cached version from testConnection() / detectVersion(), or detect now
-  const sqVersion = sonarQubeClient.parsedVersion || await sonarQubeClient.detectVersion();
-
-  let ruleEnrichmentMap = prebuiltEnrichmentMap || new Map();
-  if (!prebuiltEnrichmentMap && !hasCleanCodeTaxonomy(sqVersion)) {
-    logger.warn(`SonarQube ${sqVersion.raw} does not support Clean Code taxonomy (requires 10.0+). Fetching enrichment from SonarCloud...`);
-    try {
-      ruleEnrichmentMap = await buildRuleEnrichmentMap(sonarCloudClient, sonarCloudProfiles);
-    } catch (error) {
-      logger.warn(`Failed to build rule enrichment map: ${error.message}. Falling back to type-based inference.`);
-    }
-  }
-
-  // --- Transfer main branch ---
-  const mainBranchResult = await transferBranch({
-    extractedData,
-    sonarcloudConfig,
-    sonarCloudProfiles,
-    branchName: sonarCloudMainBranch,
-    referenceBranchName: sonarCloudMainBranch,
-    wait,
-    sonarCloudClient,
-    label: 'main',
-    isMainBranch: true,
-    sonarCloudRepos,
-    ruleEnrichmentMap
-  });
-
-  // Track aggregated stats across all branches
-  const aggregatedStats = { ...mainBranchResult.stats, branchesTransferred: [sonarCloudMainBranch] };
-
-  if (transferConfig.mode === 'incremental') {
-    stateTracker.markBranchCompleted(sonarCloudMainBranch);
-  }
-
-  // --- Transfer non-main branches ---
-  if (syncAllBranches) {
-    const allBranches = extractedData.project.branches || [];
-    const nonMainBranches = allBranches.filter(b => {
-      if (b.isMain) return false;
-      if (excludeBranches.has(b.name)) return false;
-      if (includeBranches && !includeBranches.has(b.name)) return false;
-      return true;
+    const cacheDir = join(dirname(transferConfig.stateFile), '.cache', 'extractions', projectKey.replace(/[^a-zA-Z0-9_-]/g, '_'));
+    cache = new ExtractionCache(cacheDir, {
+      maxAgeDays: transferConfig.checkpoint?.cacheMaxAgeDays || 7,
     });
 
-    if (nonMainBranches.length > 0) {
-      // SonarCloud requires the main branch analysis to complete before non-main
-      // branch reports can be processed (the main branch serves as the reference
-      // baseline).  If we haven't already waited (wait=false), poll now.
-      if (!wait && mainBranchResult.ceTask?.id) {
-        logger.info(`Waiting for main branch CE task ${mainBranchResult.ceTask.id} to complete before syncing non-main branches...`);
-        try {
-          await sonarCloudClient.waitForAnalysis(mainBranchResult.ceTask.id, 600);
-          logger.info('Main branch analysis completed — proceeding with non-main branches');
-        } catch (error) {
-          logger.error(`Main branch analysis did not complete successfully: ${error.message}`);
-          logger.warn('Attempting non-main branch transfers anyway...');
-        }
-      }
+    if (forceFreshExtract) {
+      logger.info('--force-fresh-extract: clearing extraction cache');
+      await cache.clear();
+    }
 
-      logger.info(`Syncing ${nonMainBranches.length} additional branch(es): ${nonMainBranches.map(b => b.name).join(', ')}`);
+    // Purge stale cache files on startup
+    await cache.purgeStale();
 
-      for (const branch of nonMainBranches) {
-        const branchName = branch.name;
-
-        // Skip if already completed in a previous incremental run
-        if (transferConfig.mode === 'incremental' && stateTracker.isBranchCompleted(branchName)) {
-          logger.info(`Branch '${branchName}' already completed — skipping`);
-          continue;
-        }
-
-        try {
-          logger.info(`--- Extracting branch: ${branchName} ---`);
-          const branchData = await extractor.extractBranch(branchName, extractedData);
-
-          const branchResult = await transferBranch({
-            extractedData: branchData,
-            sonarcloudConfig,
-            sonarCloudProfiles,
-            branchName,
-            referenceBranchName: sonarCloudMainBranch,
-            wait,
-            sonarCloudClient,
-            label: branchName,
-            sonarCloudRepos,
-            ruleEnrichmentMap
-          });
-
-          // Accumulate stats
-          aggregatedStats.issuesTransferred += branchResult.stats.issuesTransferred;
-          aggregatedStats.hotspotsTransferred = (aggregatedStats.hotspotsTransferred || 0) + (branchResult.stats.hotspotsTransferred || 0);
-          aggregatedStats.componentsTransferred += branchResult.stats.componentsTransferred;
-          aggregatedStats.sourcesTransferred += branchResult.stats.sourcesTransferred;
-          aggregatedStats.linesOfCode += branchResult.stats.linesOfCode;
-          aggregatedStats.branchesTransferred.push(branchName);
-
-          if (transferConfig.mode === 'incremental') {
-            stateTracker.markBranchCompleted(branchName);
-          }
-        } catch (error) {
-          logger.error(`Failed to transfer branch '${branchName}': ${error.message}`);
-          logger.warn('Continuing with remaining branches...');
-        }
-      }
-    } else {
-      logger.info('No additional branches to sync (only the main branch exists)');
+    // Register shutdown cleanup
+    if (shutdownCoordinator) {
+      shutdownCoordinator.register(async () => {
+        if (journal) await journal.markInterrupted();
+        await stateTracker.save();
+        await lockFile.release();
+      });
     }
   }
 
-  // Record successful transfer in state
-  if (transferConfig.mode === 'incremental') {
-    await stateTracker.recordTransfer(aggregatedStats);
-  }
+  try {
+    // Create per-project API clients
+    const sonarQubeClient = new SonarQubeClient(sonarqubeConfig);
+    const sonarCloudClient = new SonarCloudClient(sonarcloudConfig);
 
-  logger.info(`Transfer completed for project: ${projectKey} — ${aggregatedStats.branchesTransferred.length} branch(es): ${aggregatedStats.branchesTransferred.join(', ')}`);
-  return { projectKey, sonarCloudProjectKey: sonarcloudConfig.projectKey, stats: aggregatedStats };
+    // Test connections (unless skipped)
+    if (!skipConnectionTest) {
+      await sonarQubeClient.testConnection();
+      await sonarCloudClient.testConnection();
+    }
+
+    // --- SonarQube version pre-validation ---
+    const sqVersion = sonarQubeClient.parsedVersion || await sonarQubeClient.detectVersion();
+    logger.info(`SonarQube version: ${sqVersion?.raw || 'unknown'}`);
+
+    // Initialize journal with session fingerprint
+    if (journal) {
+      const isResume = await journal.initialize({
+        sonarQubeVersion: sqVersion?.raw || 'unknown',
+        sonarQubeUrl: sonarqubeConfig.url,
+        projectKey,
+        cloudvoyagerVersion: process.env.npm_package_version || 'dev',
+      });
+
+      if (isResume) {
+        logger.info('=== RESUMING FROM CHECKPOINT ===');
+
+        // Validate SonarCloud project still exists on resume
+        const exists = await sonarCloudClient.projectExists?.() || true;
+        if (!exists) {
+          throw new Error(`SonarCloud project ${sonarcloudConfig.projectKey} no longer exists. Cannot resume.`);
+        }
+      }
+    }
+
+    checkShutdown(shutdownCheck);
+
+    // If no project name was provided, fetch it from SonarQube
+    if (!projectName) {
+      try {
+        const sqProject = await sonarQubeClient.getProject();
+        projectName = sqProject.name || null;
+      } catch (error) {
+        logger.warn(`Could not fetch project name from SonarQube: ${error.message}`);
+      }
+    }
+
+    // Ensure SonarCloud project exists (with the original human-readable name)
+    await sonarCloudClient.ensureProject(projectName);
+
+    // If CSV specifies branch includes, verify the main branch is included
+    if (includeBranches) {
+      const sqBranches = await sonarQubeClient.getBranches();
+      const sqMainBranch = sqBranches.find(b => b.isMain);
+      const sqMainBranchName = sqMainBranch?.name || 'main';
+      if (!includeBranches.has(sqMainBranchName)) {
+        logger.warn(`Main branch '${sqMainBranchName}' is excluded by CSV for project ${projectKey} — skipping entire project`);
+        if (journal) await journal.markCompleted();
+        await lockFile.release();
+        return {
+          projectKey,
+          sonarCloudProjectKey: sonarcloudConfig.projectKey,
+          stats: { issuesTransferred: 0, componentsTransferred: 0, sourcesTransferred: 0, linesOfCode: 0, branchesTransferred: [] }
+        };
+      }
+    }
+
+    checkShutdown(shutdownCheck);
+
+    // --- Extract data from SonarQube (main branch) ---
+    logger.info('Starting data extraction from SonarQube (main branch)...');
+    const config = { sonarqube: sonarqubeConfig, sonarcloud: sonarcloudConfig, transfer: transferConfig };
+    const extractor = new DataExtractor(
+      sonarQubeClient,
+      config,
+      isIncremental ? stateTracker : null,
+      performanceConfig
+    );
+
+    // Use checkpoint-aware extraction if journal available, else fallback
+    let extractedData;
+    if (journal && cache) {
+      extractedData = await extractor.extractAllWithCheckpoints(journal, cache, shutdownCheck);
+    } else {
+      extractedData = await extractor.extractAll();
+    }
+
+    checkShutdown(shutdownCheck);
+
+    // Fetch SonarCloud quality profiles and main branch name
+    logger.info('Fetching SonarCloud quality profiles...');
+    const sonarCloudProfiles = await sonarCloudClient.getQualityProfiles();
+    const sonarCloudMainBranch = await sonarCloudClient.getMainBranchName();
+
+    // Fetch SonarCloud rule repositories for auto-detecting external issues
+    logger.info('Fetching SonarCloud rule repositories...');
+    const sonarCloudRepos = await sonarCloudClient.getRuleRepositories();
+
+    let ruleEnrichmentMap = prebuiltEnrichmentMap || new Map();
+    if (!prebuiltEnrichmentMap && !hasCleanCodeTaxonomy(sqVersion)) {
+      logger.warn(`SonarQube ${sqVersion.raw} does not support Clean Code taxonomy (requires 10.0+). Fetching enrichment from SonarCloud...`);
+      try {
+        ruleEnrichmentMap = await buildRuleEnrichmentMap(sonarCloudClient, sonarCloudProfiles);
+      } catch (error) {
+        logger.warn(`Failed to build rule enrichment map: ${error.message}. Falling back to type-based inference.`);
+      }
+    }
+
+    checkShutdown(shutdownCheck);
+
+    // --- Transfer main branch ---
+    let mainBranchResult;
+    const mainBranchCompleted = journal?.getBranchStatus(sonarCloudMainBranch) === 'completed';
+
+    if (mainBranchCompleted) {
+      logger.info(`Main branch '${sonarCloudMainBranch}' already completed in journal — skipping`);
+      const ceTaskInfo = journal.getUploadedCeTask(sonarCloudMainBranch);
+      mainBranchResult = {
+        stats: { issuesTransferred: 0, hotspotsTransferred: 0, componentsTransferred: 0, sourcesTransferred: 0, linesOfCode: 0 },
+        ceTask: ceTaskInfo ? { id: ceTaskInfo.taskId } : null,
+      };
+    } else {
+      if (journal) await journal.startBranch(sonarCloudMainBranch);
+
+      // Upload deduplication: check if we already uploaded in this session
+      const uploader = new ReportUploader(sonarCloudClient);
+      const existingUpload = journal ? await uploader.checkExistingUpload(journal.sessionStartTime) : null;
+
+      if (existingUpload) {
+        mainBranchResult = {
+          stats: { issuesTransferred: 0, hotspotsTransferred: 0, componentsTransferred: 0, sourcesTransferred: 0, linesOfCode: 0 },
+          ceTask: existingUpload,
+        };
+      } else {
+        mainBranchResult = await transferBranch({
+          extractedData,
+          sonarcloudConfig,
+          sonarCloudProfiles,
+          branchName: sonarCloudMainBranch,
+          referenceBranchName: sonarCloudMainBranch,
+          wait,
+          sonarCloudClient,
+          label: 'main',
+          isMainBranch: true,
+          sonarCloudRepos,
+          ruleEnrichmentMap
+        });
+      }
+
+      if (journal) {
+        await journal.recordUpload(sonarCloudMainBranch, mainBranchResult.ceTask?.id);
+        await journal.markBranchCompleted(sonarCloudMainBranch, mainBranchResult.ceTask?.id);
+      }
+    }
+
+    // Track aggregated stats across all branches
+    const aggregatedStats = { ...mainBranchResult.stats, branchesTransferred: [sonarCloudMainBranch] };
+
+    if (isIncremental) {
+      stateTracker.markBranchCompleted(sonarCloudMainBranch);
+      await stateTracker.save(); // Save after each branch, not just at the end
+    }
+
+    checkShutdown(shutdownCheck);
+
+    // --- Transfer non-main branches ---
+    if (syncAllBranches) {
+      const allBranches = extractedData.project.branches || [];
+      const nonMainBranches = allBranches.filter(b => {
+        if (b.isMain) return false;
+        if (excludeBranches.has(b.name)) return false;
+        if (includeBranches && !includeBranches.has(b.name)) return false;
+        return true;
+      });
+
+      if (nonMainBranches.length > 0) {
+        // SonarCloud requires main branch analysis to complete before non-main branches
+        if (!wait && mainBranchResult.ceTask?.id) {
+          logger.info(`Waiting for main branch CE task ${mainBranchResult.ceTask.id} to complete before syncing non-main branches...`);
+          try {
+            await sonarCloudClient.waitForAnalysis(mainBranchResult.ceTask.id, 600);
+            logger.info('Main branch analysis completed — proceeding with non-main branches');
+          } catch (error) {
+            logger.error(`Main branch analysis did not complete successfully: ${error.message}`);
+            logger.warn('Attempting non-main branch transfers anyway...');
+          }
+        }
+
+        logger.info(`Syncing ${nonMainBranches.length} additional branch(es): ${nonMainBranches.map(b => b.name).join(', ')}`);
+
+        for (const branch of nonMainBranches) {
+          const branchName = branch.name;
+
+          // Check shutdown between branches
+          if (shutdownCheck()) {
+            logger.warn('Shutdown requested — stopping branch transfers');
+            break;
+          }
+
+          // Skip if already completed (state tracker or journal)
+          if (isIncremental && stateTracker.isBranchCompleted(branchName)) {
+            logger.info(`Branch '${branchName}' already completed — skipping`);
+            continue;
+          }
+          if (journal?.getBranchStatus(branchName) === 'completed') {
+            logger.info(`Branch '${branchName}' already completed in journal — skipping`);
+            aggregatedStats.branchesTransferred.push(branchName);
+            continue;
+          }
+
+          try {
+            if (journal) await journal.startBranch(branchName);
+
+            logger.info(`--- Extracting branch: ${branchName} ---`);
+            let branchData;
+            if (journal && cache) {
+              branchData = await extractor.extractBranchWithCheckpoints(branchName, extractedData, journal, cache, shutdownCheck);
+            } else {
+              branchData = await extractor.extractBranch(branchName, extractedData);
+            }
+
+            const branchResult = await transferBranch({
+              extractedData: branchData,
+              sonarcloudConfig,
+              sonarCloudProfiles,
+              branchName,
+              referenceBranchName: sonarCloudMainBranch,
+              wait,
+              sonarCloudClient,
+              label: branchName,
+              sonarCloudRepos,
+              ruleEnrichmentMap
+            });
+
+            // Accumulate stats
+            aggregatedStats.issuesTransferred += branchResult.stats.issuesTransferred;
+            aggregatedStats.hotspotsTransferred = (aggregatedStats.hotspotsTransferred || 0) + (branchResult.stats.hotspotsTransferred || 0);
+            aggregatedStats.componentsTransferred += branchResult.stats.componentsTransferred;
+            aggregatedStats.sourcesTransferred += branchResult.stats.sourcesTransferred;
+            aggregatedStats.linesOfCode += branchResult.stats.linesOfCode;
+            aggregatedStats.branchesTransferred.push(branchName);
+
+            if (journal) {
+              await journal.recordUpload(branchName, branchResult.ceTask?.id);
+              await journal.markBranchCompleted(branchName, branchResult.ceTask?.id);
+            }
+
+            if (isIncremental) {
+              stateTracker.markBranchCompleted(branchName);
+              await stateTracker.save(); // Save after each branch
+            }
+          } catch (error) {
+            if (error instanceof GracefulShutdownError) throw error;
+            if (journal) await journal.markBranchFailed(branchName, error.message);
+            logger.error(`Failed to transfer branch '${branchName}': ${error.message}`);
+            logger.warn('Continuing with remaining branches...');
+          }
+        }
+      } else {
+        logger.info('No additional branches to sync (only the main branch exists)');
+      }
+    }
+
+    // Record successful transfer in state
+    if (isIncremental) {
+      await stateTracker.recordTransfer(aggregatedStats);
+    }
+
+    // Mark journal as completed
+    if (journal) {
+      await journal.markCompleted();
+    }
+
+    // Release lock
+    await lockFile.release();
+
+    logger.info(`Transfer completed for project: ${projectKey} — ${aggregatedStats.branchesTransferred.length} branch(es): ${aggregatedStats.branchesTransferred.join(', ')}`);
+    return { projectKey, sonarCloudProjectKey: sonarcloudConfig.projectKey, stats: aggregatedStats };
+  } catch (error) {
+    // On graceful shutdown, journal already marked interrupted by cleanup handler
+    if (!(error instanceof GracefulShutdownError) && journal) {
+      await journal.markInterrupted().catch(() => {});
+    }
+    await lockFile.release();
+    throw error;
+  }
 }
 
 /**

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -77,3 +77,30 @@ export class ValidationError extends CloudVoyagerError {
     this.errors = errors;
   }
 }
+
+/**
+ * Graceful shutdown error (not a real failure)
+ */
+export class GracefulShutdownError extends CloudVoyagerError {
+  constructor(message = 'Operation interrupted by shutdown signal') {
+    super(message, 0);
+  }
+}
+
+/**
+ * Lock error (another instance is running)
+ */
+export class LockError extends CloudVoyagerError {
+  constructor(message) {
+    super(message, 423);
+  }
+}
+
+/**
+ * Stale resume error (version/config mismatch)
+ */
+export class StaleResumeError extends CloudVoyagerError {
+  constructor(message) {
+    super(message, 409);
+  }
+}

--- a/src/utils/progress.js
+++ b/src/utils/progress.js
@@ -1,0 +1,203 @@
+import { existsSync } from 'node:fs';
+import { dirname } from 'node:path';
+import logger from './logger.js';
+import { StateStorage } from '../state/storage.js';
+
+/**
+ * Progress display for checkpoint journal and migration journal.
+ *
+ * Reads journal files from disk and renders a human-readable status table.
+ */
+export class ProgressTracker {
+  /**
+   * @param {string} stateFilePath - Path to the state file (used to derive journal paths)
+   */
+  constructor(stateFilePath) {
+    this.stateDir = dirname(stateFilePath);
+    this.journalPath = `${stateFilePath}.journal`;
+  }
+
+  /**
+   * Display checkpoint journal status for the transfer command.
+   */
+  async displayStatus() {
+    if (!existsSync(this.journalPath)) {
+      logger.info('No checkpoint journal found. No transfer in progress.');
+      return;
+    }
+
+    const storage = new StateStorage(this.journalPath);
+    const journal = await storage.load();
+    if (!journal) {
+      logger.info('Checkpoint journal is empty or corrupt.');
+      return;
+    }
+
+    logger.info('=== Transfer Checkpoint Status ===');
+    logger.info(`Status: ${journal.status || 'unknown'}`);
+
+    if (journal.sessionFingerprint) {
+      const fp = journal.sessionFingerprint;
+      logger.info(`Project: ${fp.projectKey || 'unknown'}`);
+      logger.info(`SonarQube: ${fp.sonarQubeUrl || 'unknown'} (v${fp.sonarQubeVersion || '?'})`);
+      logger.info(`Started: ${fp.startedAt || 'unknown'}`);
+    }
+
+    // Phase progress
+    if (journal.phases) {
+      const phases = Object.entries(journal.phases);
+      const completed = phases.filter(([, p]) => p.status === 'completed').length;
+      const total = phases.length;
+      const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+      logger.info('');
+      logger.info(`Phases: ${completed}/${total} completed (${pct}%)`);
+      logger.info('');
+
+      for (const [name, phase] of phases) {
+        const icon = phase.status === 'completed' ? '[done]'
+          : phase.status === 'in_progress' ? '[>>  ]'
+            : phase.status === 'failed' ? '[FAIL]'
+              : '[    ]';
+        logger.info(`  ${icon} ${name}`);
+      }
+    }
+
+    // Branch progress
+    if (journal.branches && Object.keys(journal.branches).length > 0) {
+      const branches = Object.entries(journal.branches);
+      const completedBranches = branches.filter(([, b]) => b.status === 'completed').length;
+
+      logger.info('');
+      logger.info(`Branches: ${completedBranches}/${branches.length} completed`);
+      logger.info('');
+
+      for (const [name, branch] of branches) {
+        const icon = branch.status === 'completed' ? '[done]'
+          : branch.status === 'in_progress' ? '[>>  ]'
+            : branch.status === 'failed' ? '[FAIL]'
+              : '[    ]';
+        const detail = branch.currentPhase ? ` (at: ${branch.currentPhase})` : '';
+        logger.info(`  ${icon} ${name}${detail}`);
+      }
+    }
+
+    // Upload dedup info
+    if (journal.uploadedCeTasks && Object.keys(journal.uploadedCeTasks).length > 0) {
+      logger.info('');
+      logger.info('Uploaded CE tasks:');
+      for (const [branch, task] of Object.entries(journal.uploadedCeTasks)) {
+        logger.info(`  ${branch}: ${task.taskId} (${task.status})`);
+      }
+    }
+
+    // Estimated time remaining
+    const estimate = this.getEstimatedTimeRemaining(journal);
+    if (estimate) {
+      logger.info('');
+      logger.info(`Estimated time remaining: ${estimate}`);
+    }
+  }
+
+  /**
+   * Display migration journal status (multi-org migration).
+   * @param {string} migrationJournalPath - Path to migration.journal file
+   */
+  async displayMigrationStatus(migrationJournalPath) {
+    if (!existsSync(migrationJournalPath)) {
+      logger.info('No migration journal found.');
+      return;
+    }
+
+    const storage = new StateStorage(migrationJournalPath);
+    const journal = await storage.load();
+    if (!journal) {
+      logger.info('Migration journal is empty or corrupt.');
+      return;
+    }
+
+    logger.info('=== Migration Journal Status ===');
+    logger.info(`Status: ${journal.status || 'unknown'}`);
+    logger.info(`Started: ${journal.startedAt || 'unknown'}`);
+    if (journal.completedAt) {
+      logger.info(`Completed: ${journal.completedAt}`);
+    }
+
+    if (journal.organizations) {
+      const orgs = Object.entries(journal.organizations);
+      logger.info('');
+      logger.info(`Organizations: ${orgs.length}`);
+
+      for (const [orgKey, org] of orgs) {
+        const projects = Object.entries(org.projects || {});
+        const completedProjects = projects.filter(([, p]) => p.status === 'completed').length;
+        const failedProjects = projects.filter(([, p]) => p.status === 'failed').length;
+
+        const orgIcon = org.status === 'completed' ? '[done]'
+          : org.status === 'in_progress' ? '[>>  ]'
+            : '[    ]';
+
+        logger.info('');
+        logger.info(`  ${orgIcon} ${orgKey} (org-wide: ${org.orgWideResources || 'pending'})`);
+        logger.info(`       Projects: ${completedProjects}/${projects.length} completed` +
+          (failedProjects > 0 ? `, ${failedProjects} failed` : ''));
+
+        for (const [projKey, proj] of projects) {
+          const projIcon = proj.status === 'completed' ? '[done]'
+            : proj.status === 'in_progress' ? '[>>  ]'
+              : proj.status === 'failed' ? '[FAIL]'
+                : '[    ]';
+          const detail = proj.lastCompletedStep ? ` (last step: ${proj.lastCompletedStep})` : '';
+          const error = proj.error ? ` — ${proj.error}` : '';
+          logger.info(`         ${projIcon} ${projKey}${detail}${error}`);
+        }
+      }
+    }
+  }
+
+  /**
+   * Get overall completion percentage from a checkpoint journal.
+   * @param {object} journal
+   * @returns {number} 0-100
+   */
+  getCompletionPercentage(journal) {
+    if (!journal || !journal.phases) return 0;
+    const phases = Object.values(journal.phases);
+    if (phases.length === 0) return 0;
+    const completed = phases.filter(p => p.status === 'completed').length;
+    return Math.round((completed / phases.length) * 100);
+  }
+
+  /**
+   * Estimate time remaining based on completed phase durations.
+   * @param {object} journal
+   * @returns {string|null}
+   */
+  getEstimatedTimeRemaining(journal) {
+    if (!journal || !journal.phases) return null;
+
+    const phases = Object.values(journal.phases);
+    const completed = phases.filter(p => p.status === 'completed' && p.startedAt && p.completedAt);
+    const remaining = phases.filter(p => p.status !== 'completed');
+
+    if (completed.length === 0 || remaining.length === 0) return null;
+
+    // Average duration of completed phases
+    let totalMs = 0;
+    for (const phase of completed) {
+      totalMs += new Date(phase.completedAt).getTime() - new Date(phase.startedAt).getTime();
+    }
+    const avgMs = totalMs / completed.length;
+    const estimatedMs = avgMs * remaining.length;
+
+    if (estimatedMs < 60_000) {
+      return `~${Math.round(estimatedMs / 1000)}s`;
+    } else if (estimatedMs < 3_600_000) {
+      return `~${Math.round(estimatedMs / 60_000)}m`;
+    } else {
+      const hours = Math.floor(estimatedMs / 3_600_000);
+      const mins = Math.round((estimatedMs % 3_600_000) / 60_000);
+      return `~${hours}h ${mins}m`;
+    }
+  }
+}

--- a/src/utils/shutdown.js
+++ b/src/utils/shutdown.js
@@ -1,0 +1,93 @@
+import logger from './logger.js';
+import { GracefulShutdownError } from './errors.js';
+
+/**
+ * Coordinates graceful shutdown on SIGINT/SIGTERM.
+ *
+ * First signal: sets shuttingDown flag, runs cleanup handlers, exits 0.
+ * Second signal: forces immediate exit.
+ */
+export class ShutdownCoordinator {
+  constructor() {
+    this._shuttingDown = false;
+    this._handlers = [];
+    this._signalCount = 0;
+    this._bound = false;
+  }
+
+  /**
+   * Start listening for signals.
+   */
+  bind() {
+    if (this._bound) return;
+    this._bound = true;
+
+    const onSignal = (signal) => this._onSignal(signal);
+    process.on('SIGINT', onSignal);
+    process.on('SIGTERM', onSignal);
+  }
+
+  /**
+   * Register a cleanup handler (async function).
+   * Handlers run in registration order on graceful shutdown.
+   * @param {Function} handler - async cleanup function
+   */
+  register(handler) {
+    this._handlers.push(handler);
+  }
+
+  /**
+   * Check if shutdown has been requested.
+   * @returns {boolean}
+   */
+  isShuttingDown() {
+    return this._shuttingDown;
+  }
+
+  /**
+   * Returns a callback suitable for passing into pipeline functions.
+   * @returns {Function}
+   */
+  shutdownCheck() {
+    return () => this._shuttingDown;
+  }
+
+  /**
+   * Handle incoming signal.
+   * @param {string} signal
+   */
+  async _onSignal(signal) {
+    this._signalCount++;
+
+    if (this._signalCount === 1) {
+      this._shuttingDown = true;
+      logger.warn(`\n${signal} received. Graceful shutdown requested — finishing current operation...`);
+      logger.warn('Press Ctrl+C again to force quit immediately.');
+
+      // Run cleanup handlers
+      for (const handler of this._handlers) {
+        try {
+          await handler();
+        } catch (error) {
+          logger.debug(`Cleanup handler error: ${error.message}`);
+        }
+      }
+
+      process.exit(0);
+    } else {
+      logger.warn('\nForced shutdown.');
+      process.exit(1);
+    }
+  }
+}
+
+/**
+ * Throws GracefulShutdownError if shutdown has been requested.
+ * Use between phases to bail out cleanly.
+ * @param {Function} shutdownCheck - () => boolean
+ */
+export function checkShutdown(shutdownCheck) {
+  if (shutdownCheck && shutdownCheck()) {
+    throw new GracefulShutdownError();
+  }
+}


### PR DESCRIPTION
## Incremental Migrations with Pause/Resume

### Problem

CloudVoyager's state management was fragile:
- State only saved after ALL branches complete (one failure = no progress saved)
- No checkpoints within extraction phases (a 30min extraction that fails = full restart)
- No graceful shutdown handling (CTRL+C = lost progress)
- No protection against concurrent runs, corrupt state files, or duplicate uploads after crashes

### Solution

A **write-ahead checkpoint journal system** that saves granular progress at every major phase, enabling true pause/resume across all commands (`transfer`, `migrate`, `sync-metadata`).

If a migration is interrupted (CTRL+C, crash, network failure), simply re-run the same command to resume from where it left off. No data is lost or duplicated.

---

### Architecture: 6 New Files + 12 Modified Files

#### New Files

| File | Purpose |
|------|---------|
| `src/state/lock.js` | Advisory lock files with PID + hostname stale detection to prevent concurrent runs |
| `src/utils/shutdown.js` | Graceful SIGINT/SIGTERM handling — first signal saves progress, second force-exits |
| `src/state/checkpoint.js` | Core checkpoint journal tracking per-phase, per-branch progress with session fingerprinting |
| `src/state/extraction-cache.js` | Gzipped JSON disk cache for extraction results, with integrity checks and auto-purge |
| `src/state/migration-journal.js` | Per-org and per-project progress tracking for the `migrate` command |
| `src/utils/progress.js` | Human-readable progress display with completion % and ETA |

#### Modified Files

| File | Changes |
|------|---------|
| `src/state/storage.js` | Atomic save (write-to-temp, fsync, rename), backup rotation, safe load with fallback |
| `src/state/tracker.js` | Lock integration, save after each branch (not just at end), journal coordination |
| `src/sonarqube/extractors/index.js` | Checkpoint-aware extraction — skip completed phases, load from cache |
| `src/sonarcloud/uploader.js` | Upload deduplication via CE activity check (prevents duplicate uploads after crash) |
| `src/transfer-pipeline.js` | Journal + shutdown + version pre-validation orchestration |
| `src/migrate-pipeline.js` | Migration journal integration, conditional output-dir wipe on resume |
| `src/pipeline/project-migration.js` | Per-step checkpoints within each project migration |
| `src/commands/transfer.js` | New CLI flags (`--force-restart`, `--force-fresh-extract`, `--force-unlock`, `--show-progress`) |
| `src/commands/migrate.js` | Same new CLI flags + shutdown coordinator setup |
| `src/index.js` | Enhanced `status` command (shows journal), `reset` clears journals/locks/caches |
| `src/utils/errors.js` | New error classes: `GracefulShutdownError`, `LockError`, `StaleResumeError` |
| `src/config/schema.js` | New `transfer.checkpoint` config block (enabled, cacheExtractions, cacheMaxAgeDays, strictResume) |

---

### How It Works

**Checkpoint Journal** — Before each phase begins, the journal records intent. After completion, it records success. On resume, the journal tells us exactly where we stopped and whether to re-execute or skip.

```json
{
  "version": 2,
  "sessionFingerprint": {
    "sonarQubeVersion": "10.8.0",
    "sonarQubeUrl": "https://sq.example.com",
    "projectKey": "my-project"
  },
  "status": "in_progress",
  "phases": {
    "extract:project_metadata": { "status": "completed" },
    "extract:issues": { "status": "in_progress" },
    "extract:hotspots": { "status": "pending" }
  },
  "branches": {
    "main": { "status": "completed", "ceTaskId": "AY..." },
    "develop": { "status": "in_progress" }
  }
}
```

**Migration Journal** (for `migrate` command) — Tracks per-org and per-project completion:

```json
{
  "organizations": {
    "org-1": {
      "status": "in_progress",
      "orgWideResources": "completed",
      "projects": {
        "project-a": { "status": "completed" },
        "project-b": { "status": "in_progress", "lastCompletedStep": "upload_scanner_report" }
      }
    }
  }
}
```

---

### New CLI Flags

| Flag | Description |
|------|-------------|
| `--force-restart` | Discard journal entirely and start fresh |
| `--force-fresh-extract` | Discard extraction caches, re-extract everything |
| `--force-unlock` | Release a stale lock file from a crashed run |
| `--show-progress` | Display checkpoint status table and exit |

### New Config Options

```json
{
  "transfer": {
    "checkpoint": {
      "enabled": true,
      "cacheExtractions": true,
      "cacheMaxAgeDays": 7,
      "strictResume": false
    }
  }
}
```

---

### Edge Cases Handled

| Edge Case | How It's Handled |
|-----------|-----------------|
| State file corrupted mid-write | Atomic write (tmp+fsync+rename). Fallback to `.backup` file |
| SonarQube version changes between runs | Journal stores version in fingerprint. Warn on mismatch; block if `strictResume: true` |
| SonarCloud project deleted between runs | Pre-check on resume; fail fast with clear error |
| Disk runs out of space during state save | Pre-check via `fs.statfs`; ENOSPC caught without corrupting existing file |
| Two instances run simultaneously | Lock file with PID + hostname; stale auto-released if PID dead or >6h old |
| Process killed during upload | Upload dedup checks CE activity before re-uploading |
| Cache file corrupted | Returns null on parse error; phase re-executes gracefully |
| Lock file from different machine (NFS) | Hostname mismatch detected; requires manual `--force-unlock` |
| SIGINT during atomic state write | Rename is atomic: either old or new file exists, never half-written |

---

### Usage

```bash
# Transfer was interrupted — just re-run to resume
./cloudvoyager transfer -c config.json --verbose

# Check progress without running
./cloudvoyager transfer -c config.json --show-progress

# Force a clean restart
./cloudvoyager transfer -c config.json --verbose --force-restart

# Release a stale lock from a crashed run
./cloudvoyager transfer -c config.json --force-unlock
```

---

### Documentation Updated

- `README.md` — Added Pause and Resume section
- `docs/configuration.md` — Checkpoint config, new CLI flags
- `docs/troubleshooting.md` — Checkpoint and resume troubleshooting
- `docs/key-capabilities.md` — New section on checkpoint journal architecture
- `docs/scenario-single-project.md`, `docs/scenario-single-org.md`, `docs/scenario-multi-org.md` — Resume instructions and new flags
- `docs/local-development.md` — New development flags and examples
- `docs/CHANGELOG.md` — Full release notes
- `docs/dry-run-csv-reference.md` — Updated with checkpoint context
- `package.json` — Version bumped to 1.1.0, new script and keywords

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core `transfer`/`migrate` pipelines and state persistence (journals, caches, atomic writes, shutdown handling), where bugs can cause incorrect resume behavior or duplicate/missed uploads. Also adds new lock/unlock pathways that need careful verification (e.g., `--force-unlock` wiring).
> 
> **Overview**
> Enables **pause/resume** for migrations by introducing a write-ahead **checkpoint journal** for `transfer` (phase + per-branch progress) and a **migration journal** for `migrate` (per-org/project + per-step), plus gzipped on-disk **extraction caching** to skip completed extraction work on resume.
> 
> Adds **graceful SIGINT/SIGTERM handling** (first interrupt saves state and exits cleanly; second forces exit), **advisory lock files** to prevent concurrent runs, **upload deduplication** by checking recent SonarCloud CE activity before re-uploading, and makes state/journal persistence safer via **atomic writes + backup fallback**.
> 
> Extends CLI/config: new `transfer.checkpoint` schema block, new flags (`--force-restart`, `--force-fresh-extract`, `--force-unlock`, `--show-progress`), `status` now shows journal progress when present, `reset` also deletes journals/locks/caches, bumps package version to `1.1.0`, and updates docs extensively to describe the new workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e8bcf731332007dbe85f266ddc4c4c59f68f664. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->