### PR TITLE
fix build version for github yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: 20
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: 20
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: 20
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: 20
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: 20
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: 20
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
fix build version for github yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just alters the Node.js runtime used during CI builds; main risk is unexpected build differences if the project relied on Node 21 behavior.
> 
> **Overview**
> **CI build environment change:** Updates `.github/workflows/build.yml` to run all Node.js SEA binary build jobs (Linux/macOS/Windows, x64/arm64) on **Node.js 20** instead of 21.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5eda2b78c31847641cd16d5e2883cc15c272e5e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->