### PR TITLE
Issue #60 - Add enterprise key validation feature

### DIFF
--- a/desktop/src/main/ipc-handlers.js
+++ b/desktop/src/main/ipc-handlers.js
@@ -139,6 +139,30 @@ function registerIpcHandlers(getMainWindow) {
     }
   });
 
+  // Enterprise key validation
+  ipcMain.handle('enterprise:validate', async (_event, key, token, url) => {
+    try {
+      const baseUrl = (url || 'https://sonarcloud.io').replace(/\/+$/, '');
+      const response = await fetch(`${baseUrl}/api/v2/enterprises?enterpriseKey=${encodeURIComponent(key)}`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      if (response.ok) {
+        const data = await response.json();
+        const enterprises = data.enterprises || [];
+        if (enterprises.some(e => e.key === key)) {
+          return { valid: true };
+        }
+        return { valid: false, error: 'Enterprise key not found. Check the key and try again.' };
+      }
+      if (response.status === 401 || response.status === 403) {
+        return { valid: false, error: 'Authentication failed. Ensure your organization token has access to this enterprise.' };
+      }
+      return { valid: false, error: `Unexpected response (HTTP ${response.status})` };
+    } catch (err) {
+      return { valid: false, error: err.message || 'Network error while validating enterprise key' };
+    }
+  });
+
   // CLI handlers
   ipcMain.handle('cli:run', (_event, command, args, configType, resumeRunDir) => {
     const allConfig = loadAll();

--- a/desktop/src/preload/preload.js
+++ b/desktop/src/preload/preload.js
@@ -24,6 +24,9 @@ contextBridge.exposeInMainWorld('cloudvoyager', {
       return () => ipcRenderer.removeListener('cli:exit', handler);
     }
   },
+  enterprise: {
+    validate: (key, token, url) => ipcRenderer.invoke('enterprise:validate', key, token, url)
+  },
   dialog: {
     selectFolder: () => ipcRenderer.invoke('dialog:select-folder'),
     selectFile: () => ipcRenderer.invoke('dialog:select-file')

--- a/desktop/src/renderer/js/screens/advanced-settings/defaults.js
+++ b/desktop/src/renderer/js/screens/advanced-settings/defaults.js
@@ -31,5 +31,8 @@ window.ADVANCED_DEFAULTS = {
     strictResume: false
   },
 
-  stateFile: './.cloudvoyager-state.json'
+  stateFile: './.cloudvoyager-state.json',
+
+  // -------- Migration Behavior --------
+  allowNoEnterpriseKey: false
 };

--- a/desktop/src/renderer/js/screens/advanced-settings/reader.js
+++ b/desktop/src/renderer/js/screens/advanced-settings/reader.js
@@ -36,7 +36,8 @@ window.AdvancedSettingsReader = {
         cacheMaxAgeDays: numVal('cp-maxage', d.checkpoint.cacheMaxAgeDays),
         strictResume: chk('cp-strict') || false
       },
-      stateFile: val('cp-statefile') || d.stateFile
+      stateFile: val('cp-statefile') || d.stateFile,
+      allowNoEnterpriseKey: chk('allow-no-enterprise-key') || false
     };
   }
 };

