### PR TITLE
Migration graph: pending nodes use muted gray instead of bright red, …

### DIFF
--- a/desktop/src/renderer/js/components/migration-graph.js
+++ b/desktop/src/renderer/js/components/migration-graph.js
@@ -82,6 +82,34 @@ window.MigrationGraph = {
         ['projects', 'issueSync'], ['issueSync', 'hotspotSync'],
       ],
     },
+    verify: {
+      nodes: [
+        { id: 'vConnect',        label: 'Connect',          col: 0, row: 0, yPct: 0.50 },
+        { id: 'vFetchProjects',  label: 'Fetch Projects',   col: 1, row: 0, yPct: 0.30 },
+        { id: 'vBuildMappings',  label: 'Build Mappings',   col: 1, row: 1, yPct: 0.70 },
+        { id: 'vQualityGates',   label: 'Quality Gates',    col: 2, row: 0, yPct: 0.15 },
+        { id: 'vQualityProfiles',label: 'Quality Profiles', col: 2, row: 1, yPct: 0.38 },
+        { id: 'vGroups',         label: 'Groups',           col: 2, row: 2, yPct: 0.62 },
+        { id: 'vPermissions',    label: 'Permissions',      col: 2, row: 3, yPct: 0.85 },
+        { id: 'vProjects',       label: 'Projects',         col: 3, row: 0, yPct: 0.12 },
+        { id: 'vBranches',       label: 'Branches',         col: 3, row: 1, yPct: 0.32 },
+        { id: 'vIssues',         label: 'Issues',           col: 3, row: 2, yPct: 0.52 },
+        { id: 'vHotspots',       label: 'Hotspots',         col: 3, row: 3, yPct: 0.72 },
+        { id: 'vMeasures',       label: 'Measures',         col: 3, row: 4, yPct: 0.92 },
+        { id: 'vPortfolios',     label: 'Portfolios',       col: 4, row: 0, yPct: 0.50 },
+      ],
+      edges: [
+        ['vConnect', 'vFetchProjects'], ['vConnect', 'vBuildMappings'],
+        ['vFetchProjects', 'vQualityGates'], ['vFetchProjects', 'vQualityProfiles'],
+        ['vBuildMappings', 'vGroups'], ['vBuildMappings', 'vPermissions'],
+        ['vQualityGates', 'vProjects'], ['vQualityProfiles', 'vProjects'],
+        ['vGroups', 'vProjects'], ['vPermissions', 'vProjects'],
+        ['vProjects', 'vBranches'], ['vBranches', 'vIssues'],
+        ['vIssues', 'vHotspots'], ['vHotspots', 'vMeasures'],
+        ['vProjects', 'vPortfolios'],
+      ],
+      colPositions: [0.05, 0.22, 0.42, 0.65, 0.92],
+    },
   },
 
   // ── Font ────────────────────────────────────────────────────────
