### PR TITLE
The issue: macos-15 (and macos-14, macos-latest) are all Apple Silico…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
           path: dist/bin/cloudvoyager-macos-arm64
 
   build-sea-macos-x64:
-    runs-on: macos-15
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
…n (ARM64) runners. So the build was producing an ARM64 binary even though the job was meant for x64. The upload step then couldn't find dist/bin/cloudvoyager-macos-x64 because the binary was named cloudvoyager-macos-arm64.

Changed runs-on: macos-15 to runs-on: macos-13 on build.yml:76 — macos-13 is the last GitHub-hosted Intel (x64) macOS runner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just switches the `runs-on` image to ensure the macOS x64 job actually builds an Intel binary; main risk is potential compatibility differences on the older macOS-13 runner.
> 
> **Overview**
> Fixes the macOS x64 GitHub Actions build to run on an Intel runner by changing `build-sea-macos-x64` from `macos-15` to `macos-13`, ensuring the produced SEA artifact matches the expected `cloudvoyager-macos-x64` output path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de71976b2e4055dee7649aed6d6860fd72308d88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->