### PR TITLE
All 7 files updated. Here's a summary of what was changed:

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ CloudVoyager copies everything — projects, code issues, security hotspots, qua
 <!-- Updated: 2026-03-10 -->
 ## 🔄 Pause and Resume
 
-All migrations support **automatic checkpointing**. If a migration is interrupted (CTRL+C, crash, network failure), simply re-run the same command to resume from where it left off. No data is lost or duplicated.
+All migrations support **automatic checkpointing**. Progress is saved after every phase (extract, build, encode, upload). If a migration is interrupted — whether by CTRL+C (graceful shutdown), a crash, or a network failure — simply re-run the same command to resume from where it left off. No data is lost or duplicated.
+
+A **lock file** prevents concurrent runs against the same project, so you cannot accidentally start two migrations at once.
 
 ```bash
 # Transfer was interrupted — just re-run to resume
@@ -44,9 +46,18 @@ All migrations support **automatic checkpointing**. If a migration is interrupte
 
 # Check progress without running
 ./cloudvoyager transfer -c config.json --show-progress
+
+# Discard checkpoint and start the migration from scratch
+./cloudvoyager transfer -c config.json --force-restart
+
+# Re-extract data from SonarQube but keep other cached phases
+./cloudvoyager transfer -c config.json --force-fresh-extract
+
+# Clear a stale lock file (e.g. after a hard crash)
+./cloudvoyager transfer -c config.json --force-unlock
 ```
 
