### PR TITLE
The release artifacts will now be named with clear platform identifiers:

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -15,17 +15,20 @@ linux:
     - target: AppImage
   category: Utility
   icon: assets/icon.png
+  artifactName: CloudVoyager.Desktop-${version}-linux-${arch}.${ext}
 
 mac:
   target:
     - target: dmg
   identity: null
   icon: assets/icon.icns
+  artifactName: CloudVoyager.Desktop-${version}-macos-${arch}.${ext}
 
 win:
   target:
     - target: nsis
   icon: assets/icon.ico
+  artifactName: CloudVoyager.Desktop-${version}-win-${arch}.${ext}
 
 nsis:
   oneClick: false


### PR DESCRIPTION
Before	After
CloudVoyager.Desktop-1.1.1-arm64.AppImage	CloudVoyager.Desktop-1.1.1-linux-arm64.AppImage CloudVoyager.Desktop-1.1.1.AppImage	CloudVoyager.Desktop-1.1.1-linux-x64.AppImage CloudVoyager.Desktop-1.1.1-arm64.dmg	CloudVoyager.Desktop-1.1.1-macos-arm64.dmg CloudVoyager.Desktop.Setup.1.1.1.exe	CloudVoyager.Desktop-1.1.1-win-x64.exe The pattern is CloudVoyager.Desktop-{version}-{platform}-{arch}.{ext} for all platforms, making it immediately clear which OS each artifact is for.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects only release artifact filenames and could impact downstream scripts expecting the old names.
> 
> **Overview**
> Updates `desktop/electron-builder.yml` to set `artifactName` for Linux, macOS, and Windows builds to `CloudVoyager.Desktop-${version}-{platform}-${arch}.${ext}`, making release artifacts unambiguous by OS/arch (and changing the published filenames accordingly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2cc6d3c5192599dde15a5c0ffdb3f85da535281. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->