### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,14 @@ You will get an error when opening the desktop app for the first time:
 <img width="267" height="313" alt="image" src="https://github.com/user-attachments/assets/dbd5abc8-800a-457a-8312-71cbec18fdb5" />
 
 Now, **PROCEED TO DO THE FOLLOWING** for it to work:
-- Open your Terminal and unblock permissions by running this command: `xattr -cr "CloudVoyager Desktop.app"`.
-- Or if that does not work, older versions use an older command `xattr -c /Applications/CloudVoyager\ Desktop.app`
+- Open your Terminal and unblock permissions by running this command: 
+
+  `xattr -cr "CloudVoyager Desktop.app"`
+  
+- Or if that does not work, older versions use an older command
+
+  `xattr -c /Applications/CloudVoyager\ Desktop.app`
+
 - This only happens for MacOS due to MacOS in-built Gatekeeper permissions. After running the command above, you should be able to run CloudVoyager Desktop.
 - For Windows and Linux users, you will not face this issue.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that reformats the macOS `xattr` workaround instructions; no code or behavior is affected.
> 
> **Overview**
> Clarifies the README instructions for macOS Gatekeeper first-run errors by splitting the `xattr` workaround into two separate bullet steps with standalone, copy-pastable commands (current vs. older versions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e271e306ccd8a7f3112dff06a3904bada964404f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->