### PR TITLE
fix graph

### DIFF
--- a/desktop/src/renderer/js/components/migration-graph.js
+++ b/desktop/src/renderer/js/components/migration-graph.js
@@ -1114,18 +1114,26 @@ window.MigrationGraph = {
       return;
     }
 
-    // Portfolios
+    // Portfolios — finalize all per-project sub-nodes before moving on
     m = line.match(/Creating (\d+) portfolios/);
     if (m) {
       this._setNodeCount('portfolios', m[1]);
       this.setNodeState('projects', 'done');
+      this.setNodeState('scannerUpload', 'done');
+      this.setNodeState('issueSync', 'done');
+      this.setNodeState('hotspotSync', 'done');
       this.setNodeState('projectConfig', 'done');
       this.setNodeState('portfolios', 'active');
       return;
     }
 
-    // Complete
+    // Complete — finalize all nodes (sub-nodes may still be amber/red from last project reset)
     if (/Migration complete|=== Migration completed/.test(line)) {
+      this.setNodeState('projects', 'done');
+      this.setNodeState('scannerUpload', 'done');
+      this.setNodeState('issueSync', 'done');
+      this.setNodeState('hotspotSync', 'done');
+      this.setNodeState('projectConfig', 'done');
       this.setNodeState('portfolios', 'done');
       return;
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-state change limited to log parsing for the migration progress graph; main risk is incorrect node state transitions if log patterns differ.
> 
> **Overview**
> Ensures the migration progress graph doesn’t leave per-project sub-nodes in an unfinished state when the run moves on to portfolios or finishes.
> 
> When `Creating <n> portfolios` or final `Migration complete` logs are seen, the parser now explicitly marks `projects`, `scannerUpload`, `issueSync`, `hotspotSync`, and `projectConfig` as `done` before advancing/finishing `portfolios`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bcddb8eeffae18fb9f406bc5dd06159759a9e1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->