### PR TITLE
Issue #95 - Ensure project settings are migrated if possible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloudvoyager",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cloudvoyager",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.16",

--- a/src/pipelines/sq-10.0/sonarcloud/api/project-config/helpers/set-project-setting.js
+++ b/src/pipelines/sq-10.0/sonarcloud/api/project-config/helpers/set-project-setting.js
@@ -1,14 +1,10 @@
 // -------- Set Project Setting --------
 
 import logger from '../../../../../../shared/utils/logger.js';
+import { buildSettingsParams } from '../../../../../../shared/utils/settings-params.js';
 
 export async function setProjectSetting(client, key, { value, values, fieldValues } = {}, component) {
   logger.debug(`Setting ${key} on project ${component}`);
-  const params = new URLSearchParams();
-  params.append('key', key);
-  params.append('component', component);
-  if (value !== undefined && value !== null) params.append('value', value);
-  if (values?.length) values.forEach(v => params.append('values', v));
-  if (fieldValues?.length) fieldValues.forEach(fv => params.append('fieldValues', JSON.stringify(fv)));
+  const params = buildSettingsParams({ key, component, value, values, fieldValues });
   await client.post(`/api/settings/set?${params.toString()}`, null);
 }

--- a/src/pipelines/sq-10.0/sonarcloud/api/project-config/helpers/set-project-setting.js
+++ b/src/pipelines/sq-10.0/sonarcloud/api/project-config/helpers/set-project-setting.js
@@ -2,7 +2,13 @@
 
 import logger from '../../../../../../shared/utils/logger.js';
 
