### PR TITLE
Here's a summary of what was added across all files:

### DIFF
--- a/desktop/src/main/config-store.js
+++ b/desktop/src/main/config-store.js
@@ -19,7 +19,7 @@ const schema = {
         checkpoint: { enabled: true, cacheExtractions: true, cacheMaxAgeDays: 7, strictResume: false }
       },
       rateLimit: { maxRetries: 3, baseDelay: 1000, minRequestInterval: 0 },
-      performance: { autoTune: false, maxConcurrency: 64, maxMemoryMB: 8192 }
+      performance: { autoTune: false, maxConcurrency: 64, maxMemoryMB: 8192, projectVerification: { concurrency: 3 } }
     }
   },
   migrateConfig: {
@@ -43,7 +43,7 @@ const schema = {
         dryRun: false
       },
       rateLimit: { maxRetries: 3, baseDelay: 1000, minRequestInterval: 0 },
-      performance: { autoTune: false, maxConcurrency: 64, maxMemoryMB: 8192 }
+      performance: { autoTune: false, maxConcurrency: 64, maxMemoryMB: 8192, projectVerification: { concurrency: 3 } }
     }
   },
   envVars: {

--- a/desktop/src/renderer/js/screens/migrate-config.js
+++ b/desktop/src/renderer/js/screens/migrate-config.js
@@ -184,6 +184,7 @@ window.MigrateConfigScreen = {
         ${ConfigForm.checkbox('skip-hotspot-meta', 'Skip updating security hotspot details', m.skipHotspotMetadataSync, { hint: "Don't update security hotspot statuses and comments" })}
         ${ConfigForm.checkbox('skip-qp-sync', 'Skip updating coding rules', m.skipQualityProfileSync, { hint: "Don't transfer quality profile configurations" })}
         ${ConfigForm.checkbox('sync-branches', 'Include all code branches', t.syncAllBranches, { hint: 'When unchecked, only the main branch is transferred' })}
+        ${ConfigForm.textField('exclude-branches', 'Exclude branches', (t.excludeBranches || []).join(', '), { hint: 'Comma-separated branch names to skip (e.g. feature/old, release/legacy)' })}
         ${ConfigForm.numberField('batch-size', 'Items per group', t.batchSize, { min: 1, max: 500, hint: 'How many items to process at once (1\u2013500)' })}
         ${ConfigForm.checkbox('verbose', 'Show detailed log output', this.config._verbose || false, { hint: 'Display extra technical details in the log' })}
         ${ConfigForm.checkbox('wait-analysis', 'Wait for SonarCloud to finish reviewing', this.config._waitAnalysis || false, { hint: 'Keep running until SonarCloud completes its analysis' })}
@@ -212,6 +213,7 @@ window.MigrateConfigScreen = {
       this.config.migrate.skipHotspotMetadataSync = container.querySelector('#skip-hotspot-meta').checked;
       this.config.migrate.skipQualityProfileSync = container.querySelector('#skip-qp-sync').checked;
       this.config.transfer.syncAllBranches = container.querySelector('#sync-branches').checked;
+      this.config.transfer.excludeBranches = container.querySelector('#exclude-branches').value.split(',').map(s => s.trim()).filter(Boolean);
       this.config.transfer.batchSize = parseInt(container.querySelector('#batch-size').value, 10) || 100;
       this.config._verbose = container.querySelector('#verbose').checked;
       this.config._waitAnalysis = container.querySelector('#wait-analysis')?.checked;
@@ -273,6 +275,7 @@ window.MigrateConfigScreen = {
           ['Preview only', m.dryRun ? 'Yes' : 'No'],
           ['Reports output folder', m.outputDir],
           ['Include all branches', t.syncAllBranches ? 'Yes' : 'No'],
+          ['Excluded branches', (t.excludeBranches || []).join(', ') || 'None'],
           ['Items per group', t.batchSize]
         ])}
       </div>

--- a/desktop/src/renderer/js/screens/sync-metadata-config.js
+++ b/desktop/src/renderer/js/screens/sync-metadata-config.js
@@ -18,10 +18,10 @@ window.SyncMetadataConfigScreen = {
     this.config = stored || {
       sonarqube: { url: '', token: '' },
       sonarcloud: { enterprise: { key: '' }, organizations: [] },
-      transfer: { mode: 'full', batchSize: 100, syncAllBranches: true },
+      transfer: { mode: 'full', batchSize: 100, syncAllBranches: true, excludeBranches: [], checkpoint: { enabled: true, cacheExtractions: true, cacheMaxAgeDays: 7, strictResume: false } },
       migrate: { outputDir: './migration-output', skipIssueMetadataSync: false, skipHotspotMetadataSync: false, skipQualityProfileSync: false },
       rateLimit: { maxRetries: 3, baseDelay: 1000, minRequestInterval: 0 },
-      performance: { autoTune: false, maxConcurrency: 8, maxMemoryMB: 0 }
+      performance: { autoTune: false, maxConcurrency: 64, maxMemoryMB: 8192 }
     };
     this.config._verbose = this.config._verbose || false;
     this.config._skipIssueSync = this.config._skipIssueSync || false;
@@ -161,6 +161,8 @@ window.SyncMetadataConfigScreen = {
         ${ConfigForm.checkbox('verbose', 'Show detailed log output', this.config._verbose || false, { hint: 'Display extra technical details in the log' })}
       </div>
 
+      ${ConfigForm.collapsible('advanced-section', 'More Settings (Advanced)', TransferConfigScreen.renderAdvancedHtml.call({ config: this.config }), true)}
+
       <div class="button-row spread">
         <button class="btn btn-secondary" id="btn-back">Back</button>
         <div style="display:flex;gap:12px">
@@ -170,8 +172,10 @@ window.SyncMetadataConfigScreen = {
       </div>
     `;
 
+    ConfigForm.attachHandlers(container);
     container.querySelector('#btn-back').addEventListener('click', () => this.renderStep(container, 1));
     container.querySelector('#btn-test').addEventListener('click', async () => {
+      TransferConfigScreen.readAdvancedValues.call({ config: this.config }, container);
       await this.saveConfig();
       App.navigate('connection-test', { command: 'test', configType: 'migrate', returnTo: 'sync-metadata-config' });
     });
@@ -181,6 +185,7 @@ window.SyncMetadataConfigScreen = {
       this.config._skipHotspotSync = container.querySelector('#skip-hotspot-meta')?.checked || false;
       this.config._skipQPSync = container.querySelector('#skip-qp-sync')?.checked || false;
       this.config._skipBranches = container.querySelector('#skip-branches')?.checked || false;
+      TransferConfigScreen.readAdvancedValues.call({ config: this.config }, container);
       await this.saveConfig();
 
       const args = [];

--- a/desktop/src/renderer/js/screens/transfer-config.js
+++ b/desktop/src/renderer/js/screens/transfer-config.js
@@ -113,6 +113,7 @@ window.TransferConfigScreen = {
           { value: 'incremental', label: 'Only new & changed data' }
         ], t.mode)}
         ${ConfigForm.checkbox('sync-branches', 'Include all code branches', t.syncAllBranches, { hint: 'When unchecked, only the main branch is transferred' })}
+        ${ConfigForm.textField('exclude-branches', 'Exclude branches', (t.excludeBranches || []).join(', '), { hint: 'Comma-separated branch names to skip (e.g. feature/old, release/legacy)' })}
         ${ConfigForm.numberField('batch-size', 'Items per group', t.batchSize, { min: 1, max: 500, hint: 'How many items to process at once (1\u2013500). Higher = faster but uses more memory' })}
         ${ConfigForm.checkbox('wait-analysis', 'Wait for SonarCloud to finish reviewing', this.config._waitAnalysis || false, { hint: 'Keep running until SonarCloud completes its analysis of the uploaded data' })}
         ${ConfigForm.checkbox('verbose', 'Show detailed log output', this.config._verbose || false, { hint: 'Display extra technical details in the log during transfer' })}
@@ -130,6 +131,7 @@ window.TransferConfigScreen = {
     container.querySelector('#btn-next').addEventListener('click', () => {
       this.config.transfer.mode = container.querySelector('input[name="transfer-mode"]:checked')?.value || 'incremental';
       this.config.transfer.syncAllBranches = container.querySelector('#sync-branches').checked;
+      this.config.transfer.excludeBranches = container.querySelector('#exclude-branches').value.split(',').map(s => s.trim()).filter(Boolean);
       this.config.transfer.batchSize = parseInt(container.querySelector('#batch-size').value, 10) || 100;
       this.config._waitAnalysis = container.querySelector('#wait-analysis').checked;
       this.config._verbose = container.querySelector('#verbose').checked;
@@ -162,10 +164,12 @@ window.TransferConfigScreen = {
           ${ConfigForm.numberField('perf-issue-sync', 'Issue sync concurrency', perf.issueSync?.concurrency ?? 20, { min: 1, max: 50, hint: 'Max concurrent issue metadata sync operations to SonarCloud' })}
           ${ConfigForm.numberField('perf-hotspot-sync', 'Hotspot sync concurrency', perf.hotspotSync?.concurrency ?? 20, { min: 1, max: 50, hint: 'Max concurrent hotspot sync operations to SonarCloud' })}
           ${ConfigForm.numberField('perf-project', 'Project migration concurrency', perf.projectMigration?.concurrency ?? 8, { min: 1, max: 16, hint: 'Max concurrent project migrations' })}
+          ${ConfigForm.numberField('perf-verify', 'Project verification concurrency', perf.projectVerification?.concurrency ?? 3, { min: 1, max: 16, hint: 'Max concurrent project verifications' })}
         </div>
       </div>
       <div class="card" style="margin-top:12px">
         <div class="card-header">Progress Recovery</div>
+        ${ConfigForm.textField('cp-statefile', 'State file path', this.config.transfer.stateFile || './.cloudvoyager-state.json', { hint: 'Path to the file that tracks transfer progress between runs' })}
         ${ConfigForm.checkbox('cp-enabled', 'Save progress checkpoints', cp.enabled, { hint: 'If interrupted, resume from where it stopped instead of starting over' })}
         ${ConfigForm.checkbox('cp-cache', 'Keep downloaded data temporarily', cp.cacheExtractions, { hint: "Saves extracted data so it doesn't need to be re-downloaded on retry" })}
         <div class="form-grid">
@@ -194,7 +198,9 @@ window.TransferConfigScreen = {
     this.config.performance.issueSync = { concurrency: numVal('perf-issue-sync', 20) };
     this.config.performance.hotspotSync = { concurrency: numVal('perf-hotspot-sync', 20) };
     this.config.performance.projectMigration = { concurrency: numVal('perf-project', 8) };
+    this.config.performance.projectVerification = { concurrency: numVal('perf-verify', 3) };
 
+    this.config.transfer.stateFile = val('cp-statefile') || './.cloudvoyager-state.json';
     this.config.transfer.checkpoint.enabled = chk('cp-enabled') !== false;
     this.config.transfer.checkpoint.cacheExtractions = chk('cp-cache') !== false;
     this.config.transfer.checkpoint.cacheMaxAgeDays = numVal('cp-maxage', 7);
@@ -247,6 +253,7 @@ window.TransferConfigScreen = {
         ${ConfigForm.summaryTable([
           ['What to transfer', modeLabel],
           ['Include all branches', t.syncAllBranches ? 'Yes' : 'No'],
+          ['Excluded branches', (t.excludeBranches || []).join(', ') || 'None'],
           ['Items per group', t.batchSize]
         ])}
       </div>

--- a/desktop/src/renderer/js/screens/verify-config.js
+++ b/desktop/src/renderer/js/screens/verify-config.js
@@ -18,10 +18,10 @@ window.VerifyConfigScreen = {
     this.config = stored || {
       sonarqube: { url: '', token: '' },
       sonarcloud: { enterprise: { key: '' }, organizations: [] },
-      transfer: { mode: 'full', batchSize: 100, syncAllBranches: true },
+      transfer: { mode: 'full', batchSize: 100, syncAllBranches: true, excludeBranches: [], checkpoint: { enabled: true, cacheExtractions: true, cacheMaxAgeDays: 7, strictResume: false } },
       migrate: { outputDir: './migration-output' },
       rateLimit: { maxRetries: 3, baseDelay: 1000, minRequestInterval: 0 },
-      performance: { autoTune: false, maxConcurrency: 8, maxMemoryMB: 0 }
+      performance: { autoTune: false, maxConcurrency: 64, maxMemoryMB: 8192 }
     };
     // Verify-specific transient options
     this.config._onlyComponents = this.config._onlyComponents || [];
@@ -173,6 +173,8 @@ window.VerifyConfigScreen = {
         ${ConfigForm.checkbox('verbose', 'Show detailed log output', this.config._verbose || false, { hint: 'Display extra technical details in the log' })}
       </div>
 
+      ${ConfigForm.collapsible('advanced-section', 'More Settings (Advanced)', TransferConfigScreen.renderAdvancedHtml.call({ config: this.config }), true)}
+
       <div class="button-row spread">
         <button class="btn btn-secondary" id="btn-back">Back</button>
         <div style="display:flex;gap:12px">
@@ -182,12 +184,15 @@ window.VerifyConfigScreen = {
       </div>
     `;
 
+    ConfigForm.attachHandlers(container);
     container.querySelector('#btn-back').addEventListener('click', () => this.renderStep(container, 1));
     container.querySelector('#btn-test').addEventListener('click', async () => {
+      TransferConfigScreen.readAdvancedValues.call({ config: this.config }, container);
       await this.saveConfig();
       App.navigate('connection-test', { command: 'test', configType: 'migrate', returnTo: 'verify-config' });
     });
     container.querySelector('#btn-start').addEventListener('click', async () => {
+      TransferConfigScreen.readAdvancedValues.call({ config: this.config }, container);
       await this.saveConfig();
       const args = [];
       if (this.config._verbose) args.push('--verbose');


### PR DESCRIPTION
Changes Made
transfer-config.js

Added excludeBranches text field (comma-separated) after the "sync branches" checkbox Added stateFile text field in the Progress Recovery advanced section Added projectVerification.concurrency number field in the Speed & Resources advanced section Added excludeBranches row in the review summary
Added read logic for all 3 new fields
migrate-config.js

Added excludeBranches text field after the "sync branches" checkbox Added read logic and review summary row
(Enterprise key was added in the earlier round)
verify-config.js

Updated defaults: added excludeBranches, checkpoint object, corrected performance defaults Added the full advanced collapsible section (rate-limit, performance, checkpoint) via TransferConfigScreen.renderAdvancedHtml Added readAdvancedValues calls before save
sync-metadata-config.js

Same as verify: updated defaults, added advanced collapsible, added read logic config-store.js

Added projectVerification: { concurrency: 3 } to performance defaults in both transferConfig and migrateConfig The desktop app UI now has full parity with the backend config schemas.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes persisted config defaults and wires new inputs into transfer/migrate/verify/sync flows, which could alter runtime behavior (concurrency, checkpoint/state handling) if values are mis-set or migration code assumes older shapes.
> 
> **Overview**
> Adds desktop UI/config parity for transfer-related settings across wizards.
> 
> Users can now *exclude specific branches* via a comma-separated `excludeBranches` field, and the review screens display the excluded list. The advanced settings UI now exposes `stateFile` and a new `performance.projectVerification.concurrency` knob, and `verify`/`sync-metadata` screens now include the shared advanced collapsible and read those values before saving/running.
> 
> Updates `electron-store` schema defaults (`config-store.js`) to include `projectVerification` performance defaults (and aligns default `transfer` shape for checkpoint/excluded branches where used).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5de6185b5e9b25632b4227f42b2abaab73a6a5cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->