-See the [Configuration Reference](docs/configuration.md#checkpoint-settings) for checkpoint options.
+See the [Configuration Reference](docs/configuration.md#checkpoint-settings) for checkpoint options (`transfer.checkpoint`).
 
 <!-- Updated: 2026-03-09 -->
 ## 🔄 SonarQube Version Compatibility

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,13 +128,19 @@ src/
 │       ├── format-markdown.js # Markdown verification report
 │       └── format-pdf.js     # PDF verification report
 ├── state/
-│   ├── storage.js            # File-based state persistence
-│   └── tracker.js            # Incremental transfer state tracking
+│   ├── storage.js            # File-based state persistence (atomic write, backup rotation)
+│   ├── tracker.js            # Incremental transfer state tracking (with lock integration)
+│   ├── lock.js               # Advisory lock files for concurrent run prevention
+│   ├── checkpoint.js          # Phase-level checkpoint journal for pause/resume
+│   ├── extraction-cache.js    # Disk-cached extraction results (gzipped JSON)
+│   └── migration-journal.js   # Multi-project migration progress tracking
 └── utils/
     ├── logger.js             # Winston-based logging
-    ├── errors.js             # Custom error classes
+    ├── errors.js             # Custom error classes (including LockError, StaleResumeError, GracefulShutdownError)
     ├── concurrency.js        # Concurrency primitives (limiter, mapConcurrent, progress)
-    └── system-info.js        # System info detection (CPU, memory) and auto-tune
+    ├── system-info.js        # System info detection (CPU, memory) and auto-tune
+    ├── shutdown.js           # Graceful SIGINT/SIGTERM shutdown coordinator
+    └── progress.js           # Checkpoint progress display and ETA
 ```
 
 <!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
@@ -147,12 +153,17 @@ Uses `transfer-pipeline.js`:
 
 1. **Load config** — validate and apply env var overrides
 2. **Initialize state** — load previous state for incremental transfers
-3. **Test connections** — verify SonarQube and SonarCloud connectivity
-4. **Extract data** — extract project data from SonarQube (issues, sources, measures, etc.)
-5. **Build messages** — transform extracted data into protobuf message structures
-6. **Encode** — encode messages to binary protobuf format
-7. **Upload** — submit encoded report to SonarCloud CE endpoint
-8. **Update state** — record successful transfer in state file
+3. **Acquire lock file** — prevent concurrent runs on the same project
+4. **Initialize checkpoint journal** — load or create checkpoint for pause/resume
+5. **Test connections** — verify SonarQube and SonarCloud connectivity
+6. **Extract data** — extract project data from SonarQube (issues, sources, measures, etc.)
+7. **Build messages** — transform extracted data into protobuf message structures
+8. **Encode** — encode messages to binary protobuf format
+9. **Upload** — submit encoded report to SonarCloud CE endpoint
+10. **Release lock** — release the advisory lock file
+11. **Update state** — record successful transfer in state file
+
+Interrupted transfers resume from the last completed checkpoint phase, skipping already-finished steps.
 
 <!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
 ### `migrate` — Full Multi-Org Migration
@@ -162,7 +173,8 @@ Uses `migrate-pipeline.js`:
 1. **Extract server-wide data** — projects, quality gates, quality profiles, groups, permissions, templates, portfolios, DevOps bindings, server info, webhooks
 2. **Generate organization mappings** — map projects to target orgs by DevOps binding, generate CSV files for review
 3. **Save server info** — write system, plugins, settings, webhooks, ALM settings as JSON reference files
-4. **For each target organization:**
+4. **Initialize migration journal** — load or create journal tracking per-org and per-project progress
+5. **For each target organization:**
    - Create groups
    - Set global permissions
    - Create quality gates
@@ -180,6 +192,8 @@ Uses `migrate-pipeline.js`:
      - Assign migrated built-in quality profiles
      - Set project-level permissions
    - Create portfolios and assign projects
+
+On resume, completed organizations and projects are skipped based on the migration journal.
 
 <!-- Updated: Mar 4, 2026 at 12:00:00 PM -->
 ### `verify` — Migration Verification
@@ -215,6 +229,8 @@ Uses `verify-pipeline.js`:
 - **Client-Service Pattern** — API clients handle HTTP, services handle business logic
 - **Builder Pattern** — ProtobufBuilder constructs complex message structures
 - **State Pattern** — StateTracker manages transfer state for incremental sync
+- **Checkpoint Pattern** — write-ahead journal tracks phase completion for crash recovery
+- **Lock Pattern** — advisory lock files prevent concurrent runs with stale detection
 - **Error Hierarchy** — custom error classes provide specific error handling
 - **Concurrency Pattern** — `mapConcurrent` replaces sequential loops with bounded parallel execution
 

--- a/docs/backward-compatibility.md
+++ b/docs/backward-compatibility.md
@@ -43,6 +43,8 @@ SonarQube server version: 2025.1.0.12345 (modern 10.4+ issue statuses)
 
 The version is detected once and cached for the lifetime of the client — no redundant API calls.
 
+The detected version is also stored in the checkpoint journal's session fingerprint. On resume, the journal validates that the SonarQube version hasn't changed — a mismatch triggers a warning (or blocks the resume if `transfer.checkpoint.strictResume` is enabled).
+
 ### Version-Aware Issue Fetching
 
 The issue search API changed in SonarQube 10.4:
@@ -127,6 +129,7 @@ These components work the same regardless of SonarQube version:
 - Issue metadata sync (statuses, comments, transitions)
 - Multi-branch support
 - Pagination (handles both `paging.total` and legacy `total` response formats)
+- Checkpoint journal and pause/resume (version-independent state tracking)
 
 ## Usage
 

--- a/docs/dry-run-csv-reference.md
+++ b/docs/dry-run-csv-reference.md
@@ -21,6 +21,9 @@ The `--dry-run` flag generates 9 exhaustive CSV files in `migration-output/mappi
    -> Detects existing CSVs, reads them into memory BEFORE wiping output dir
    -> Re-extracts from SonarQube, applies CSV overrides
    -> Migrates using filtered data
+
+4. If interrupted, re-run the same command to resume from the last checkpoint.
+   Completed projects and phases are skipped automatically.
 ```
 
 ## Include Column
@@ -230,6 +233,7 @@ In `portfolio-mappings.csv`, set `Include` to `no` on the specific member row (n
 - Running `--dry-run` again will regenerate fresh CSVs, overwriting any edits.
 - If CSV references entities that no longer exist in SonarQube (e.g., a project was deleted between dry-run and full run), a warning is logged and the reference is skipped.
 - Gate names, project keys, and group names are matched **case-sensitively**.
+- If a migration is interrupted mid-run, re-running the same command resumes from the last checkpoint. Already-migrated projects and resources are skipped.
 
 ## 📚 Further Reading
 

--- a/docs/pseudocode-explanation.md
+++ b/docs/pseudocode-explanation.md
@@ -24,6 +24,7 @@ This document describes each feature of the CloudVoyager migration tool in pseud
 16. [State Management](#16-state-management)
 17. [Configuration & Validation](#17-configuration--validation)
 18. [Performance Tuning](#18-performance-tuning)
+19. [Checkpoint Journal and Pause/Resume](#19-checkpoint-journal--pauseresume)
 
 ---
 
@@ -97,6 +98,14 @@ FUNCTION transferProject(sonarqubeConfig, sonarcloudConfig, transferConfig, perf
   sqClient = new VersionAwareSonarQubeClient(sonarqubeConfig)
   scClient = new SonarCloudClient(sonarcloudConfig)
 
+  // --- Checkpoint Setup ---
+  lock = new LockFile(transferConfig.stateFile)
+  lock.acquire()                    // prevents concurrent runs
+  journal = new CheckpointJournal(stateFile + '.journal')
+  journal.initialize({ sonarQubeVersion, sonarQubeUrl, projectKey })
+  cache = new ExtractionCache(outputDir)
+  shutdownCoordinator.register(() => { journal.markInterrupted(); lock.release() })
+
   // --- Connection Test ---
   sqClient.testConnection()
   scClient.testConnection()
@@ -119,8 +128,9 @@ FUNCTION transferProject(sonarqubeConfig, sonarcloudConfig, transferConfig, perf
     ruleEnrichmentMap = buildRuleEnrichmentMap(scClient, scProfiles)
     // Fetches Clean Code attributes from SC to enrich old SQ data
 
-  // --- Extract & Transfer Main Branch ---
-  extractedData = DataExtractor.extractAll()
+  // --- Extract & Transfer Main Branch (checkpoint-aware) ---
+  extractedData = DataExtractor.extractAllWithCheckpoints(journal, cache, shutdownCheck)
+  // Each phase: check journal (skip if completed, load from cache) → execute → cache → mark complete
   mainResult = transferBranch(extractedData, mainBranch, ...)
 
   IF wait:
@@ -1076,14 +1086,22 @@ CLASS StateTracker:
       ]
     }
 
-  FUNCTION initialize():
+  FUNCTION initialize(lockFile):
     state = storage.load() OR defaultState
+    IF lockFile:
+      lock = lockFile
+      lock.acquire()    // ensures single-instance access
 
   FUNCTION recordTransfer(stats):
     state.lastSync = now()
     state.syncHistory.PUSH({ timestamp: now(), success: true, stats })
     IF syncHistory.length > 10: TRIM to last 10
     storage.save(state)
+
+  FUNCTION saveAfterBranch(branchName, stats):
+    state.completedBranches.ADD(branchName)
+    state.lastSync = now()
+    storage.save(state)    // persist immediately after each branch
 
   FUNCTION reset():
     state = defaultState
@@ -1208,4 +1226,132 @@ PERFORMANCE FEATURES:
   // Upload retry
   - CE submit has 2 attempts with timeout fallback
   - On timeout: checks /api/ce/activity for the submitted task
+```
+
+---
+
+## 19. Checkpoint Journal and Pause/Resume
+
+```
+CHECKPOINT JOURNAL:
+
+CLASS CheckpointJournal:
+  JOURNAL SHAPE:
+    {
+      version: 2,
+      sessionFingerprint: { sonarQubeVersion, sonarQubeUrl, projectKey, startedAt },
+      status: "in_progress" | "completed" | "interrupted",
+      phases: {
+        "extract:project_metadata": { status: "completed", completedAt },
+        "extract:issues":           { status: "in_progress", startedAt },
+        "extract:hotspots":         { status: "pending" },
+        ...
+      },
+      branches: {
+        "main":    { status: "completed", ceTaskId: "AY..." },
+        "develop": { status: "in_progress" },
+      },
+      uploadedCeTasks: {
+        "main": { taskId, submittedAt, status: "SUCCESS" }
+      }
+    }
+
+  FUNCTION initialize(fingerprint):
+    IF journal file exists:
+      LOAD existing journal
+      validateFingerprint(fingerprint)    // warn/block on SQ version mismatch
+    ELSE:
+      CREATE new journal with fingerprint
+
+  FUNCTION isPhaseCompleted(phaseName):
+    RETURN phases[phaseName].status == "completed"
+
+  FUNCTION startPhase(phaseName):
+    phases[phaseName] = { status: "in_progress", startedAt: now() }
+    atomicSave()
+
+  FUNCTION completePhase(phaseName):
+    phases[phaseName] = { status: "completed", completedAt: now() }
+    atomicSave()
+
+  FUNCTION recordUpload(branch, ceTaskId):
+    uploadedCeTasks[branch] = { taskId: ceTaskId, submittedAt: now() }
+    atomicSave()
+
+  FUNCTION markInterrupted():
+    status = "interrupted"
+    atomicSave()
+
+
+CLASS LockFile:
+  FUNCTION acquire():
+    IF lock file exists:
+      lockData = READ lock file
+      IF lockData.pid is alive AND lockData.hostname == currentHostname:
+        THROW LockError("Another instance is running")
+      IF lockData.hostname != currentHostname:
+        THROW LockError("Lock held by different machine, use --force-unlock")
+      IF lockData is stale (PID dead or >6h old):
+        LOG warning, overwrite lock
+    WRITE { pid, startedAt, hostname } to lock file
+
+  FUNCTION release():
+    DELETE lock file
+
+  FUNCTION forceRelease():
+    DELETE lock file (unconditionally)
+
+
+CLASS ShutdownCoordinator:
+  FUNCTION register(handler):
+    cleanupHandlers.PUSH(handler)
+
+  ON SIGINT (first time):
+    shuttingDown = true
+    RUN all cleanup handlers (save journal, release lock)
+    process.exit(0)
+
+  ON SIGINT (second time):
+    process.exit(1)    // force exit
+
+  FUNCTION isShuttingDown():
+    RETURN shuttingDown
+
+
+CLASS ExtractionCache:
+  FUNCTION save(phaseName, branch, data):
+    path = outputDir/cache/extractions/projectKey/branch/phaseName.json.gz
+    GZIP(JSON.stringify(data))
+    WRITE to path with integrity metadata
+
+  FUNCTION load(phaseName, branch):
+    TRY:
+      READ and decompress from path
+      VERIFY integrity
+      RETURN parsed data
+    CATCH:
+      RETURN null    // corrupt cache = re-extract
+
+
+CLASS MigrationJournal:
+  JOURNAL SHAPE:
+    {
+      version: 1,
+      status: "in_progress",
+      organizations: {
+        "org-1": {
+          status: "in_progress",
+          orgWideResources: "completed",
+          projects: {
+            "project-a": { status: "completed" },
+            "project-b": { status: "in_progress", lastCompletedStep: "upload_scanner_report" },
+          }
+        }
+      }
+    }
+
+  FUNCTION isOrgCompleted(orgKey):     RETURN orgs[orgKey].status == "completed"
+  FUNCTION isProjectCompleted(orgKey, projectKey): RETURN projects[key].status == "completed"
+  FUNCTION completeProject(orgKey, projectKey):    SET status, atomicSave()
+  FUNCTION completeStep(orgKey, projectKey, step): SET lastCompletedStep, atomicSave()
 ```

--- a/docs/technical-details.md
+++ b/docs/technical-details.md
@@ -154,6 +154,41 @@ Performance config is resolved at startup by `resolvePerformanceConfig()`, which
 
 When `maxMemoryMB` is set (via config or `--max-memory` flag), the tool automatically re-spawns itself with `NODE_OPTIONS="--max-old-space-size=<value>"` if the current heap limit is insufficient. This is transparent to the user — output streams seamlessly through the respawned process.
 
+<!-- Updated: Mar 10, 2026 -->
+## 🔄 Checkpoint Journal and Pause/Resume
+
+CloudVoyager uses a write-ahead checkpoint journal to track progress at every major phase. If a transfer or migration is interrupted (CTRL+C, crash, network failure), re-running the same command resumes from the last completed checkpoint.
+
+### Journal Structure
+
+Each transfer creates a checkpoint journal file alongside the state file:
+
+- **Phase tracking**: Each extraction phase (project metadata, metrics, components, rules, issues, hotspots, measures, sources, etc.) is tracked individually
+- **Branch tracking**: Per-branch completion status with CE task IDs for upload deduplication
+- **Session fingerprint**: SonarQube version, URL, and project key are recorded to detect environment changes between runs
+
+### Atomic State Persistence
+
+State files use a write-to-temp-then-rename pattern for crash safety:
+1. Write to `<file>.tmp`
+2. `fsync` to ensure data hits disk
+3. Rename to final path (atomic on POSIX)
+4. Backup rotation: previous state copied to `<file>.backup` before each save
+
+If the main state file is corrupted, the system falls back to the `.backup` file automatically.
+
+### Extraction Caching
+
+Completed extraction phases are cached as gzipped JSON in `<outputDir>/cache/extractions/<projectKey>/`. On resume, cached phases are loaded from disk instead of re-fetching from SonarQube. Cache files include integrity metadata and auto-purge after 7 days (configurable via `transfer.checkpoint.cacheMaxAgeDays`).
+
+### Upload Deduplication
+
+Before re-uploading after a crash, the uploader queries `/api/ce/activity` for recent tasks on the project. If a task was submitted after the session start and is still SUCCESS/IN_PROGRESS/PENDING, the upload is skipped to prevent duplicate CE tasks.
+
+### Lock Files
+
+Advisory lock files (`<stateFile>.lock`) prevent concurrent runs. Lock metadata includes PID, hostname, and timestamp. Stale locks (dead PID or >6 hours old) are auto-released. Cross-machine locks (NFS) require manual `--force-unlock`.
+
 ## 📚 Further Reading
 
 - [Configuration Reference](configuration.md) — all config options, environment variables, npm scripts

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -17,6 +17,8 @@ cloudvoyager verify -c migrate-config.json --only issue-metadata
 cloudvoyager verify -c migrate-config.json --only quality-gates
 ```
 
+> **Tip:** Verification is read-only and does not modify any data. If a verification run is interrupted, simply re-run it — there is no checkpoint state to manage for verification.
+
 ## Output
 
 Verification produces three report files in `./verification-output/`:


### PR DESCRIPTION
File	Changes
README.md	Enhanced Pause and Resume section with phase-level checkpointing, CTRL+C handling, lock files, new CLI flags (--force-restart, --force-fresh-extract, --force-unlock) docs/architecture.md	Added 6 new files to project structure tree (lock.js, checkpoint.js, extraction-cache.js, migration-journal.js, shutdown.js, progress.js), checkpoint steps in transfer/migrate pipelines, 2 new design patterns docs/technical-details.md	New "Checkpoint Journal and Pause/Resume" section covering journal structure, atomic state persistence, extraction caching, upload deduplication, lock files docs/backward-compatibility.md	Added checkpoint journal to version-independent features list, version fingerprint validation note in auto-detection section docs/pseudocode-explanation.md	Added checkpoint setup to transfer pipeline, enhanced StateTracker with lock integration, new section 19 with full pseudocode for CheckpointJournal, LockFile, ShutdownCoordinator, ExtractionCache, MigrationJournal docs/verification.md	Added tip that verification is read-only with no checkpoint state docs/dry-run-csv-reference.md	Added resume step to workflow, checkpoint resume note

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are documentation-only; main risk is user confusion if the documented flags/resume semantics diverge from actual CLI behavior.
> 
> **Overview**
> **Documentation refresh for pause/resume and journaling.** Clarifies that migrations checkpoint after each major phase, resume automatically after interruptions, and use advisory lock files to prevent concurrent runs.
> 
> Documents new/related CLI controls like `--show-progress`, `--force-restart`, `--force-fresh-extract`, and `--force-unlock`, and expands architecture/technical docs with checkpoint journal structure (including SonarQube version fingerprint validation), extraction caching, upload deduplication, and multi-org migration journal resume semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71ca7ea84905183b3eaeba099a38572d73bc7eba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->