### PR TITLE
Problem: macos-13 (Intel x64) runner isn't available on your GitHub p…

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -77,7 +77,7 @@ jobs:
           path: dist/desktop/*.dmg
 
   build-desktop-macos-x64:
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
           path: dist/bin/cloudvoyager-macos-arm64
 
   build-sea-macos-x64:
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -85,8 +85,8 @@ jobs:
           path: node_modules
           key: node-modules-macos-x64-${{ hashFiles('package-lock.json') }}
       - run: npm ci
-      - name: Build macos-x64 binary via Node.js SEA
-        run: npm run package
+      - name: Build macos-x64 binary via Node.js SEA (cross-compile)
+        run: node scripts/build.js --package --target=macos-x64
       - name: Upload macos-x64
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -14,6 +14,8 @@ const args = process.argv.slice(2);
 const shouldPackage = args.includes('--package');
 const useBun = args.includes('--bun');
 const crossCompile = args.includes('--cross');
+const targetArg = args.find(a => a.startsWith('--target='));
+const targetPlatform = targetArg ? targetArg.split('=')[1] : null;
 
 // Node.js SEA packaging requires v20. v22+ embeds the sentinel twice, causing postject to fail.
 if (shouldPackage && !useBun) {
@@ -87,11 +89,37 @@ async function esbuildBundle(entryPoint, distDir) {
 }
 
 /**
- * Build a Node.js SEA binary for the current platform.
- * Requires: dist/cli.cjs to already exist.
+ * Download a Node.js binary for a different architecture (cross-compile SEA).
+ * Returns the path to the downloaded node executable.
  */
-function seaPackage(distDir, binDir) {
-  const platformId = detectPlatform();
+function downloadNodeBinary(targetPlatformId, distDir) {
+  const nodeVersion = process.versions.node;
+  const nodeArchMap = { 'macos-x64': 'darwin-x64', 'macos-arm64': 'darwin-arm64', 'linux-x64': 'linux-x64', 'linux-arm64': 'linux-arm64' };
+  const nodeTarget = nodeArchMap[targetPlatformId];
+  if (!nodeTarget) {
+    console.error(`Cross-compile SEA not supported for target: ${targetPlatformId}`);
+    process.exit(1);
+  }
+
+  const tarball = `node-v${nodeVersion}-${nodeTarget}.tar.gz`;
+  const url = `https://nodejs.org/dist/v${nodeVersion}/${tarball}`;
+  const downloadDir = join(distDir, 'node-cross');
+  mkdirSync(downloadDir, { recursive: true });
+
+  console.log(`Downloading Node.js v${nodeVersion} for ${nodeTarget}...`);
+  execSync(`curl -fsSL "${url}" | tar xz -C "${downloadDir}" --strip-components=1`, { stdio: 'inherit' });
+
+  return join(downloadDir, 'bin', 'node');
+}
+
+/**
+ * Build a Node.js SEA binary for the current (or target) platform.
+ * Requires: dist/cli.cjs to already exist.
+ * Pass overridePlatform (e.g. "macos-x64") to cross-compile.
+ */
+function seaPackage(distDir, binDir, overridePlatform) {
+  const platformId = overridePlatform || detectPlatform();
+  const isCross = overridePlatform && overridePlatform !== detectPlatform();
   mkdirSync(binDir, { recursive: true });
 
   const seaConfig = {
@@ -110,18 +138,27 @@ function seaPackage(distDir, binDir) {
     stdio: 'inherit',
   });
 
-  const ext = process.platform === 'win32' ? '.exe' : '';
+  const targetIsWin = platformId.startsWith('win');
+  const targetIsMac = platformId.startsWith('macos');
+  const ext = targetIsWin ? '.exe' : '';
   const binaryPath = join(binDir, `${BINARY_NAME}-${platformId}${ext}`);
-  console.log(`Copying node binary to ${BINARY_NAME}-${platformId}${ext}...`);
-  copyFileSync(process.execPath, binaryPath);
 
-  if (process.platform === 'darwin') {
+  if (isCross) {
+    const nodeBin = downloadNodeBinary(platformId, distDir);
+    console.log(`Copying cross-platform node binary to ${BINARY_NAME}-${platformId}${ext}...`);
+    copyFileSync(nodeBin, binaryPath);
+  } else {
+    console.log(`Copying node binary to ${BINARY_NAME}-${platformId}${ext}...`);
+    copyFileSync(process.execPath, binaryPath);
+  }
+
+  if (targetIsMac || process.platform === 'darwin') {
     console.log('Removing macOS code signature...');
     execSync(`codesign --remove-signature "${binaryPath}"`, { stdio: 'inherit' });
   }
 
   console.log('Injecting SEA blob...');
-  const sentinelFlag = process.platform === 'darwin'
+  const sentinelFlag = targetIsMac
     ? '--sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 --macho-segment-name NODE_SEA'
     : '--sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2';
   execSync(
@@ -129,7 +166,7 @@ function seaPackage(distDir, binDir) {
     { cwd: rootDir, stdio: 'inherit' }
   );
 
-  if (process.platform === 'darwin') {
+  if (targetIsMac || process.platform === 'darwin') {
     console.log('Re-signing macOS binary...');
     execSync(`codesign --sign - "${binaryPath}"`, { stdio: 'inherit' });
   }
@@ -193,7 +230,7 @@ async function build() {
     await esbuildBundle(entryPoint, distDir);
     console.log('Bundle created: dist/cli.cjs');
 
-    const name = seaPackage(distDir, binDir);
+    const name = seaPackage(distDir, binDir, targetPlatform);
     console.log(`Binary created: dist/bin/${name}`);
     return;
   }


### PR DESCRIPTION
…lan, and macos-15/macos-latest are ARM64 (Apple Silicon).

Solution: Cross-compile the macOS x64 binary from an ARM64 runner by downloading the x64 Node.js binary from nodejs.org and using it as the SEA host.

Changes made:

scripts/build.js — Added --target=<platform> flag support. When specified (e.g. --target=macos-x64), it downloads the correct Node.js binary for that architecture and injects the SEA blob into it instead of using the host's process.execPath.

.github/workflows/build.yml:76 — Changed build-sea-macos-x64 to run on macos-latest with node scripts/build.js --package --target=macos-x64.

.github/workflows/build-desktop.yml:80 — Changed build-desktop-macos-x64 to run on macos-latest (electron-builder handles x64 targeting via the --x64 flag).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the release build pipeline and introduces downloading/executing a platform-specific Node tarball during packaging, which could affect artifact correctness and CI reliability.
> 
> **Overview**
> Switches macOS x64 CI jobs from `macos-13` to `macos-latest` and updates the macOS x64 CLI build to **cross-compile** instead of relying on an Intel runner.
> 
> Adds `--target=<platform>` support to `scripts/build.js` so SEA packaging can inject the blob into a downloaded Node.js binary for the requested target (e.g. `--target=macos-x64`), including using target-aware macOS signing/postject flags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1c8d792139d067861d1d41188f97568ce02c77b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->