### PR TITLE
Here's a summary of what was added:

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -76,6 +76,30 @@ jobs:
           name: cloudvoyager-desktop-macos-arm64
           path: dist/desktop/*.dmg
 
+  build-desktop-macos-x64:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Download CLI binary
+        uses: actions/download-artifact@v4
+        with:
+          name: cloudvoyager-macos-x64
+          path: desktop/resources/cli/
+      - name: Make binary executable
+        run: chmod +x desktop/resources/cli/cloudvoyager-macos-x64
+      - name: Install desktop dependencies
+        run: cd desktop && npm ci
+      - name: Build desktop app (macos-x64)
+        run: cd desktop && npm run build:mac-x64
+      - name: Upload desktop artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cloudvoyager-desktop-macos-x64
+          path: dist/desktop/*.dmg
+
   build-desktop-win-x64:
     runs-on: windows-latest
     steps:

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,6 +9,7 @@
     "build:linux-x64": "electron-builder --linux --x64",
     "build:linux-arm64": "electron-builder --linux --arm64",
     "build:mac-arm64": "electron-builder --mac --arm64",
+    "build:mac-x64": "electron-builder --mac --x64",
     "build:win-x64": "electron-builder --win --x64",
     "build:win-arm64": "electron-builder --win --arm64"
   },


### PR DESCRIPTION
desktop/package.json:12 — Added build:mac-x64 script build-desktop.yml:79-99 — Added build-desktop-macos-x64 job using macos-13 (Intel runner), downloading the cloudvoyager-macos-x64 CLI binary and building the desktop .dmg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds an additional macOS Intel build; primary risk is increased pipeline time or artifact/job misconfiguration.
> 
> **Overview**
> Adds macOS **x64** (Intel) support to the desktop build pipeline.
> 
> The workflow now runs a new `build-desktop-macos-x64` job on `macos-13`, downloads the `cloudvoyager-macos-x64` CLI artifact, builds a `.dmg`, and uploads it. The desktop `package.json` adds a matching `build:mac-x64` script for `electron-builder`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73dd7bbf0b836b5c08647e26a5757e9a9a07aa9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->