### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ The execution screen features real-time progress tracking with an animated pixel
 Download the latest version from the [releases page](https://github.com/sonar-solutions/cloudvoyager/releases).
 
 **NEXT, PLEASE DO THE BELOW**: 
+
 You will get an error when opening the desktop app for the first time:
 
 <img width="267" height="313" alt="image" src="https://github.com/user-attachments/assets/dbd5abc8-800a-457a-8312-71cbec18fdb5" />
 
 Now, **PROCEED TO DO THE FOLLOWING** for it to work:
+
 - Open your Terminal and unblock permissions by running this command: 
 
   `xattr -cr "CloudVoyager Desktop.app"`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that adjusts spacing around the macOS first-run Gatekeeper instructions; no code or runtime behavior is affected.
> 
> **Overview**
> Adds minor formatting/spacing in `README.md` around the **macOS first-run Gatekeeper** instructions for the Desktop app (the `xattr` unblock steps), improving readability without changing any functionality.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d719b6c3a7f51ef9b24df50a7126fa2b9f083aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->