### PR TITLE
only trigger on main

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -8,8 +8,6 @@ name: SonarCloud Analysis
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 # -------- Permissions --------
 permissions:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,8 +7,6 @@ name: Unit Tests
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 # -------- Permissions --------
 permissions:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low code risk, but it reduces CI coverage by no longer running SonarCloud analysis and unit tests on pull requests, which could let issues slip in before merge.
> 
> **Overview**
> Both `SonarCloud Analysis` and `Unit Tests` GitHub Actions workflows are changed to **stop running on `pull_request` events** and now trigger **only on pushes to `main`**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc2ba44cb0637c14416f366e4b4cac1cd864a6cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->