--- a/desktop/src/renderer/js/screens/advanced-settings/renderer.js
+++ b/desktop/src/renderer/js/screens/advanced-settings/renderer.js
@@ -19,6 +19,7 @@ window.AdvancedSettingsScreen = {
         <p>Fine-tune performance, throttling, and progress recovery</p>
       </div>
 
+      ${this.renderMigrationBehaviorCard()}
       ${this.renderThrottlingCard()}
       ${this.renderPerformanceCard()}
       ${this.renderRecoveryCard()}
@@ -34,6 +35,15 @@ window.AdvancedSettingsScreen = {
 
     ConfigForm.attachHandlers(container);
     this.attachEventListeners(container);
+  },
+
+  renderMigrationBehaviorCard() {
+    return `
+      <div class="card">
+        <div class="card-header">Migration Behavior</div>
+        ${ConfigForm.checkbox('allow-no-enterprise-key', 'Allow migration without enterprise key', this.config.allowNoEnterpriseKey || false, { hint: 'When enabled, the enterprise key becomes optional. Portfolios will not be migrated without an enterprise key. Intended for Sonar internal testing or team/free plan migrations.' })}
+      </div>
+    `;
   },
 
   renderThrottlingCard() {

--- a/desktop/src/renderer/js/screens/migrate-config.js
+++ b/desktop/src/renderer/js/screens/migrate-config.js
@@ -107,6 +107,10 @@ window.MigrateConfigScreen = {
     this.attachOrgHandlers(container);
     this._enterpriseValidated = false;
 
+    container.querySelector('#enterprise-key')?.addEventListener('input', () => {
+      this._enterpriseValidated = false;
+    });
+
     container.querySelector('#btn-validate-enterprise').addEventListener('click', async () => {
       await this._validateEnterpriseKey(container);
     });

--- a/desktop/src/renderer/js/screens/migrate-config.js
+++ b/desktop/src/renderer/js/screens/migrate-config.js
@@ -16,12 +16,14 @@ window.MigrateConfigScreen = {
     const stored = await window.cloudvoyager.config.loadKey('migrateConfig');
     this.config = stored || {
       sonarqube: { url: '', token: '' },
-      sonarcloud: { enterprise: { key: '' }, organizations: [] },
+      sonarcloud: { organizations: [] },
       transfer: { mode: 'incremental', batchSize: 100, syncAllBranches: true, excludeBranches: [] },
       migrate: { outputDir: './migration-output', skipIssueMetadataSync: false, skipHotspotMetadataSync: false, skipQualityProfileSync: false, dryRun: false },
       rateLimit: { maxRetries: 3, baseDelay: 1000, minRequestInterval: 0 },
       performance: { autoTune: false, maxConcurrency: 64, maxMemoryMB: 8192 }
     };
+    const advancedConfig = await window.cloudvoyager.config.loadKey('advancedConfig');
+    this.allowNoEnterpriseKey = advancedConfig?.allowNoEnterpriseKey || false;
   },
 
   async render(container) {
@@ -77,6 +79,11 @@ window.MigrateConfigScreen = {
     });
 
     const enterprise = this.config.sonarcloud.enterprise || { key: '' };
+    const isRequired = !this.allowNoEnterpriseKey;
+    const headerLabel = isRequired ? 'Enterprise' : 'Enterprise (optional)';
+    const hintText = isRequired
+      ? 'Your SonarCloud enterprise key. The key will be validated before proceeding.'
+      : 'Optional. Without an enterprise key, portfolios will not be migrated.';
 
     container.innerHTML = `
       <div class="page-header">
@@ -84,8 +91,10 @@ window.MigrateConfigScreen = {
         <p>Add the SonarCloud organizations you want to migrate your data into</p>
       </div>
       <div class="card">
-        <div class="card-header">Enterprise (optional)</div>
-        ${ConfigForm.textField('enterprise-key', 'Enterprise Key', enterprise.key, { placeholder: 'my-enterprise', hint: 'Required for portfolio migration. Leave blank if not using enterprise features.' })}
+        <div class="card-header">${headerLabel}</div>
+        ${ConfigForm.textField('enterprise-key', 'Enterprise Key', enterprise.key, { placeholder: 'my-enterprise', required: isRequired, hint: hintText })}
+        <div id="enterprise-validation-status" style="margin-top:8px"></div>
+        <button class="btn btn-secondary btn-sm" id="btn-validate-enterprise" style="margin-top:8px">Validate Enterprise Key</button>
       </div>
       <div id="org-list">${orgsHtml}</div>
       <button class="add-org-btn" id="add-org">+ Add Organization</button>
@@ -96,20 +105,67 @@ window.MigrateConfigScreen = {
     `;
 
     this.attachOrgHandlers(container);
+    this._enterpriseValidated = false;
+
+    container.querySelector('#btn-validate-enterprise').addEventListener('click', async () => {
+      await this._validateEnterpriseKey(container);
+    });
+
     container.querySelector('#add-org').addEventListener('click', () => {
       this.readOrgs(container);
       this.config.sonarcloud.organizations.push({ key: '', token: '', url: 'https://sonarcloud.io' });
       this.renderStep(container, 1);
     });
     container.querySelector('#btn-back').addEventListener('click', () => this.renderStep(container, 0));
-    container.querySelector('#btn-next').addEventListener('click', () => {
+    container.querySelector('#btn-next').addEventListener('click', async () => {
       const orgResult = ConfigForm.validateOrgs(container);
       if (!orgResult.valid) return;
       this.readOrgs(container);
       const ek = container.querySelector('#enterprise-key')?.value.trim() || '';
-      this.config.sonarcloud.enterprise = { key: ek };
+
+      if (isRequired && !ek) return;
+
+      if (ek && !this._enterpriseValidated) {
+        const valid = await this._validateEnterpriseKey(container);
+        if (!valid) return;
+      }
+
+      if (ek) {
+        this.config.sonarcloud.enterprise = { key: ek };
+      } else {
+        delete this.config.sonarcloud.enterprise;
+      }
       this.saveAndNext(container);
     });
+  },
+
+  async _validateEnterpriseKey(container) {
+    const ek = container.querySelector('#enterprise-key')?.value.trim() || '';
+    const statusEl = container.querySelector('#enterprise-validation-status');
+    if (!ek) {
+      statusEl.innerHTML = '<span style="color:var(--warning)">Please enter an enterprise key to validate.</span>';
+      this._enterpriseValidated = false;
+      return false;
+    }
+
+    this.readOrgs(container);
+    const firstOrg = (this.config.sonarcloud.organizations || [])[0];
+    if (!firstOrg?.token) {
+      statusEl.innerHTML = '<span style="color:var(--warning)">Add at least one organization with a token first.</span>';
+      this._enterpriseValidated = false;
+      return false;
+    }
+
+    statusEl.innerHTML = '<span style="color:var(--text-secondary)">Validating...</span>';
+    const result = await window.cloudvoyager.enterprise.validate(ek, firstOrg.token, firstOrg.url || 'https://sonarcloud.io');
+    if (result.valid) {
+      statusEl.innerHTML = '<span style="color:var(--success)">Enterprise key validated successfully.</span>';
+      this._enterpriseValidated = true;
+      return true;
+    }
+    statusEl.innerHTML = `<span style="color:var(--error)">${result.error}</span>`;
+    this._enterpriseValidated = false;
+    return false;
   },
 
   renderOrgEntry(org, index) {
@@ -262,7 +318,9 @@ window.MigrateConfigScreen = {
           <span>${ConfigForm.icon('cloud')} SonarCloud Organizations (${orgs.length})</span>
           <button class="btn btn-sm btn-secondary" data-edit-step="1">Edit</button>
         </div>
-        ${enterprise.key ? ConfigForm.summaryTable([['Enterprise Key', enterprise.key]]) : ''}
+        ${enterprise.key
+          ? ConfigForm.summaryTable([['Enterprise Key', enterprise.key]])
+          : `<p style="font-size:13px;color:var(--warning);margin:8px 0">No enterprise key provided — portfolios will not be migrated.</p>`}
         ${ConfigForm.summaryTable(orgRows)}
       </div>
 

--- a/src/pipelines/sq-10.0/pipeline/org-migration/helpers/migrate-enterprise-portfolios.js
+++ b/src/pipelines/sq-10.0/pipeline/org-migration/helpers/migrate-enterprise-portfolios.js
@@ -5,8 +5,16 @@ import { migratePortfolios } from '../../../sonarcloud/migrators/portfolios.js';
 
 export async function migrateEnterprisePortfolios(extractedData, mergedProjectKeyMap, results, ctx) {
   const enterpriseConfig = ctx.enterpriseConfig;
-  if (!enterpriseConfig?.key) { logger.info('No enterprise key configured — skipping portfolio migration'); return; }
   const allPortfolios = extractedData.portfolios || [];
+  if (!enterpriseConfig?.key) {
+    if (allPortfolios.length > 0) {
+      results.portfoliosSkipped = (results.portfoliosSkipped || 0) + allPortfolios.length;
+      logger.warn(`No enterprise key configured — skipping ${allPortfolios.length} portfolio(s)`);
+    } else {
+      logger.info('No enterprise key configured — skipping portfolio migration');
+    }
+    return;
+  }
   if (allPortfolios.length === 0) { logger.info('No portfolios to migrate'); return; }
   if (ctx.onlyComponents?.includes('portfolios')) {
     logger.warn('Note: --only portfolios requires that projects are already migrated to SonarCloud.');

--- a/src/pipelines/sq-10.0/pipeline/org-migration/helpers/migrate-enterprise-portfolios.js
+++ b/src/pipelines/sq-10.0/pipeline/org-migration/helpers/migrate-enterprise-portfolios.js
@@ -1,4 +1,5 @@
 import logger from '../../../../../shared/utils/logger.js';
+import { handleMissingEnterpriseKey } from '../../../../../shared/utils/portfolio-skip.js';
 import { migratePortfolios } from '../../../sonarcloud/migrators/portfolios.js';
 
 // -------- Migrate Enterprise Portfolios --------
@@ -6,15 +7,7 @@ import { migratePortfolios } from '../../../sonarcloud/migrators/portfolios.js';
 export async function migrateEnterprisePortfolios(extractedData, mergedProjectKeyMap, results, ctx) {
   const enterpriseConfig = ctx.enterpriseConfig;
   const allPortfolios = extractedData.portfolios || [];
-  if (!enterpriseConfig?.key) {
-    if (allPortfolios.length > 0) {
-      results.portfoliosSkipped = (results.portfoliosSkipped || 0) + allPortfolios.length;
-      logger.warn(`No enterprise key configured — skipping ${allPortfolios.length} portfolio(s)`);
-    } else {
-      logger.info('No enterprise key configured — skipping portfolio migration');
-    }
-    return;
-  }
+  if (!enterpriseConfig?.key) { handleMissingEnterpriseKey(allPortfolios, results); return; }
   if (allPortfolios.length === 0) { logger.info('No portfolios to migrate'); return; }
   if (ctx.onlyComponents?.includes('portfolios')) {
     logger.warn('Note: --only portfolios requires that projects are already migrated to SonarCloud.');

--- a/src/pipelines/sq-10.0/pipeline/results/helpers/create-empty-results.js
+++ b/src/pipelines/sq-10.0/pipeline/results/helpers/create-empty-results.js
@@ -12,6 +12,7 @@ export function createEmptyResults() {
     qualityProfiles: 0,
     groups: 0,
     portfolios: 0,
+    portfoliosSkipped: 0,
     issueSyncStats: { matched: 0, transitioned: 0, assigned: 0, assignmentFailed: 0, failedAssignments: [] },
     hotspotSyncStats: { matched: 0, statusChanged: 0 },
     projectKeyWarnings: [],

--- a/src/pipelines/sq-10.0/pipeline/results/helpers/log-migration-summary.js
+++ b/src/pipelines/sq-10.0/pipeline/results/helpers/log-migration-summary.js
@@ -31,6 +31,10 @@ export function logMigrationSummary(results, outputDir) {
     for (const { projectKey, detail } of ncpSkipped) logger.warn(`  ${projectKey}: ${detail}`);
   }
 
+  if (results.portfoliosSkipped > 0) {
+    logger.warn(`Portfolios NOT migrated: ${results.portfoliosSkipped} portfolio(s) found in source but skipped — no enterprise key was provided`);
+  }
+
   logger.info(`Output: ${outputDir}`);
   logger.info('========================');
 }

--- a/src/pipelines/sq-10.4/pipeline/org-migration/helpers/migrate-enterprise-portfolios.js
+++ b/src/pipelines/sq-10.4/pipeline/org-migration/helpers/migrate-enterprise-portfolios.js
@@ -1,5 +1,6 @@
 import { migratePortfolios } from '../../../sonarcloud/migrators/portfolios.js';
 import logger from '../../../../../shared/utils/logger.js';
+import { handleMissingEnterpriseKey } from '../../../../../shared/utils/portfolio-skip.js';
 
 // -------- Main Logic --------
 
@@ -8,15 +9,7 @@ import logger from '../../../../../shared/utils/logger.js';
  */
 export async function migrateEnterprisePortfolios(extractedData, mergedProjectKeyMap, results, ctx) {
   const allPortfolios = extractedData.portfolios || [];
-  if (!ctx.enterpriseConfig?.key) {
-    if (allPortfolios.length > 0) {
-      results.portfoliosSkipped = (results.portfoliosSkipped || 0) + allPortfolios.length;
-      logger.warn(`No enterprise key configured — skipping ${allPortfolios.length} portfolio(s)`);
-    } else {
-      logger.info('No enterprise key — skipping portfolio migration');
-    }
-    return;
-  }
+  if (!ctx.enterpriseConfig?.key) { handleMissingEnterpriseKey(allPortfolios, results); return; }
   if (allPortfolios.length === 0) { logger.info('No portfolios to migrate'); return; }
 
   if (ctx.onlyComponents?.includes('portfolios')) {

--- a/src/pipelines/sq-10.4/pipeline/org-migration/helpers/migrate-enterprise-portfolios.js
+++ b/src/pipelines/sq-10.4/pipeline/org-migration/helpers/migrate-enterprise-portfolios.js
@@ -7,8 +7,16 @@ import logger from '../../../../../shared/utils/logger.js';
  * Migrate portfolios at the enterprise level (after all orgs are migrated).
  */
 export async function migrateEnterprisePortfolios(extractedData, mergedProjectKeyMap, results, ctx) {
-  if (!ctx.enterpriseConfig?.key) { logger.info('No enterprise key — skipping portfolio migration'); return; }
   const allPortfolios = extractedData.portfolios || [];
+  if (!ctx.enterpriseConfig?.key) {
+    if (allPortfolios.length > 0) {
+      results.portfoliosSkipped = (results.portfoliosSkipped || 0) + allPortfolios.length;
+      logger.warn(`No enterprise key configured — skipping ${allPortfolios.length} portfolio(s)`);
+    } else {
+      logger.info('No enterprise key — skipping portfolio migration');
+    }
+    return;
+  }
   if (allPortfolios.length === 0) { logger.info('No portfolios to migrate'); return; }
 
   if (ctx.onlyComponents?.includes('portfolios')) {

--- a/src/pipelines/sq-10.4/pipeline/results/helpers/create-empty-results.js
+++ b/src/pipelines/sq-10.4/pipeline/results/helpers/create-empty-results.js
@@ -13,6 +13,7 @@ export function createEmptyResults() {
     qualityProfiles: 0,
     groups: 0,
     portfolios: 0,
+    portfoliosSkipped: 0,
     issueSyncStats: { matched: 0, transitioned: 0, assigned: 0, assignmentFailed: 0, failedAssignments: [] },
     hotspotSyncStats: { matched: 0, statusChanged: 0 },
     projectKeyWarnings: [],

--- a/src/pipelines/sq-10.4/pipeline/results/helpers/log-migration-summary.js
+++ b/src/pipelines/sq-10.4/pipeline/results/helpers/log-migration-summary.js
@@ -26,6 +26,10 @@ export function logMigrationSummary(results, outputDir) {
   logProjectKeyWarnings(results);
   logNewCodePeriodWarnings(results);
 
+  if (results.portfoliosSkipped > 0) {
+    logger.warn(`Portfolios NOT migrated: ${results.portfoliosSkipped} portfolio(s) found in source but skipped — no enterprise key was provided`);
+  }
+
   logger.info(`Output: ${outputDir}`);
   logger.info('========================');
 }

--- a/src/pipelines/sq-2025/pipeline/org-migration/helpers/migrate-enterprise-portfolios.js
+++ b/src/pipelines/sq-2025/pipeline/org-migration/helpers/migrate-enterprise-portfolios.js
@@ -1,5 +1,6 @@
 import { migratePortfolios } from '../../../sonarcloud/migrators/portfolios.js';
 import logger from '../../../../../shared/utils/logger.js';
+import { handleMissingEnterpriseKey } from '../../../../../shared/utils/portfolio-skip.js';
 
 // -------- Migrate Enterprise Portfolios --------
 
@@ -7,15 +8,7 @@ import logger from '../../../../../shared/utils/logger.js';
 export async function migrateEnterprisePortfolios(extractedData, mergedProjectKeyMap, results, ctx) {
   const enterpriseConfig = ctx.enterpriseConfig;
   const allPortfolios = extractedData.portfolios || [];
-  if (!enterpriseConfig?.key) {
-    if (allPortfolios.length > 0) {
-      results.portfoliosSkipped = (results.portfoliosSkipped || 0) + allPortfolios.length;
-      logger.warn(`No enterprise key configured — skipping ${allPortfolios.length} portfolio(s)`);
-    } else {
-      logger.info('No enterprise key configured — skipping portfolio migration');
-    }
-    return;
-  }
+  if (!enterpriseConfig?.key) { handleMissingEnterpriseKey(allPortfolios, results); return; }
   if (allPortfolios.length === 0) { logger.info('No portfolios to migrate'); return; }
 
   if (ctx.onlyComponents && ctx.onlyComponents.includes('portfolios')) {

--- a/src/pipelines/sq-2025/pipeline/org-migration/helpers/migrate-enterprise-portfolios.js
+++ b/src/pipelines/sq-2025/pipeline/org-migration/helpers/migrate-enterprise-portfolios.js
@@ -6,12 +6,16 @@ import logger from '../../../../../shared/utils/logger.js';
 /** Migrate portfolios at the enterprise level (V2 Enterprise API). */
 export async function migrateEnterprisePortfolios(extractedData, mergedProjectKeyMap, results, ctx) {
   const enterpriseConfig = ctx.enterpriseConfig;
+  const allPortfolios = extractedData.portfolios || [];
   if (!enterpriseConfig?.key) {
-    logger.info('No enterprise key configured — skipping portfolio migration');
+    if (allPortfolios.length > 0) {
+      results.portfoliosSkipped = (results.portfoliosSkipped || 0) + allPortfolios.length;
+      logger.warn(`No enterprise key configured — skipping ${allPortfolios.length} portfolio(s)`);
+    } else {
+      logger.info('No enterprise key configured — skipping portfolio migration');
+    }
     return;
   }
-
-  const allPortfolios = extractedData.portfolios || [];
   if (allPortfolios.length === 0) { logger.info('No portfolios to migrate'); return; }
 
   if (ctx.onlyComponents && ctx.onlyComponents.includes('portfolios')) {

--- a/src/pipelines/sq-2025/pipeline/results/helpers/create-empty-results.js
+++ b/src/pipelines/sq-2025/pipeline/results/helpers/create-empty-results.js
@@ -13,6 +13,7 @@ export function createEmptyResults() {
     qualityProfiles: 0,
     groups: 0,
     portfolios: 0,
+    portfoliosSkipped: 0,
     issueSyncStats: { matched: 0, transitioned: 0, assigned: 0, assignmentFailed: 0, failedAssignments: [] },
     hotspotSyncStats: { matched: 0, statusChanged: 0 },
     projectKeyWarnings: [],

--- a/src/pipelines/sq-2025/pipeline/results/helpers/log-migration-summary.js
+++ b/src/pipelines/sq-2025/pipeline/results/helpers/log-migration-summary.js
@@ -29,6 +29,10 @@ export function logMigrationSummary(results, outputDir) {
     for (const { projectKey, detail } of ncpSkipped) logger.warn(`  ${projectKey}: ${detail}`);
   }
 
+  if (results.portfoliosSkipped > 0) {
+    logger.warn(`Portfolios NOT migrated: ${results.portfoliosSkipped} portfolio(s) found in source but skipped — no enterprise key was provided`);
+  }
+
   logger.info(`Output: ${outputDir}`);
   logger.info('========================');
 }

--- a/src/pipelines/sq-9.9/pipeline/org-migration/helpers/migrate-enterprise-portfolios.js
+++ b/src/pipelines/sq-9.9/pipeline/org-migration/helpers/migrate-enterprise-portfolios.js
@@ -1,20 +1,13 @@
 import { migratePortfolios } from '../../../sonarcloud/migrators/portfolios.js';
 import logger from '../../../../../shared/utils/logger.js';
+import { handleMissingEnterpriseKey } from '../../../../../shared/utils/portfolio-skip.js';
 
 // -------- Migrate Enterprise Portfolios --------
 
 export async function migrateEnterprisePortfolios(extractedData, mergedProjectKeyMap, results, ctx) {
   const enterpriseConfig = ctx.enterpriseConfig;
   const allPortfolios = extractedData.portfolios || [];
-  if (!enterpriseConfig?.key) {
-    if (allPortfolios.length > 0) {
-      results.portfoliosSkipped = (results.portfoliosSkipped || 0) + allPortfolios.length;
-      logger.warn(`No enterprise key configured — skipping ${allPortfolios.length} portfolio(s)`);
-    } else {
-      logger.info('No enterprise key configured — skipping portfolio migration');
-    }
-    return;
-  }
+  if (!enterpriseConfig?.key) { handleMissingEnterpriseKey(allPortfolios, results); return; }
   if (allPortfolios.length === 0) { logger.info('No portfolios to migrate'); return; }
 
   if (ctx.onlyComponents?.includes('portfolios')) {

--- a/src/pipelines/sq-9.9/pipeline/org-migration/helpers/migrate-enterprise-portfolios.js
+++ b/src/pipelines/sq-9.9/pipeline/org-migration/helpers/migrate-enterprise-portfolios.js
@@ -5,12 +5,16 @@ import logger from '../../../../../shared/utils/logger.js';
 
 export async function migrateEnterprisePortfolios(extractedData, mergedProjectKeyMap, results, ctx) {
   const enterpriseConfig = ctx.enterpriseConfig;
+  const allPortfolios = extractedData.portfolios || [];
   if (!enterpriseConfig?.key) {
-    logger.info('No enterprise key configured — skipping portfolio migration');
+    if (allPortfolios.length > 0) {
+      results.portfoliosSkipped = (results.portfoliosSkipped || 0) + allPortfolios.length;
+      logger.warn(`No enterprise key configured — skipping ${allPortfolios.length} portfolio(s)`);
+    } else {
+      logger.info('No enterprise key configured — skipping portfolio migration');
+    }
     return;
   }
-
-  const allPortfolios = extractedData.portfolios || [];
   if (allPortfolios.length === 0) { logger.info('No portfolios to migrate'); return; }
 
   if (ctx.onlyComponents?.includes('portfolios')) {

--- a/src/pipelines/sq-9.9/pipeline/results/helpers/create-empty-results.js
+++ b/src/pipelines/sq-9.9/pipeline/results/helpers/create-empty-results.js
@@ -12,6 +12,7 @@ export function createEmptyResults() {
     qualityProfiles: 0,
     groups: 0,
     portfolios: 0,
+    portfoliosSkipped: 0,
     issueSyncStats: { matched: 0, transitioned: 0, assigned: 0, assignmentFailed: 0, failedAssignments: [] },
     hotspotSyncStats: { matched: 0, statusChanged: 0 },
     projectKeyWarnings: [],

--- a/src/pipelines/sq-9.9/pipeline/results/helpers/log-migration-summary.js
+++ b/src/pipelines/sq-9.9/pipeline/results/helpers/log-migration-summary.js
@@ -22,6 +22,11 @@ export function logMigrationSummary(results, outputDir) {
 
   logProjectKeyWarnings(results);
   logNewCodePeriodWarnings(results);
+
+  if (results.portfoliosSkipped > 0) {
+    logger.warn(`Portfolios NOT migrated: ${results.portfoliosSkipped} portfolio(s) found in source but skipped — no enterprise key was provided`);
+  }
+
   logger.info(`Output: ${outputDir}`);
   logger.info('========================');
 }

--- a/src/shared/utils/portfolio-skip.js
+++ b/src/shared/utils/portfolio-skip.js
@@ -6,7 +6,6 @@ import logger from './logger.js';
  *
  * @param {Array} portfolios - Portfolios extracted from the source SonarQube.
  * @param {object} results   - Mutable migration results object.
- * @returns {boolean} true if the enterprise key is missing (caller should return early).
  */
 export function handleMissingEnterpriseKey(portfolios, results) {
   if (portfolios.length > 0) {

--- a/src/shared/utils/portfolio-skip.js
+++ b/src/shared/utils/portfolio-skip.js
@@ -1,0 +1,18 @@
+import logger from './logger.js';
+
+/**
+ * Handle the case where no enterprise key is configured.
+ * Logs a warning (if portfolios exist) or info, and records skipped count.
+ *
+ * @param {Array} portfolios - Portfolios extracted from the source SonarQube.
+ * @param {object} results   - Mutable migration results object.
+ * @returns {boolean} true if the enterprise key is missing (caller should return early).
+ */
+export function handleMissingEnterpriseKey(portfolios, results) {
+  if (portfolios.length > 0) {
+    results.portfoliosSkipped = (results.portfoliosSkipped || 0) + portfolios.length;
+    logger.warn(`No enterprise key configured — skipping ${portfolios.length} portfolio(s)`);
+  } else {
+    logger.info('No enterprise key configured — skipping portfolio migration');
+  }
+}


### PR DESCRIPTION
- Implemented IPC handler for enterprise key validation in `ipc-handlers.js`.
- Exposed `validate` method in the preload script to allow renderer access.
- Updated `migrate-config.js` to include enterprise key validation logic and UI elements for user interaction.
- Enhanced migration behavior to conditionally require an enterprise key based on user settings.
- Updated logging to track skipped portfolios due to missing enterprise keys in migration processes.

This feature improves the user experience by providing real-time validation feedback for enterprise keys during migration.