-export async function setProjectSetting(client, key, value, component) {
+export async function setProjectSetting(client, key, { value, values, fieldValues } = {}, component) {
   logger.debug(`Setting ${key} on project ${component}`);
-  await client.post('/api/settings/set', null, { params: { key, value, component } });
+  const params = new URLSearchParams();
+  params.append('key', key);
+  params.append('component', component);
+  if (value !== undefined && value !== null) params.append('value', value);
+  if (values?.length) values.forEach(v => params.append('values', v));
+  if (fieldValues?.length) fieldValues.forEach(fv => params.append('fieldValues', JSON.stringify(fv)));
+  await client.post(`/api/settings/set?${params.toString()}`, null);
 }

--- a/src/pipelines/sq-10.0/sonarcloud/migrators/project-config/helpers/migrate-project-settings.js
+++ b/src/pipelines/sq-10.0/sonarcloud/migrators/project-config/helpers/migrate-project-settings.js
@@ -1,4 +1,5 @@
 import logger from '../../../../../../shared/utils/logger.js';
+import { dispatchSettingToApi } from '../../../../../../shared/utils/settings-params.js';
 
 // -------- Migrate Project Settings --------
 
@@ -7,16 +8,7 @@ export async function migrateProjectSettings(projectKey, settings, client) {
 
   for (const setting of settings) {
     try {
-      if (setting.value) {
-        await client.setProjectSetting(setting.key, { value: setting.value }, projectKey);
-      } else if (setting.values?.length) {
-        await client.setProjectSetting(setting.key, { values: setting.values }, projectKey);
-      } else if (setting.fieldValues?.length) {
-        await client.setProjectSetting(setting.key, { fieldValues: setting.fieldValues }, projectKey);
-      } else {
-        continue;
-      }
-      logger.debug(`Set setting ${setting.key} on ${projectKey}`);
+      await dispatchSettingToApi(client, setting, projectKey);
     } catch (error) {
       logger.warn(`Failed to set setting ${setting.key} on ${projectKey}: ${error.message}`);
     }

--- a/src/pipelines/sq-10.0/sonarcloud/migrators/project-config/helpers/migrate-project-settings.js
+++ b/src/pipelines/sq-10.0/sonarcloud/migrators/project-config/helpers/migrate-project-settings.js
@@ -7,13 +7,18 @@ export async function migrateProjectSettings(projectKey, settings, client) {
 
   for (const setting of settings) {
     try {
-      const value = setting.value || (setting.values ? setting.values.join(',') : '');
-      if (value) {
-        await client.setProjectSetting(setting.key, value, projectKey);
-        logger.debug(`Set setting ${setting.key} on ${projectKey}`);
+      if (setting.value) {
+        await client.setProjectSetting(setting.key, { value: setting.value }, projectKey);
+      } else if (setting.values?.length) {
+        await client.setProjectSetting(setting.key, { values: setting.values }, projectKey);
+      } else if (setting.fieldValues?.length) {
+        await client.setProjectSetting(setting.key, { fieldValues: setting.fieldValues }, projectKey);
+      } else {
+        continue;
       }
+      logger.debug(`Set setting ${setting.key} on ${projectKey}`);
     } catch (error) {
-      logger.debug(`Failed to set setting ${setting.key} on ${projectKey}: ${error.message}`);
+      logger.warn(`Failed to set setting ${setting.key} on ${projectKey}: ${error.message}`);
     }
   }
 }

--- a/src/pipelines/sq-10.4/sonarcloud/api/project-config/helpers/project-settings-api.js
+++ b/src/pipelines/sq-10.4/sonarcloud/api/project-config/helpers/project-settings-api.js
@@ -1,4 +1,5 @@
 import logger from '../../../../../../shared/utils/logger.js';
+import { buildSettingsParams } from '../../../../../../shared/utils/settings-params.js';
 
 // -------- Main Logic --------
 
@@ -6,12 +7,7 @@ import logger from '../../../../../../shared/utils/logger.js';
 
 export async function setProjectSetting(client, key, { value, values, fieldValues } = {}, component) {
   logger.debug(`Setting ${key} on project ${component}`);
-  const params = new URLSearchParams();
-  params.append('key', key);
-  params.append('component', component);
-  if (value !== undefined && value !== null) params.append('value', value);
-  if (values?.length) values.forEach(v => params.append('values', v));
-  if (fieldValues?.length) fieldValues.forEach(fv => params.append('fieldValues', JSON.stringify(fv)));
+  const params = buildSettingsParams({ key, component, value, values, fieldValues });
   await client.post(`/api/settings/set?${params.toString()}`, null);
 }
 

--- a/src/pipelines/sq-10.4/sonarcloud/api/project-config/helpers/project-settings-api.js
+++ b/src/pipelines/sq-10.4/sonarcloud/api/project-config/helpers/project-settings-api.js
@@ -4,9 +4,15 @@ import logger from '../../../../../../shared/utils/logger.js';
 
 // SonarCloud project settings and tags API calls.
 
-export async function setProjectSetting(client, key, value, component) {
+export async function setProjectSetting(client, key, { value, values, fieldValues } = {}, component) {
   logger.debug(`Setting ${key} on project ${component}`);
-  await client.post('/api/settings/set', null, { params: { key, value, component } });
+  const params = new URLSearchParams();
+  params.append('key', key);
+  params.append('component', component);
+  if (value !== undefined && value !== null) params.append('value', value);
+  if (values?.length) values.forEach(v => params.append('values', v));
+  if (fieldValues?.length) fieldValues.forEach(fv => params.append('fieldValues', JSON.stringify(fv)));
+  await client.post(`/api/settings/set?${params.toString()}`, null);
 }
 
 export async function setProjectTags(client, projectKey, tags) {

--- a/src/pipelines/sq-10.4/sonarcloud/migrators/project-config/helpers/migrate-project-settings.js
+++ b/src/pipelines/sq-10.4/sonarcloud/migrators/project-config/helpers/migrate-project-settings.js
@@ -1,4 +1,5 @@
 import logger from '../../../../../../shared/utils/logger.js';
+import { dispatchSettingToApi } from '../../../../../../shared/utils/settings-params.js';
 
 // -------- Main Logic --------
 
@@ -7,16 +8,7 @@ export async function migrateProjectSettings(projectKey, settings, client) {
   logger.info(`Migrating ${settings.length} project settings for ${projectKey}`);
   for (const setting of settings) {
     try {
-      if (setting.value) {
-        await client.setProjectSetting(setting.key, { value: setting.value }, projectKey);
-      } else if (setting.values?.length) {
-        await client.setProjectSetting(setting.key, { values: setting.values }, projectKey);
-      } else if (setting.fieldValues?.length) {
-        await client.setProjectSetting(setting.key, { fieldValues: setting.fieldValues }, projectKey);
-      } else {
-        continue;
-      }
-      logger.debug(`Set setting ${setting.key} on ${projectKey}`);
+      await dispatchSettingToApi(client, setting, projectKey);
     } catch (error) {
       logger.warn(`Failed to set setting ${setting.key} on ${projectKey}: ${error.message}`);
     }

--- a/src/pipelines/sq-10.4/sonarcloud/migrators/project-config/helpers/migrate-project-settings.js
+++ b/src/pipelines/sq-10.4/sonarcloud/migrators/project-config/helpers/migrate-project-settings.js
@@ -7,13 +7,18 @@ export async function migrateProjectSettings(projectKey, settings, client) {
   logger.info(`Migrating ${settings.length} project settings for ${projectKey}`);
   for (const setting of settings) {
     try {
-      const value = setting.value || (setting.values ? setting.values.join(',') : '');
-      if (value) {
-        await client.setProjectSetting(setting.key, value, projectKey);
-        logger.debug(`Set setting ${setting.key} on ${projectKey}`);
+      if (setting.value) {
+        await client.setProjectSetting(setting.key, { value: setting.value }, projectKey);
+      } else if (setting.values?.length) {
+        await client.setProjectSetting(setting.key, { values: setting.values }, projectKey);
+      } else if (setting.fieldValues?.length) {
+        await client.setProjectSetting(setting.key, { fieldValues: setting.fieldValues }, projectKey);
+      } else {
+        continue;
       }
+      logger.debug(`Set setting ${setting.key} on ${projectKey}`);
     } catch (error) {
-      logger.debug(`Failed to set setting ${setting.key} on ${projectKey}: ${error.message}`);
+      logger.warn(`Failed to set setting ${setting.key} on ${projectKey}: ${error.message}`);
     }
   }
 }

--- a/src/pipelines/sq-2025/sonarcloud/api/project-config/helpers/set-project-setting.js
+++ b/src/pipelines/sq-2025/sonarcloud/api/project-config/helpers/set-project-setting.js
@@ -1,14 +1,10 @@
 import logger from '../../../../../../shared/utils/logger.js';
+import { buildSettingsParams } from '../../../../../../shared/utils/settings-params.js';
 
 // -------- Set Project Setting --------
 
 export async function setProjectSetting(client, key, { value, values, fieldValues } = {}, component) {
   logger.debug(`Setting ${key} on project ${component}`);
-  const params = new URLSearchParams();
-  params.append('key', key);
-  params.append('component', component);
-  if (value !== undefined && value !== null) params.append('value', value);
-  if (values?.length) values.forEach(v => params.append('values', v));
-  if (fieldValues?.length) fieldValues.forEach(fv => params.append('fieldValues', JSON.stringify(fv)));
+  const params = buildSettingsParams({ key, component, value, values, fieldValues });
   await client.post(`/api/settings/set?${params.toString()}`, null);
 }

--- a/src/pipelines/sq-2025/sonarcloud/api/project-config/helpers/set-project-setting.js
+++ b/src/pipelines/sq-2025/sonarcloud/api/project-config/helpers/set-project-setting.js
@@ -2,7 +2,13 @@ import logger from '../../../../../../shared/utils/logger.js';
 
 // -------- Set Project Setting --------
 
-export async function setProjectSetting(client, key, value, component) {
+export async function setProjectSetting(client, key, { value, values, fieldValues } = {}, component) {
   logger.debug(`Setting ${key} on project ${component}`);
-  await client.post('/api/settings/set', null, { params: { key, value, component } });
+  const params = new URLSearchParams();
+  params.append('key', key);
+  params.append('component', component);
+  if (value !== undefined && value !== null) params.append('value', value);
+  if (values?.length) values.forEach(v => params.append('values', v));
+  if (fieldValues?.length) fieldValues.forEach(fv => params.append('fieldValues', JSON.stringify(fv)));
+  await client.post(`/api/settings/set?${params.toString()}`, null);
 }

--- a/src/pipelines/sq-2025/sonarcloud/migrators/project-config/helpers/migrate-project-settings.js
+++ b/src/pipelines/sq-2025/sonarcloud/migrators/project-config/helpers/migrate-project-settings.js
@@ -8,13 +8,18 @@ export async function migrateProjectSettings(projectKey, settings, client) {
 
   for (const setting of settings) {
     try {
-      const value = setting.value || (setting.values ? setting.values.join(',') : '');
-      if (value) {
-        await client.setProjectSetting(setting.key, value, projectKey);
-        logger.debug(`Set setting ${setting.key} on ${projectKey}`);
+      if (setting.value) {
+        await client.setProjectSetting(setting.key, { value: setting.value }, projectKey);
+      } else if (setting.values?.length) {
+        await client.setProjectSetting(setting.key, { values: setting.values }, projectKey);
+      } else if (setting.fieldValues?.length) {
+        await client.setProjectSetting(setting.key, { fieldValues: setting.fieldValues }, projectKey);
+      } else {
+        continue;
       }
+      logger.debug(`Set setting ${setting.key} on ${projectKey}`);
     } catch (error) {
-      logger.debug(`Failed to set setting ${setting.key} on ${projectKey}: ${error.message}`);
+      logger.warn(`Failed to set setting ${setting.key} on ${projectKey}: ${error.message}`);
     }
   }
 }

--- a/src/pipelines/sq-2025/sonarcloud/migrators/project-config/helpers/migrate-project-settings.js
+++ b/src/pipelines/sq-2025/sonarcloud/migrators/project-config/helpers/migrate-project-settings.js
@@ -1,4 +1,5 @@
 import logger from '../../../../../../shared/utils/logger.js';
+import { dispatchSettingToApi } from '../../../../../../shared/utils/settings-params.js';
 
 // -------- Migrate Project Settings --------
 
@@ -8,16 +9,7 @@ export async function migrateProjectSettings(projectKey, settings, client) {
 
   for (const setting of settings) {
     try {
-      if (setting.value) {
-        await client.setProjectSetting(setting.key, { value: setting.value }, projectKey);
-      } else if (setting.values?.length) {
-        await client.setProjectSetting(setting.key, { values: setting.values }, projectKey);
-      } else if (setting.fieldValues?.length) {
-        await client.setProjectSetting(setting.key, { fieldValues: setting.fieldValues }, projectKey);
-      } else {
-        continue;
-      }
-      logger.debug(`Set setting ${setting.key} on ${projectKey}`);
+      await dispatchSettingToApi(client, setting, projectKey);
     } catch (error) {
       logger.warn(`Failed to set setting ${setting.key} on ${projectKey}: ${error.message}`);
     }

--- a/src/pipelines/sq-9.9/sonarcloud/api/project-config/helpers/project-settings.js
+++ b/src/pipelines/sq-9.9/sonarcloud/api/project-config/helpers/project-settings.js
@@ -1,15 +1,11 @@
 import logger from '../../../../../../shared/utils/logger.js';
+import { buildSettingsParams } from '../../../../../../shared/utils/settings-params.js';
 
 // -------- Project Settings API Methods --------
 
 export async function setProjectSetting(client, key, { value, values, fieldValues } = {}, component) {
   logger.debug(`Setting ${key} on project ${component}`);
-  const params = new URLSearchParams();
-  params.append('key', key);
-  params.append('component', component);
-  if (value !== undefined && value !== null) params.append('value', value);
-  if (values?.length) values.forEach(v => params.append('values', v));
-  if (fieldValues?.length) fieldValues.forEach(fv => params.append('fieldValues', JSON.stringify(fv)));
+  const params = buildSettingsParams({ key, component, value, values, fieldValues });
   await client.post(`/api/settings/set?${params.toString()}`, null);
 }
 

--- a/src/pipelines/sq-9.9/sonarcloud/api/project-config/helpers/project-settings.js
+++ b/src/pipelines/sq-9.9/sonarcloud/api/project-config/helpers/project-settings.js
@@ -2,9 +2,15 @@ import logger from '../../../../../../shared/utils/logger.js';
 
 // -------- Project Settings API Methods --------
 
-export async function setProjectSetting(client, key, value, component) {
+export async function setProjectSetting(client, key, { value, values, fieldValues } = {}, component) {
   logger.debug(`Setting ${key} on project ${component}`);
-  await client.post('/api/settings/set', null, { params: { key, value, component } });
+  const params = new URLSearchParams();
+  params.append('key', key);
+  params.append('component', component);
+  if (value !== undefined && value !== null) params.append('value', value);
+  if (values?.length) values.forEach(v => params.append('values', v));
+  if (fieldValues?.length) fieldValues.forEach(fv => params.append('fieldValues', JSON.stringify(fv)));
+  await client.post(`/api/settings/set?${params.toString()}`, null);
 }
 
 export async function setProjectTags(client, projectKey, tags) {

--- a/src/pipelines/sq-9.9/sonarcloud/migrators/project-config/helpers/migrate-project-settings.js
+++ b/src/pipelines/sq-9.9/sonarcloud/migrators/project-config/helpers/migrate-project-settings.js
@@ -1,4 +1,5 @@
 import logger from '../../../../../../shared/utils/logger.js';
+import { dispatchSettingToApi } from '../../../../../../shared/utils/settings-params.js';
 
 // -------- Migrate Project Settings --------
 
@@ -7,16 +8,7 @@ export async function migrateProjectSettings(projectKey, settings, client) {
 
   for (const setting of settings) {
     try {
-      if (setting.value) {
-        await client.setProjectSetting(setting.key, { value: setting.value }, projectKey);
-      } else if (setting.values?.length) {
-        await client.setProjectSetting(setting.key, { values: setting.values }, projectKey);
-      } else if (setting.fieldValues?.length) {
-        await client.setProjectSetting(setting.key, { fieldValues: setting.fieldValues }, projectKey);
-      } else {
-        continue;
-      }
-      logger.debug(`Set setting ${setting.key} on ${projectKey}`);
+      await dispatchSettingToApi(client, setting, projectKey);
     } catch (error) {
       logger.warn(`Failed to set setting ${setting.key} on ${projectKey}: ${error.message}`);
     }

--- a/src/pipelines/sq-9.9/sonarcloud/migrators/project-config/helpers/migrate-project-settings.js
+++ b/src/pipelines/sq-9.9/sonarcloud/migrators/project-config/helpers/migrate-project-settings.js
@@ -7,13 +7,18 @@ export async function migrateProjectSettings(projectKey, settings, client) {
 
   for (const setting of settings) {
     try {
-      const value = setting.value || (setting.values ? setting.values.join(',') : '');
-      if (value) {
-        await client.setProjectSetting(setting.key, value, projectKey);
-        logger.debug(`Set setting ${setting.key} on ${projectKey}`);
+      if (setting.value) {
+        await client.setProjectSetting(setting.key, { value: setting.value }, projectKey);
+      } else if (setting.values?.length) {
+        await client.setProjectSetting(setting.key, { values: setting.values }, projectKey);
+      } else if (setting.fieldValues?.length) {
+        await client.setProjectSetting(setting.key, { fieldValues: setting.fieldValues }, projectKey);
+      } else {
+        continue;
       }
+      logger.debug(`Set setting ${setting.key} on ${projectKey}`);
     } catch (error) {
-      logger.debug(`Failed to set setting ${setting.key} on ${projectKey}: ${error.message}`);
+      logger.warn(`Failed to set setting ${setting.key} on ${projectKey}: ${error.message}`);
     }
   }
 }

--- a/src/shared/utils/settings-params.js
+++ b/src/shared/utils/settings-params.js
@@ -1,0 +1,37 @@
+import logger from './logger.js';
+
+/**
+ * Build URLSearchParams for the SonarCloud POST /api/settings/set endpoint.
+ *
+ * Handles the three value shapes the API accepts:
+ *  - scalar `value` for single-value settings
+ *  - repeated `values` for multi-value (TEXT_ARRAY) settings
+ *  - repeated `fieldValues` (JSON-encoded) for property-set settings
+ */
+export function buildSettingsParams({ key, component, value, values, fieldValues }) {
+  const params = new URLSearchParams();
+  params.append('key', key);
+  params.append('component', component);
+  if (value !== undefined && value !== null) params.append('value', value);
+  if (values?.length) values.forEach(v => params.append('values', v));
+  if (fieldValues?.length) fieldValues.forEach(fv => params.append('fieldValues', JSON.stringify(fv)));
+  return params;
+}
+
+/**
+ * Resolve which value shape a setting carries and forward it to the client API.
+ * Returns true if a value was dispatched, false if the setting was empty/skipped.
+ */
+export async function dispatchSettingToApi(client, setting, projectKey) {
+  if (setting.value) {
+    await client.setProjectSetting(setting.key, { value: setting.value }, projectKey);
+  } else if (setting.values?.length) {
+    await client.setProjectSetting(setting.key, { values: setting.values }, projectKey);
+  } else if (setting.fieldValues?.length) {
+    await client.setProjectSetting(setting.key, { fieldValues: setting.fieldValues }, projectKey);
+  } else {
+    return false;
+  }
+  logger.debug(`Set setting ${setting.key} on ${projectKey}`);
+  return true;
+}

--- a/test/sonarcloud/migrators/migrators.test.js
+++ b/test/sonarcloud/migrators/migrators.test.js
@@ -1133,10 +1133,10 @@ test('migrateProjectSettings sets settings with value field', async t => {
   await migrateProjectSettings('proj', settings, client);
 
   t.is(client.setProjectSetting.callCount, 1);
-  t.deepEqual(client.setProjectSetting.firstCall.args, ['sonar.coverage.exclusions', '**/*.test.js', 'proj']);
+  t.deepEqual(client.setProjectSetting.firstCall.args, ['sonar.coverage.exclusions', { value: '**/*.test.js' }, 'proj']);
 });
 
-test('migrateProjectSettings joins values array', async t => {
+test('migrateProjectSettings passes values array without joining', async t => {
   const client = mockClient();
   const settings = [
     { key: 'sonar.exclusions', values: ['**/*.test.js', '**/*.spec.js'] }
@@ -1145,19 +1145,99 @@ test('migrateProjectSettings joins values array', async t => {
   await migrateProjectSettings('proj', settings, client);
 
   t.is(client.setProjectSetting.callCount, 1);
-  t.is(client.setProjectSetting.firstCall.args[1], '**/*.test.js,**/*.spec.js');
+  t.deepEqual(client.setProjectSetting.firstCall.args, [
+    'sonar.exclusions',
+    { values: ['**/*.test.js', '**/*.spec.js'] },
+    'proj'
+  ]);
+});
+
+test('migrateProjectSettings passes fieldValues to API', async t => {
+  const client = mockClient();
+  const settings = [
+    { key: 'sonar.issue.enforce.multicriteria', fieldValues: [{ resourceKey: '**/*.js', ruleKey: 'squid:S001' }] }
+  ];
+
+  await migrateProjectSettings('proj', settings, client);
+
+  t.is(client.setProjectSetting.callCount, 1);
+  t.deepEqual(client.setProjectSetting.firstCall.args, [
+    'sonar.issue.enforce.multicriteria',
+    { fieldValues: [{ resourceKey: '**/*.js', ruleKey: 'squid:S001' }] },
+    'proj'
+  ]);
+});
+
+test('migrateProjectSettings prefers value over values when both present', async t => {
+  const client = mockClient();
+  const settings = [
+    { key: 'sonar.mixed', value: 'scalar', values: ['a', 'b'] }
+  ];
+
+  await migrateProjectSettings('proj', settings, client);
+
+  t.is(client.setProjectSetting.callCount, 1);
+  t.deepEqual(client.setProjectSetting.firstCall.args, ['sonar.mixed', { value: 'scalar' }, 'proj']);
+});
+
+test('migrateProjectSettings handles single-element values array', async t => {
+  const client = mockClient();
+  const settings = [
+    { key: 'sonar.exclusions', values: ['**/*.test.js'] }
+  ];
+
+  await migrateProjectSettings('proj', settings, client);
+
+  t.is(client.setProjectSetting.callCount, 1);
+  t.deepEqual(client.setProjectSetting.firstCall.args, [
+    'sonar.exclusions',
+    { values: ['**/*.test.js'] },
+    'proj'
+  ]);
+});
+
+test('migrateProjectSettings handles boolean string values', async t => {
+  const client = mockClient();
+  const settings = [
+    { key: 'sonar.scm.disabled', value: 'false' },
+    { key: 'sonar.cpd.enabled', value: 'true' }
+  ];
+
+  await migrateProjectSettings('proj', settings, client);
+
+  t.is(client.setProjectSetting.callCount, 2);
+  t.deepEqual(client.setProjectSetting.firstCall.args, ['sonar.scm.disabled', { value: 'false' }, 'proj']);
+  t.deepEqual(client.setProjectSetting.secondCall.args, ['sonar.cpd.enabled', { value: 'true' }, 'proj']);
 });
 
 test('migrateProjectSettings skips settings with no value', async t => {
   const client = mockClient();
   const settings = [
     { key: 'sonar.empty' },
-    { key: 'sonar.empty.values', values: [] }
+    { key: 'sonar.empty.values', values: [] },
+    { key: 'sonar.empty.fv', fieldValues: [] }
   ];
 
   await migrateProjectSettings('proj', settings, client);
 
   t.is(client.setProjectSetting.callCount, 0);
+});
+
+test('migrateProjectSettings continues after failure on one setting', async t => {
+  const client = mockClient({
+    setProjectSetting: sinon.stub()
+      .onFirstCall().rejects(new Error('fail'))
+      .onSecondCall().resolves({})
+  });
+  const settings = [
+    { key: 'sonar.bad', value: 'x' },
+    { key: 'sonar.good', value: 'y' }
+  ];
+
+  await migrateProjectSettings('proj', settings, client);
+
+  t.is(client.setProjectSetting.callCount, 2);
+  t.deepEqual(client.setProjectSetting.secondCall.args, ['sonar.good', { value: 'y' }, 'proj']);
 });
 
 test('migrateProjectSettings handles setting failure gracefully', async t => {

--- a/test/sonarqube/extractors/extractors.test.js
+++ b/test/sonarqube/extractors/extractors.test.js
@@ -724,6 +724,22 @@ test('extractProjectSettings filters non-inherited settings', async t => {
   t.is(result[0].key, 'sonar.coverage.exclusions');
 });
 
+test('extractProjectSettings preserves values array and fieldValues', async t => {
+  const client = mockClient({
+    getProjectSettings: sinon.stub().resolves([
+      { key: 'sonar.exclusions', values: ['**/*.test.js', '**/*.spec.js'], inherited: false },
+      { key: 'sonar.issue.enforce.multicriteria', fieldValues: [{ resourceKey: '**/*.js', ruleKey: 'squid:S001' }], inherited: false },
+      { key: 'sonar.global', value: 'x', inherited: true }
+    ])
+  });
+  const result = await extractProjectSettings(client);
+  t.is(result.length, 2);
+  t.deepEqual(result[0].values, ['**/*.test.js', '**/*.spec.js']);
+  t.deepEqual(result[0].fieldValues, []);
+  t.deepEqual(result[1].fieldValues, [{ resourceKey: '**/*.js', ruleKey: 'squid:S001' }]);
+  t.deepEqual(result[1].values, []);
+});
+
 // === project-tags.js ===
 test('extractProjectTags returns tags', async t => {
   const client = mockClient({


### PR DESCRIPTION
All 13 tests pass (12 unit + 1 pipeline-level). Here's the detailed summary:

## Test Summary for PR #95 Fix

### Context

When migrating a SonarQube Server project to SonarQube Cloud, project-level configuration settings (e.g., `sonar.exclusions`, `sonar.coverage.exclusions`) were silently dropped. The SonarCloud `POST /api/settings/set` API requires multi-value settings like `sonar.exclusions` to be sent as repeated `values` params (`values=a&values=b`), but the migrator was joining them into a single `value=a,b` param. Property-set settings (`fieldValues`) were never sent at all. Failures were logged at `debug` level, making them invisible.

### Unit Tests -- Extractor (`extractProjectSettings`)

| # | Test | What it verifies | Result |
|---|------|------------------|--------|
| 1 | Filters non-inherited settings | Settings marked `inherited: true` by the SonarQube API (global/parent defaults) are excluded; only project-level overrides are extracted | Pass |
| 2 | Preserves `values` array and `fieldValues` | Multi-value settings (e.g., `sonar.exclusions`) keep their `values` as an array; property-set settings keep their `fieldValues` objects; missing fields default to `[]` | Pass |

### Unit Tests -- Migrator (`migrateProjectSettings`)

| # | Test | What it verifies | Result |
|---|------|------------------|--------|
| 1 | Scalar `value` setting | A single-value setting like `sonar.coverage.exclusions: "**/*.test.js"` is sent as `{ value }` to the API | Pass |
| 2 | `values` array without joining | **[Core fix]** A multi-value setting like `sonar.exclusions: ["**/*.test.js", "**/*.spec.js"]` is sent as `{ values: [...] }`, not a comma-joined string | Pass |
| 3 | `fieldValues` passed to API | **[Core fix]** A property-set setting like `sonar.issue.enforce.multicriteria` with `fieldValues` is now sent to the API instead of being silently skipped | Pass |
| 4 | `value` wins when both present | If the API returns both `value` and `values` on the same setting, the scalar `value` takes priority | Pass |
| 5 | Single-element `values` array | A `values` array with one entry is still sent as `values` param (not collapsed to `value`) | Pass |
| 6 | Boolean string values | Settings like `sonar.scm.disabled: "false"` are truthy strings and get migrated correctly | Pass |
| 7 | Skips empty settings | Settings with no `value`, empty `values: []`, or empty `fieldValues: []` are skipped (no API call) | Pass |
| 8 | Continues after one failure | **[Error visibility fix]** If the API rejects one setting, the remaining settings are still migrated | Pass |
| 9 | Graceful error handling | API failures don't crash the migration; errors are caught and logged at `warn` level | Pass |
| 10 | Empty settings list | No API calls are made when there are no project settings to migrate | Pass |

### Pipeline / Functional Test (`migrateAll`)

| # | Test | What it verifies | Result |
|---|------|------------------|--------|
| 1 | `--only project-settings` runs full pipeline | End-to-end: SonarQube extraction -> project settings/tags/links/NCP/DevOps binding migration -> SonarCloud write; non-settings steps (scanner upload, issue sync) are correctly skipped | Pass |