@@ -327,6 +355,171 @@ window.MigrationGraph = {
         ctx.fillRect(cx + s * 0.25, cy - s * 0.35, s * 0.2, s * 0.8);
         break;
 
+      // Verify-mode icons (prefix 'v' stripped for matching, reuse where sensible)
+      case 'vConnect': // Magnifying glass + plug
+        ctx.beginPath();
+        ctx.arc(cx - s * 0.1, cy - s * 0.1, s * 0.35, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.moveTo(cx + s * 0.15, cy + s * 0.2);
+        ctx.lineTo(cx + s * 0.55, cy + s * 0.6);
+        ctx.stroke();
+        break;
+
+      case 'vFetchProjects': // List with download
+        ctx.strokeRect(cx - s * 0.45, cy - s * 0.6, s * 0.9, s * 1.2);
+        ctx.beginPath();
+        ctx.moveTo(cx - s * 0.2, cy - s * 0.25);
+        ctx.lineTo(cx + s * 0.25, cy - s * 0.25);
+        ctx.moveTo(cx - s * 0.2, cy + s * 0.05);
+        ctx.lineTo(cx + s * 0.25, cy + s * 0.05);
+        ctx.stroke();
+        break;
+
+      case 'vBuildMappings': // Network/map
+        ctx.beginPath();
+        ctx.arc(cx - s * 0.35, cy - s * 0.3, s * 0.15, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.arc(cx + s * 0.35, cy - s * 0.3, s * 0.15, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.arc(cx, cy + s * 0.35, s * 0.15, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.moveTo(cx - s * 0.2, cy - s * 0.2);
+        ctx.lineTo(cx + s * 0.2, cy - s * 0.2);
+        ctx.moveTo(cx - s * 0.25, cy - s * 0.15);
+        ctx.lineTo(cx - s * 0.1, cy + s * 0.2);
+        ctx.moveTo(cx + s * 0.25, cy - s * 0.15);
+        ctx.lineTo(cx + s * 0.1, cy + s * 0.2);
+        ctx.stroke();
+        break;
+
+      case 'vQualityGates': // Shield with checkmark
+        ctx.beginPath();
+        ctx.moveTo(cx, cy - s * 0.8);
+        ctx.lineTo(cx - s * 0.6, cy - s * 0.4);
+        ctx.lineTo(cx - s * 0.6, cy + s * 0.1);
+        ctx.quadraticCurveTo(cx, cy + s * 0.9, cx, cy + s * 0.9);
+        ctx.quadraticCurveTo(cx, cy + s * 0.9, cx + s * 0.6, cy + s * 0.1);
+        ctx.lineTo(cx + s * 0.6, cy - s * 0.4);
+        ctx.closePath();
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.moveTo(cx - s * 0.2, cy);
+        ctx.lineTo(cx - s * 0.05, cy + s * 0.2);
+        ctx.lineTo(cx + s * 0.25, cy - s * 0.15);
+        ctx.stroke();
+        break;
+
+      case 'vQualityProfiles': // Clipboard with checkmark
+        ctx.strokeRect(cx - s * 0.45, cy - s * 0.7, s * 0.9, s * 1.4);
+        ctx.beginPath();
+        ctx.moveTo(cx - s * 0.2, cy - s * 0.1);
+        ctx.lineTo(cx - s * 0.05, cy + s * 0.1);
+        ctx.lineTo(cx + s * 0.25, cy - s * 0.2);
+        ctx.stroke();
+        break;
+
+      case 'vGroups': // Two people (reuse groups icon)
+        ctx.beginPath();
+        ctx.arc(cx - s * 0.25, cy - s * 0.25, s * 0.25, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.arc(cx - s * 0.25, cy + s * 0.55, s * 0.4, Math.PI, 0);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.arc(cx + s * 0.35, cy - s * 0.15, s * 0.2, 0, Math.PI * 2);
+        ctx.stroke();
+        break;
+
+      case 'vPermissions': // Lock (reuse permissions icon)
+        ctx.beginPath();
+        ctx.arc(cx, cy - s * 0.2, s * 0.35, Math.PI, 0);
+        ctx.stroke();
+        ctx.strokeRect(cx - s * 0.45, cy, s * 0.9, s * 0.65);
+        ctx.beginPath();
+        ctx.arc(cx, cy + s * 0.25, s * 0.08, 0, Math.PI * 2);
+        ctx.fill();
+        break;
+
+      case 'vProjects': // Folder (reuse projects icon)
+        ctx.beginPath();
+        ctx.moveTo(cx - s * 0.55, cy - s * 0.25);
+        ctx.lineTo(cx - s * 0.55, cy - s * 0.55);
+        ctx.lineTo(cx - s * 0.1, cy - s * 0.55);
+        ctx.lineTo(cx + s * 0.05, cy - s * 0.35);
+        ctx.lineTo(cx + s * 0.55, cy - s * 0.35);
+        ctx.lineTo(cx + s * 0.55, cy + s * 0.55);
+        ctx.lineTo(cx - s * 0.55, cy + s * 0.55);
+        ctx.closePath();
+        ctx.stroke();
+        break;
+
+      case 'vBranches': // Git branch
+        ctx.beginPath();
+        ctx.arc(cx - s * 0.25, cy - s * 0.4, s * 0.15, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.arc(cx + s * 0.25, cy - s * 0.4, s * 0.15, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.arc(cx, cy + s * 0.45, s * 0.15, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.moveTo(cx - s * 0.25, cy - s * 0.25);
+        ctx.quadraticCurveTo(cx - s * 0.25, cy + s * 0.15, cx, cy + s * 0.3);
+        ctx.moveTo(cx + s * 0.25, cy - s * 0.25);
+        ctx.quadraticCurveTo(cx + s * 0.25, cy + s * 0.15, cx, cy + s * 0.3);
+        ctx.stroke();
+        break;
+
+      case 'vIssues': // Bug/issue
+        ctx.beginPath();
+        ctx.arc(cx, cy, s * 0.4, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.moveTo(cx, cy - s * 0.15);
+        ctx.lineTo(cx, cy + s * 0.1);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.arc(cx, cy + s * 0.22, s * 0.04, 0, Math.PI * 2);
+        ctx.fill();
+        break;
+
+      case 'vHotspots': // Flame (reuse hotspotSync icon)
+        ctx.beginPath();
+        ctx.moveTo(cx, cy + s * 0.6);
+        ctx.quadraticCurveTo(cx - s * 0.5, cy + s * 0.1, cx - s * 0.3, cy - s * 0.3);
+        ctx.quadraticCurveTo(cx - s * 0.1, cy - s * 0.1, cx, cy - s * 0.7);
+        ctx.quadraticCurveTo(cx + s * 0.1, cy - s * 0.1, cx + s * 0.3, cy - s * 0.3);
+        ctx.quadraticCurveTo(cx + s * 0.5, cy + s * 0.1, cx, cy + s * 0.6);
+        ctx.stroke();
+        break;
+
+      case 'vMeasures': // Chart bars (reuse analysis icon)
+        ctx.beginPath();
+        ctx.moveTo(cx - s * 0.5, cy + s * 0.5);
+        ctx.lineTo(cx - s * 0.5, cy - s * 0.5);
+        ctx.moveTo(cx - s * 0.55, cy + s * 0.5);
+        ctx.lineTo(cx + s * 0.55, cy + s * 0.5);
+        ctx.stroke();
+        ctx.fillRect(cx - s * 0.35, cy + s * 0.1, s * 0.2, s * 0.35);
+        ctx.fillRect(cx - s * 0.05, cy - s * 0.2, s * 0.2, s * 0.65);
+        ctx.fillRect(cx + s * 0.25, cy - s * 0.35, s * 0.2, s * 0.8);
+        break;
+
+      case 'vPortfolios': // Grid (reuse portfolios icon)
+        ctx.strokeRect(cx - s * 0.55, cy - s * 0.4, s * 1.1, s * 0.8);
+        ctx.beginPath();
+        ctx.moveTo(cx, cy - s * 0.4);
+        ctx.lineTo(cx, cy + s * 0.4);
+        ctx.moveTo(cx - s * 0.55, cy);
+        ctx.lineTo(cx + s * 0.55, cy);
+        ctx.stroke();
+        break;
+
       default: // Circle dot fallback
         ctx.beginPath();
         ctx.arc(cx, cy, s * 0.3, 0, Math.PI * 2);
@@ -355,8 +548,12 @@ window.MigrationGraph = {
     this.container.appendChild(this.canvas);
     this.ctx = this.canvas.getContext('2d');
 
-    // Theme
+    // Theme — re-read colors when data-theme attribute changes
     this.readThemeColors();
+    this._themeObserver = new MutationObserver(() => this.readThemeColors());
+    this._themeObserver.observe(document.documentElement, {
+      attributes: true, attributeFilter: ['data-theme'],
+    });
 
     // Build graph
     this._buildGraph();
@@ -389,6 +586,10 @@ window.MigrationGraph = {
     if (this.resizeObserver) {
       this.resizeObserver.disconnect();
       this.resizeObserver = null;
+    }
+    if (this._themeObserver) {
+      this._themeObserver.disconnect();
+      this._themeObserver = null;
     }
     if (this.canvas) {
       this.canvas.removeEventListener('mousedown', this._onMouseDown);
@@ -819,8 +1020,9 @@ window.MigrationGraph = {
         color = { r: 210, g: 153, b: 34 };
         alpha = 0.7;
       } else {
-        color = { r: 248, g: 81, b: 73 };
-        alpha = 0.4;
+        const pending = (this.themeColors && this.themeColors.pending) || { r: 110, g: 118, b: 138 };
+        color = pending;
+        alpha = 0.25;
       }
 
       ctx.save();
@@ -991,6 +1193,8 @@ window.MigrationGraph = {
       this._parseTransferLine(line);
     } else if (this.mode === 'sync-metadata') {
       this._parseSyncMetadataLine(line);
+    } else if (this.mode === 'verify') {
+      this._parseVerifyLine(line);
     }
   },
 
@@ -1027,15 +1231,12 @@ window.MigrationGraph = {
       this.setNodeState('qualityGates', 'active');
       return;
     }
-    if (/Restoring.*quality profiles/.test(line)) {
-      this.setNodeState('qualityGates', 'done');
-      return;
-    }
 
-    // Quality Profiles
-    m = line.match(/Restoring (\d+) quality profiles/);
+    // Quality Profiles (also marks quality gates done)
+    m = line.match(/Restoring(?: (\d+))? quality profiles/);
     if (m) {
-      this._setNodeCount('qualityProfiles', m[1]);
+      this.setNodeState('qualityGates', 'done');
+      if (m[1]) this._setNodeCount('qualityProfiles', m[1]);
       this.setNodeState('qualityProfiles', 'active');
       return;
     }
@@ -1194,6 +1395,190 @@ window.MigrationGraph = {
     }
   },
 
+  _parseVerifyLine(line) {
+    let m;
+
+    // Step 1: Connect
+    if (/=== Step 1.*Connecting/.test(line)) {
+      this.setNodeState('vConnect', 'active');
+      return;
+    }
+    if (/Using pipeline/.test(line)) {
+      this.setNodeState('vConnect', 'done');
+      return;
+    }
+
+    // Step 2: Fetch projects
+    if (/=== Step 2.*Fetching project list/.test(line)) {
+      this.setNodeState('vConnect', 'done');
+      this.setNodeState('vFetchProjects', 'active');
+      return;
+    }
+    m = line.match(/Found (\d+) projects in SonarQube/);
+    if (m) {
+      this._setNodeCount('vFetchProjects', m[1]);
+      this.setNodeState('vFetchProjects', 'done');
+      return;
+    }
+
+    // Step 3: Build mappings
+    if (/=== Step 3.*Building organization mappings/.test(line)) {
+      this.setNodeState('vFetchProjects', 'done');
+      this.setNodeState('vBuildMappings', 'active');
+      return;
+    }
+
+    // Org-wide verification checks
+    if (/Verifying organization/.test(line)) {
+      this.setNodeState('vBuildMappings', 'done');
+      return;
+    }
+
+    if (/Verifying quality gates/.test(line)) {
+      this.setNodeState('vQualityGates', 'active');
+      return;
+    }
+    if (/Quality gate verification/.test(line)) {
+      this.setNodeState('vQualityGates', 'done');
+      return;
+    }
+
+    if (/Verifying quality profiles/.test(line)) {
+      this.setNodeState('vQualityProfiles', 'active');
+      return;
+    }
+    if (/Quality profile verification/.test(line)) {
+      this.setNodeState('vQualityProfiles', 'done');
+      return;
+    }
+
+    if (/Verifying groups/.test(line)) {
+      this.setNodeState('vGroups', 'active');
+      return;
+    }
+    if (/Group verification/.test(line)) {
+      this.setNodeState('vGroups', 'done');
+      return;
+    }
+
+    if (/Verifying global permissions|Verifying permission templates/.test(line)) {
+      this.setNodeState('vPermissions', 'active');
+      return;
+    }
+    if (/Permission template verification|Global permission verification/.test(line)) {
+      this.setNodeState('vPermissions', 'done');
+      return;
+    }
+
+    // Per-project checks
+    m = line.match(/--- Project (\d+)\/(\d+)/);
+    if (m) {
+      this._setNodeCount('vProjects', m[1] + '/' + m[2]);
+      const node = this._nodeById('vProjects');
+      if (node && node.state === 'pending') {
+        // Mark org-wide checks done when projects start
+        this.setNodeState('vQualityGates', 'done');
+        this.setNodeState('vQualityProfiles', 'done');
+        this.setNodeState('vGroups', 'done');
+        this.setNodeState('vPermissions', 'done');
+        this.setNodeState('vProjects', 'active');
+      }
+      if (node && node.state === 'active') {
+        node.count = m[1] + '/' + m[2];
+      }
+      // Reset sub-nodes for each new project
+      this._resetVerifySubNodes();
+      return;
+    }
+
+    // Branch verification
+    if (/Branch verification/.test(line)) {
+      this.setNodeState('vBranches', 'active');
+      this.setNodeState('vBranches', 'done');
+      return;
+    }
+
+    // Issue verification
+    if (/Fetching issues from SonarQube/.test(line)) {
+      this.setNodeState('vBranches', 'done');
+      this.setNodeState('vIssues', 'active');
+      return;
+    }
+    if (/Issue verification/.test(line)) {
+      this.setNodeState('vIssues', 'done');
+      return;
+    }
+
+    // Hotspot verification
+    if (/Fetching hotspots from SonarQube|Fetching hotspots for project/.test(line)) {
+      this.setNodeState('vIssues', 'done');
+      this.setNodeState('vHotspots', 'active');
+      return;
+    }
+    if (/Hotspot verification/.test(line)) {
+      this.setNodeState('vHotspots', 'done');
+      return;
+    }
+
+    // Measures verification
+    if (/Fetching measures for project|Measures verification/.test(line)) {
+      this.setNodeState('vHotspots', 'done');
+      this.setNodeState('vMeasures', 'active');
+      if (/Measures verification/.test(line)) {
+        this.setNodeState('vMeasures', 'done');
+      }
+      return;
+    }
+
+    // Project settings/config checks
+    if (/Fetching project settings|Fetching quality gate for|Fetching quality profiles for/.test(line)) {
+      this.setNodeState('vMeasures', 'done');
+      return;
+    }
+
+    // Portfolios
+    if (/Verifying portfolios/.test(line)) {
+      this.setNodeState('vProjects', 'done');
+      this.setNodeState('vBranches', 'done');
+      this.setNodeState('vIssues', 'done');
+      this.setNodeState('vHotspots', 'done');
+      this.setNodeState('vMeasures', 'done');
+      this.setNodeState('vPortfolios', 'active');
+      return;
+    }
+    if (/Portfolio verification/.test(line)) {
+      this.setNodeState('vPortfolios', 'done');
+      return;
+    }
+
+    // Overall completion
+    if (/Verification complete|=== Verification Summary ===/.test(line)) {
+      this.setNodeState('vProjects', 'done');
+      this.setNodeState('vBranches', 'done');
+      this.setNodeState('vIssues', 'done');
+      this.setNodeState('vHotspots', 'done');
+      this.setNodeState('vMeasures', 'done');
+      this.setNodeState('vPortfolios', 'done');
+      return;
+    }
+  },
+
+  _resetVerifySubNodes() {
+    // Reset per-project sub-nodes so they cycle pending→active→done for each project
+    const subIds = ['vBranches', 'vIssues', 'vHotspots', 'vMeasures'];
+    subIds.forEach(id => {
+      const node = this._nodeById(id);
+      if (node) {
+        node.state = 'pending';
+        node.progress = 0;
+      }
+    });
+    // Remove particles for sub-node edges
+    this.particles = this.particles.filter(p => {
+      return !subIds.some(id => p.key.includes(id));
+    });
+  },
+
   // ── State Transitions ──────────────────────────────────────────
 
   setNodeState(nodeId, newState) {
@@ -1260,13 +1645,16 @@ window.MigrationGraph = {
 
   lerpColor(progress) {
     const p = Math.max(0, Math.min(1, progress));
+    const pending = (this.themeColors && this.themeColors.pending) || { r: 110, g: 118, b: 138 };
     let r, g, b;
     if (p <= 0.5) {
+      // Pending (theme-aware muted) → Amber
       const t = p / 0.5;
-      r = 248 + (210 - 248) * t;
-      g = 81 + (153 - 81) * t;
-      b = 73 + (34 - 73) * t;
+      r = pending.r + (210 - pending.r) * t;
+      g = pending.g + (153 - pending.g) * t;
+      b = pending.b + (34 - pending.b) * t;
     } else {
+      // Amber → Green
       const t = (p - 0.5) / 0.5;
       r = 210 + (63 - 210) * t;
       g = 153 + (185 - 153) * t;
@@ -1299,10 +1687,16 @@ window.MigrationGraph = {
 
   readThemeColors() {
     const styles = getComputedStyle(document.documentElement);
+    const theme = document.documentElement.getAttribute('data-theme');
+    const isDark = theme !== 'light';
     this.themeColors = {
       text: styles.getPropertyValue('--text-primary').trim() || '#e6edf3',
       textMuted: styles.getPropertyValue('--text-muted').trim() || '#7d8590',
       gridLine: styles.getPropertyValue('--glass-border').trim() || 'rgba(74, 125, 255, 0.08)',
+      // Pending: muted slate for dark, muted cool gray for light
+      pending: isDark
+        ? { r: 110, g: 118, b: 138 }
+        : { r: 160, g: 168, b: 185 },
     };
   },
 };

--- a/desktop/src/renderer/js/screens/execution.js
+++ b/desktop/src/renderer/js/screens/execution.js
@@ -66,6 +66,7 @@ window.ExecutionScreen = {
     const graphMode = (commandLabel === 'transfer') ? 'transfer'
       : (commandLabel === 'migrate') ? 'migrate'
       : (commandLabel === 'sync-metadata') ? 'sync-metadata'
+      : (commandLabel === 'verify') ? 'verify'
       : null;
     if (graphMode && typeof MigrationGraph !== 'undefined') {
       const graphContainer = container.querySelector('#migration-graph-container');
@@ -265,10 +266,15 @@ window.ExecutionScreen = {
   },
 
   drawWhale() {
-    const palette = {
+    const isDark = document.documentElement.getAttribute('data-theme') !== 'light';
+    const palette = isDark ? {
       'D': '#1e293b', 'M': '#334155', 'L': '#94a3b8',
       'W': '#f8fafc', 'B': '#0f172a', 'C': '#bae6fd',
       'S': '#7dd3fc', 'P': '#e0f2fe'
+    } : {
+      'D': '#1e3a5f', 'M': '#2d5986', 'L': '#5b8cb8',
+      'W': '#ffffff', 'B': '#0c2340', 'C': '#7ec8e3',
+      'S': '#4da8da', 'P': '#b8dff0'
     };
 
     // Frame 1: Tail up, spout visible
@@ -421,8 +427,11 @@ window.ExecutionScreen = {
 
       const drawStars = () => {
         starCtx.clearRect(0, 0, starW, starH);
+        const dark = document.documentElement.getAttribute('data-theme') !== 'light';
         for (const star of stars) {
-          const color = star.isBlue ? `rgba(200, 220, 255, ${star.opacity})` : `rgba(255, 255, 255, ${star.opacity})`;
+          const color = dark
+            ? (star.isBlue ? `rgba(200, 220, 255, ${star.opacity})` : `rgba(255, 255, 255, ${star.opacity})`)
+            : (star.isBlue ? `rgba(100, 140, 200, ${star.opacity * 0.5})` : `rgba(80, 100, 140, ${star.opacity * 0.4})`);
           starCtx.fillStyle = color;
           starCtx.beginPath();
           starCtx.arc(star.x, star.y, star.r, 0, Math.PI * 2);
@@ -740,19 +749,68 @@ window.ExecutionScreen = {
   },
 
   /**
-   * Verify pipeline: similar project-based structure.
+   * Verify pipeline progress layout (0-100%):
+   *   0-5%   : Connect (Step 1)
+   *   5-10%  : Fetch projects (Step 2)
+   *  10-15%  : Build mappings (Step 3) + org-wide checks
+   *  15-93%  : Per-project verification (divided equally among N projects)
+   *  93-98%  : Portfolios + summary
    */
   parseVerifyProgress(line, s) {
-    if (line.includes('=== Step 1:')) { this.setProgress(3); return; }
-    if (line.includes('=== Step 2:')) { this.setProgress(8); return; }
-    if (line.includes('=== Step 3:')) { this.setProgress(12); return; }
+    if (line.includes('=== Step 1:')) {
+      this.setProgress(2);
+      this.setPhaseLabel('Connecting to SonarQube...');
+      return;
+    }
+    if (line.includes('=== Step 2:')) {
+      this.setProgress(6);
+      this.setPhaseLabel('Fetching project list...');
+      return;
+    }
+    if (line.includes('=== Step 3:')) {
+      this.setProgress(10);
+      this.setPhaseLabel('Building org mappings...');
+      return;
+    }
+    if (line.includes('Verifying quality gates')) {
+      this.setProgress(11);
+      this.setPhaseLabel('Verifying quality gates...');
+      return;
+    }
+    if (line.includes('Verifying quality profiles')) {
+      this.setProgress(12);
+      this.setPhaseLabel('Verifying quality profiles...');
+      return;
+    }
+    if (line.includes('Verifying groups')) {
+      this.setProgress(13);
+      this.setPhaseLabel('Verifying groups...');
+      return;
+    }
+    if (line.includes('Verifying permission templates')) {
+      this.setProgress(14);
+      this.setPhaseLabel('Verifying permissions...');
+      return;
+    }
 
     const projectMatch = line.match(/--- Project (\d+)\/(\d+):/);
     if (projectMatch) {
       s.currentProject = parseInt(projectMatch[1], 10);
       s.totalProjects = parseInt(projectMatch[2], 10);
-      const pct = 15 + Math.round(((s.currentProject - 1) / s.totalProjects) * 80);
+      const pct = 15 + Math.round(((s.currentProject - 1) / s.totalProjects) * 78);
       this.setProgress(pct);
+      this.setPhaseLabel('Verifying project ' + s.currentProject + '/' + s.totalProjects + '...');
+      return;
+    }
+
+    if (line.includes('Verifying portfolios')) {
+      this.setProgress(94);
+      this.setPhaseLabel('Verifying portfolios...');
+      return;
+    }
+    if (line.includes('=== Verification Summary ===')) {
+      this.setProgress(98);
+      this.setPhaseLabel('Verification complete');
       return;
     }
   },

--- a/desktop/src/renderer/styles/main.css
+++ b/desktop/src/renderer/styles/main.css
@@ -58,6 +58,23 @@
   --scanline-opacity: 0.03;
   --ambient-accent: rgba(74, 125, 255, 0.06);
   --ambient-success: rgba(63, 185, 80, 0.04);
+  --overlay-bg: rgba(0, 0, 0, 0.7);
+  --shadow-heavy: rgba(0, 0, 0, 0.4);
+  --shadow-medium: rgba(0, 0, 0, 0.15);
+  --highlight-line: rgba(255, 255, 255, 0.05);
+  --whale-particle: rgba(255, 255, 255, 0.7);
+  --whale-particle-blue: rgba(200, 220, 255, 0.6);
+  --whale-shimmer: rgba(255, 255, 255, 0.15);
+  --whale-border-trail: rgba(255, 255, 255, 0.3);
+  --whale-border-trail-done: rgba(255, 255, 255, 0.5);
+  --ansi-red: #f85149;
+  --ansi-green: #3fb950;
+  --ansi-yellow: #d29922;
+  --ansi-blue: #58a6ff;
+  --ansi-magenta: #bc8cff;
+  --ansi-cyan: #39d2f5;
+  --ansi-white: #e6edf3;
+  --ansi-gray: #8b949e;
 }
 
 /* Light theme */
@@ -96,6 +113,23 @@
   --scanline-opacity: 0.015;
   --ambient-accent: rgba(9, 105, 218, 0.04);
   --ambient-success: rgba(26, 127, 55, 0.03);
+  --overlay-bg: rgba(0, 0, 0, 0.4);
+  --shadow-heavy: rgba(0, 0, 0, 0.15);
+  --shadow-medium: rgba(0, 0, 0, 0.08);
+  --highlight-line: rgba(0, 0, 0, 0.03);
+  --whale-particle: rgba(255, 255, 255, 0.9);
+  --whale-particle-blue: rgba(200, 220, 255, 0.8);
+  --whale-shimmer: rgba(255, 255, 255, 0.4);
+  --whale-border-trail: rgba(255, 255, 255, 0.5);
+  --whale-border-trail-done: rgba(255, 255, 255, 0.7);
+  --ansi-red: #cf222e;
+  --ansi-green: #1a7f37;
+  --ansi-yellow: #9a6700;
+  --ansi-blue: #0969da;
+  --ansi-magenta: #8250df;
+  --ansi-cyan: #0598bc;
+  --ansi-white: #1f2328;
+  --ansi-gray: #656d76;
 }
 
 * {
@@ -146,7 +180,7 @@ body::after {
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
-  box-shadow: 2px 0 20px rgba(0, 0, 0, 0.3);
+  box-shadow: 2px 0 20px var(--shadow-medium);
 }
 
 #sidebar-header {
@@ -239,13 +273,13 @@ body::after {
   border-radius: var(--radius);
   padding: 20px;
   margin-bottom: 16px;
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  box-shadow: 0 4px 24px var(--shadow-medium), inset 0 1px 0 var(--highlight-line);
   transition: border-color 200ms ease, box-shadow 200ms ease;
 }
 
 .card:hover {
   border-color: var(--accent);
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2), 0 0 12px var(--glow-accent), inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  box-shadow: 0 4px 24px var(--shadow-medium), 0 0 12px var(--glow-accent), inset 0 1px 0 var(--highlight-line);
 }
 
 .card-header {
@@ -272,8 +306,8 @@ body::after {
 .btn-primary {
   background: linear-gradient(135deg, var(--accent), var(--accent-hover));
   color: #fff;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: 0 0 12px var(--glow-accent), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--highlight-line);
+  box-shadow: 0 0 12px var(--glow-accent), inset 0 1px 0 var(--highlight-line);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   font-weight: 600;
@@ -282,7 +316,7 @@ body::after {
 
 .btn-primary:hover {
   background: linear-gradient(135deg, var(--accent-hover), var(--accent));
-  box-shadow: 0 0 24px var(--glow-accent), inset 0 1px 0 rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 24px var(--glow-accent), inset 0 1px 0 var(--highlight-line);
   transform: translateY(-1px);
 }
 
@@ -319,7 +353,7 @@ body::after {
 .btn-danger {
   background: linear-gradient(135deg, var(--danger), #e63946);
   color: #fff;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--highlight-line);
   box-shadow: 0 0 12px var(--glow-danger);
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -369,7 +403,7 @@ body::after {
 .form-group textarea:focus {
   outline: none;
   border-color: var(--border-focus);
-  box-shadow: 0 0 12px var(--glow-accent), inset 0 0 4px rgba(74, 125, 255, 0.1);
+  box-shadow: 0 0 12px var(--glow-accent), inset 0 0 4px var(--accent-bg);
 }
 
 .form-group input::placeholder {

--- a/desktop/src/renderer/styles/wizard.css
+++ b/desktop/src/renderer/styles/wizard.css
@@ -441,7 +441,7 @@
   position: relative;
   overflow: hidden;
   border: 3px solid var(--whale-track-border);
-  box-shadow: 0 4px 12px var(--whale-track-shadow), inset 0 0 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px var(--whale-track-shadow), inset 0 0 10px var(--shadow-medium);
   image-rendering: pixelated;
 }
 
@@ -452,17 +452,17 @@
   height: 100%;
   width: 0%;
   background-color: var(--whale-trail-bg);
-  background-image: linear-gradient(90deg, transparent, rgba(255,255,255,0.15), transparent);
+  background-image: linear-gradient(90deg, transparent, var(--whale-shimmer), transparent);
   background-size: 200%;
   animation: shimmer 2s linear infinite;
-  border-right: 2px solid rgba(255, 255, 255, 0.3);
+  border-right: 2px solid var(--whale-border-trail);
   transition: width 0.6s ease-out;
   z-index: 1;
 }
 
 .whale-trail-complete {
   background-color: var(--whale-trail-complete);
-  border-right-color: rgba(255, 255, 255, 0.5);
+  border-right-color: var(--whale-border-trail-done);
   animation: glow-pulse-success 2s ease-in-out infinite;
 }
 
@@ -696,14 +696,14 @@
 }
 
 /* ANSI color classes */
-.ansi-red { color: #f85149; }
-.ansi-green { color: #3fb950; }
-.ansi-yellow { color: #d29922; }
-.ansi-blue { color: #58a6ff; }
-.ansi-magenta { color: #bc8cff; }
-.ansi-cyan { color: #39d2f5; }
-.ansi-white { color: #e6edf3; }
-.ansi-gray { color: #8b949e; }
+.ansi-red { color: var(--ansi-red); }
+.ansi-green { color: var(--ansi-green); }
+.ansi-yellow { color: var(--ansi-yellow); }
+.ansi-blue { color: var(--ansi-blue); }
+.ansi-magenta { color: var(--ansi-magenta); }
+.ansi-cyan { color: var(--ansi-cyan); }
+.ansi-white { color: var(--ansi-white); }
+.ansi-gray { color: var(--ansi-gray); }
 .ansi-bold { font-weight: 700; }
 
 /* Results screen */
@@ -762,11 +762,11 @@
   flex-shrink: 0;
 }
 
-.report-type-badge.json { background: rgba(74, 125, 255, 0.15); color: #58a6ff; box-shadow: 0 0 6px rgba(74, 125, 255, 0.3); }
-.report-type-badge.md { background: rgba(63, 185, 80, 0.15); color: #3fb950; box-shadow: 0 0 6px rgba(63, 185, 80, 0.3); }
-.report-type-badge.pdf { background: rgba(248, 81, 73, 0.15); color: #f85149; box-shadow: 0 0 6px rgba(248, 81, 73, 0.3); }
-.report-type-badge.txt { background: rgba(210, 153, 34, 0.15); color: #d29922; box-shadow: 0 0 6px rgba(210, 153, 34, 0.3); }
-.report-type-badge.csv { background: rgba(139, 148, 158, 0.15); color: #8b949e; box-shadow: 0 0 6px rgba(139, 148, 158, 0.3); }
+.report-type-badge.json { background: var(--accent-bg); color: var(--accent); box-shadow: 0 0 6px var(--glow-accent); }
+.report-type-badge.md { background: var(--success-bg); color: var(--success); box-shadow: 0 0 6px var(--glow-success); }
+.report-type-badge.pdf { background: var(--danger-bg); color: var(--danger); box-shadow: 0 0 6px var(--glow-danger); }
+.report-type-badge.txt { background: var(--warning-bg); color: var(--warning); box-shadow: 0 0 6px var(--glow-accent); }
+.report-type-badge.csv { background: var(--accent-bg); color: var(--text-muted); box-shadow: none; }
 
 .report-item {
   display: flex;
@@ -925,7 +925,7 @@
 .dialog-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: var(--overlay-bg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -942,7 +942,7 @@
   padding: 28px;
   max-width: 420px;
   width: 90%;
-  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.4), 0 0 20px var(--glow-accent);
+  box-shadow: 0 8px 40px var(--shadow-heavy), 0 0 20px var(--glow-accent);
   animation: dialog-enter 200ms ease-out;
 }
 
@@ -1020,7 +1020,7 @@
   background: var(--glass-bg);
   backdrop-filter: blur(var(--glass-blur, 12px));
   -webkit-backdrop-filter: blur(var(--glass-blur, 12px));
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  box-shadow: 0 4px 24px var(--shadow-medium), inset 0 1px 0 var(--highlight-line);
   position: relative;
   overflow: hidden;
 }

--- a/src/shared/verification/reports/format-markdown.js
+++ b/src/shared/verification/reports/format-markdown.js
@@ -45,7 +45,45 @@ function formatSummary(results) {
   lines.push(`| Errors | ${s.errors} |`);
   lines.push(`| **Overall** | **${overall}** |`);
   lines.push('');
+
+  // List skipped checks with reasons
+  const skippedChecks = collectSkippedChecks(results);
+  if (skippedChecks.length > 0) {
+    lines.push('**Skipped checks:**\n');
+    for (const { checkName, context, reason } of skippedChecks) {
+      const where = context ? ` (${context})` : '';
+      lines.push(`- **${checkName}**${where}: ${reason}`);
+    }
+    lines.push('');
+  }
+
   return lines.join('\n');
+}
+
+function collectSkippedChecks(results) {
+  const skipped = [];
+
+  for (const org of results.orgResults) {
+    for (const [name, check] of Object.entries(org.checks || {})) {
+      if (check?.status === 'skipped') {
+        skipped.push({ checkName: name, context: `org: ${org.orgKey}`, reason: check.details || check.error || 'No reason provided' });
+      }
+    }
+  }
+
+  for (const project of results.projectResults) {
+    for (const [name, check] of Object.entries(project.checks || {})) {
+      if (check?.status === 'skipped') {
+        skipped.push({ checkName: name, context: `project: ${project.sqProjectKey}`, reason: check.details || check.error || 'No reason provided' });
+      }
+    }
+  }
+
+  if (results.portfolios?.status === 'skipped') {
+    skipped.push({ checkName: 'Portfolios', context: null, reason: results.portfolios.details || 'No reason provided' });
+  }
+
+  return skipped;
 }
 
 function formatUnsyncableWarnings(results) {

--- a/src/shared/verification/reports/format-pdf.js
+++ b/src/shared/verification/reports/format-pdf.js
@@ -66,7 +66,7 @@ function buildSummaryTable(results) {
   const s = results.summary;
   const overall = s.failed === 0 && s.errors === 0 ? 'ALL CHECKS PASSED' : `${s.failed} FAILED, ${s.errors} ERRORS`;
 
-  return [
+  const nodes = [
     { text: 'Summary', style: 'heading' },
     {
       table: {
@@ -87,6 +87,52 @@ function buildSummaryTable(results) {
       margin: [0, 0, 0, 10],
     }
   ];
+
+  // List skipped checks with reasons
+  const skippedChecks = collectSkippedChecks(results);
+  if (skippedChecks.length > 0) {
+    nodes.push({ text: 'Skipped Checks', style: 'subheading' });
+    const skipRows = [
+      [{ text: 'Check', style: 'tableHeader' }, { text: 'Context', style: 'tableHeader' }, { text: 'Reason', style: 'tableHeader' }]
+    ];
+    for (const { checkName, context, reason } of skippedChecks) {
+      skipRows.push([checkName, context || '', reason]);
+    }
+    nodes.push({
+      table: { headerRows: 1, widths: [80, 100, '*'], body: skipRows },
+      layout: 'lightHorizontalLines',
+      fontSize: 8,
+      margin: [0, 0, 0, 10],
+    });
+  }
+
+  return nodes;
+}
+
+function collectSkippedChecks(results) {
+  const skipped = [];
+
+  for (const org of results.orgResults) {
+    for (const [name, check] of Object.entries(org.checks || {})) {
+      if (check?.status === 'skipped') {
+        skipped.push({ checkName: name, context: `org: ${org.orgKey}`, reason: check.details || check.error || 'No reason provided' });
+      }
+    }
+  }
+
+  for (const project of results.projectResults) {
+    for (const [name, check] of Object.entries(project.checks || {})) {
+      if (check?.status === 'skipped') {
+        skipped.push({ checkName: name, context: `project: ${project.sqProjectKey}`, reason: check.details || check.error || 'No reason provided' });
+      }
+    }
+  }
+
+  if (results.portfolios?.status === 'skipped') {
+    skipped.push({ checkName: 'Portfolios', context: '', reason: results.portfolios.details || 'No reason provided' });
+  }
+
+  return skipped;
 }
 
 function buildOrgResults(results) {

--- a/src/shared/verification/reports/index.js
+++ b/src/shared/verification/reports/index.js
@@ -53,6 +53,29 @@ export function logVerificationSummary(results) {
   logger.info(`Errors:        ${s.errors}`);
   logger.info('');
 
+  // List skipped checks with reasons
+  if (s.skipped > 0) {
+    logger.info('--- Skipped Checks ---');
+    for (const org of results.orgResults) {
+      for (const [name, check] of Object.entries(org.checks || {})) {
+        if (check?.status === 'skipped') {
+          logger.info(`  ${name} (org: ${org.orgKey}): ${check.details || check.error || 'No reason provided'}`);
+        }
+      }
+    }
+    for (const project of results.projectResults) {
+      for (const [name, check] of Object.entries(project.checks || {})) {
+        if (check?.status === 'skipped') {
+          logger.info(`  ${name} (project: ${project.sqProjectKey}): ${check.details || check.error || 'No reason provided'}`);
+        }
+      }
+    }
+    if (results.portfolios?.status === 'skipped') {
+      logger.info(`  Portfolios: ${results.portfolios.details || 'No reason provided'}`);
+    }
+    logger.info('');
+  }
+
   if (s.failed === 0 && s.errors === 0) {
     logger.info('Result: ALL CHECKS PASSED');
   } else {


### PR DESCRIPTION
…colors are theme-aware and update live on theme switch

ANSI terminal colors: dark theme uses bright GitHub colors, light theme uses darker readable variants
Whale sprites: separate palettes for dark (slate tones) and light (deeper blue tones)
Starfield: white stars in dark mode, subtle blue-gray dots in light mode
All shadows/overlays/borders: use CSS variables that adapt per theme
Report badges: use existing semantic CSS variables
Cards, buttons, dialogs, sidebar: all shadows use theme-aware variables

format-markdown.js — After the summary table, lists each skipped check with its name, context (org/project), and reason format-pdf.js — Adds a "Skipped Checks" table below the summary with Check, Context, and Reason columns index.js (console output) — Adds a "Skipped Checks" section listing each skipped check with its reason

Added a full DAG visualization for the verify command with 13 nodes across 5 columns:

Graph structure:

Col 0: Connect
Col 1: Fetch Projects, Build Mappings
Col 2: Quality Gates, Quality Profiles, Groups, Permissions (org-wide checks) Col 3: Projects, Branches, Issues, Hotspots, Measures (per-project checks) Col 4: Portfolios
Changes made:

migration-graph.js — Added:

verify graph definition in _graphDefs with 13 nodes and 15 edges 13 verify-specific icons (magnifying glass for connect, git branch icon, bug icon for issues, etc.) _parseVerifyLine() state machine that parses verify log output into node transitions _resetVerifySubNodes() to cycle per-project sub-nodes (Branches, Issues, Hotspots, Measures) for each project Wired verify mode into updateFromLog()
execution.js — Added:

verify to the graphMode mapping so the graph container is created Enhanced parseVerifyProgress() with detailed phase labels and finer-grained progress percentages matching the graph nodes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds a new log-parsing state machine and DAG visualization for the `verify` command, which could mis-handle log patterns or regress execution-screen rendering. Other changes are mostly theme/styling and report formatting.
> 
> **Overview**
> Adds a new **`verify` mode** to the execution UI: the migration graph now renders a 13-node DAG with verify-specific icons and a `_parseVerifyLine()` log parser (including per-project sub-node resets), and `execution.js` wires `verify` into graph creation and progress/phase labels.
> 
> Makes the renderer **theme-aware and live-updating** by introducing CSS variables for shadows/overlays/ANSI colors and updating whale palettes/starfield colors; the migration graph also re-reads theme colors on `data-theme` changes and renders pending edges/nodes in a muted theme-specific gray instead of bright red.
> 
> Improves verification outputs by listing **skipped checks with context and reasons** in console summary (`reports/index.js`), markdown reports, and a new “Skipped Checks” table in the PDF report.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bb8fabcaace9a9c7688838cc9f69c2d78607c2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->