### PR TITLE
Issue #70 - Add support for SQC US

### DIFF
--- a/desktop/src/renderer/js/screens/advanced-settings/defaults.js
+++ b/desktop/src/renderer/js/screens/advanced-settings/defaults.js
@@ -3,6 +3,9 @@
  */
 window.ADVANCED_DEFAULTS = {
 
+  // -------- SonarQube Cloud --------
+  sqcCustomUrl: '',
+
   // -------- Request Throttling --------
   rateLimit: {
     maxRetries: 3,

--- a/desktop/src/renderer/js/screens/advanced-settings/reader.js
+++ b/desktop/src/renderer/js/screens/advanced-settings/reader.js
@@ -14,6 +14,7 @@ window.AdvancedSettingsReader = {
     const d = window.ADVANCED_DEFAULTS;
 
     return {
+      sqcCustomUrl: (val('adv-sqc-url') || '').trim(),
       rateLimit: {
         maxRetries: numVal('rl-retries', d.rateLimit.maxRetries),
         baseDelay: numVal('rl-delay', d.rateLimit.baseDelay),

--- a/desktop/src/renderer/js/screens/advanced-settings/renderer.js
+++ b/desktop/src/renderer/js/screens/advanced-settings/renderer.js
@@ -19,7 +19,7 @@ window.AdvancedSettingsScreen = {
         <p>Fine-tune performance, throttling, and progress recovery</p>
       </div>
 
-      ${this.renderMigrationBehaviorCard()}
+      ${this.renderSqcCard()}
       ${this.renderThrottlingCard()}
       ${this.renderPerformanceCard()}
       ${this.renderRecoveryCard()}
@@ -37,11 +37,11 @@ window.AdvancedSettingsScreen = {
     this.attachEventListeners(container);
   },
 
-  renderMigrationBehaviorCard() {
+  renderSqcCard() {
     return `
       <div class="card">
-        <div class="card-header">Migration Behavior</div>
-        ${ConfigForm.checkbox('allow-no-enterprise-key', 'Allow migration without enterprise key', this.config.allowNoEnterpriseKey || false, { hint: 'When enabled, the enterprise key becomes optional. Portfolios will not be migrated without an enterprise key. Intended for Sonar internal testing or team/free plan migrations.' })}
+        <div class="card-header">SonarQube Cloud</div>
+        ${ConfigForm.textField('adv-sqc-url', 'Custom SonarQube Cloud URL', this.config.sqcCustomUrl || '', { placeholder: 'https://sonarcloud.io', hint: 'Override the EU/US instance selection with a custom URL, e.g. for staging environments. Leave blank to use the standard EU/US selection.' })}
       </div>
     `;
   },

--- a/desktop/src/renderer/js/screens/migrate-config.js
+++ b/desktop/src/renderer/js/screens/migrate-config.js
@@ -173,6 +173,7 @@ window.MigrateConfigScreen = {
   },
 
   renderOrgEntry(org, index) {
+    const instance = org.url === 'https://sonarqube.us' ? 'us' : 'eu';
     return `
       <div class="org-entry" data-org-index="${index}">
         <div class="org-entry-header">
@@ -183,7 +184,10 @@ window.MigrateConfigScreen = {
           ${ConfigForm.textField(`org-key-${index}`, 'Organization Key', org.key, { placeholder: 'my-org', required: true, hint: 'Your organization identifier in SonarCloud' })}
           ${ConfigForm.textField(`org-token-${index}`, 'Token', org.token, { type: 'password', required: true, hint: 'Authentication token for this organization' })}
         </div>
-        ${ConfigForm.textField(`org-url-${index}`, 'SonarCloud Address (URL)', org.url || 'https://sonarcloud.io', { hint: 'Leave as default unless you are using a staging or custom environment' })}
+        ${ConfigForm.radioGroup(`org-instance-${index}`, 'SonarQube Cloud Instance', [
+          { value: 'eu', label: 'EU (sonarcloud.io)' },
+          { value: 'us', label: 'US (sonarqube.us)' }
+        ], instance)}
       </div>
     `;
   },
@@ -204,10 +208,11 @@ window.MigrateConfigScreen = {
     const orgs = [];
     container.querySelectorAll('.org-entry').forEach((el) => {
       const i = el.dataset.orgIndex;
+      const instance = container.querySelector(`input[name="org-instance-${i}"]:checked`)?.value || 'eu';
       orgs.push({
         key: container.querySelector(`#org-key-${i}`)?.value.trim() || '',
         token: container.querySelector(`#org-token-${i}`)?.value.trim() || '',
-        url: container.querySelector(`#org-url-${i}`)?.value.trim() || 'https://sonarcloud.io'
+        url: instance === 'us' ? 'https://sonarqube.us' : 'https://sonarcloud.io'
       });
     });
     this.config.sonarcloud.organizations = orgs;

--- a/desktop/src/renderer/js/screens/sync-metadata-config.js
+++ b/desktop/src/renderer/js/screens/sync-metadata-config.js
@@ -121,10 +121,11 @@ window.SyncMetadataConfigScreen = {
     const orgs = [];
     container.querySelectorAll('.org-entry').forEach((el) => {
       const i = el.dataset.orgIndex;
+      const instance = container.querySelector(`input[name="org-instance-${i}"]:checked`)?.value || 'eu';
       orgs.push({
         key: container.querySelector(`#org-key-${i}`)?.value.trim() || '',
         token: container.querySelector(`#org-token-${i}`)?.value.trim() || '',
-        url: container.querySelector(`#org-url-${i}`)?.value.trim() || 'https://sonarcloud.io'
+        url: instance === 'us' ? 'https://sonarqube.us' : 'https://sonarcloud.io'
       });
     });
     this.config.sonarcloud.organizations = orgs;

--- a/desktop/src/renderer/js/screens/transfer-config.js
+++ b/desktop/src/renderer/js/screens/transfer-config.js
@@ -71,13 +71,17 @@ window.TransferConfigScreen = {
 
   renderSonarCloudStep(container) {
     const sc = this.config.sonarcloud;
+    const instance = sc.url === 'https://sonarqube.us' ? 'us' : 'eu';
     container.innerHTML = `
       <div class="page-header">
         <h2>${ConfigForm.icon('cloud')} SonarCloud Connection</h2>
         <p>Connect to your SonarCloud organization</p>
       </div>
       <div class="card">
-        ${ConfigForm.textField('sc-url', 'SonarCloud Address (URL)', sc.url, { placeholder: 'https://sonarcloud.io', hint: 'Leave as default unless you are using a staging or custom environment' })}
+        ${ConfigForm.radioGroup('sc-instance', 'SonarQube Cloud Instance', [
+          { value: 'eu', label: 'EU (sonarcloud.io)' },
+          { value: 'us', label: 'US (sonarqube.us)' }
+        ], instance)}
         ${ConfigForm.textField('sc-token', 'Authentication Token', sc.token, { type: 'password', placeholder: 'Token', required: true, hint: 'Generate this in SonarCloud under My Account > Security' })}
         ${ConfigForm.textField('sc-org', 'Organization Key', sc.organization, { placeholder: 'my-org', required: true, hint: 'Your organization identifier in SonarCloud' })}
         ${ConfigForm.textField('sc-project', 'Project Key', sc.projectKey, { placeholder: 'my-org_my-project', required: true, hint: 'The destination project key in SonarCloud' })}
@@ -89,10 +93,13 @@ window.TransferConfigScreen = {
     `;
     ConfigForm.attachHandlers(container);
     container.querySelector('#btn-back').addEventListener('click', () => this.renderStep(container, 0));
-    container.querySelector('#btn-next').addEventListener('click', () => {
+    container.querySelector('#btn-next').addEventListener('click', async () => {
       const result = ConfigForm.validate(container);
       if (!result.valid) return;
-      this.config.sonarcloud.url = container.querySelector('#sc-url').value.trim();
+      const selectedInstance = container.querySelector('input[name="sc-instance"]:checked')?.value || 'eu';
+      const adv = await window.cloudvoyager.config.loadKey('advancedConfig');
+      const customUrl = adv?.sqcCustomUrl?.trim();
+      this.config.sonarcloud.url = customUrl || (selectedInstance === 'us' ? 'https://sonarqube.us' : 'https://sonarcloud.io');
       this.config.sonarcloud.token = container.querySelector('#sc-token').value.trim();
       this.config.sonarcloud.organization = container.querySelector('#sc-org').value.trim();
       this.config.sonarcloud.projectKey = container.querySelector('#sc-project').value.trim();

--- a/desktop/src/renderer/js/screens/verify-config.js
+++ b/desktop/src/renderer/js/screens/verify-config.js
@@ -119,10 +119,11 @@ window.VerifyConfigScreen = {
     const orgs = [];
     container.querySelectorAll('.org-entry').forEach((el) => {
       const i = el.dataset.orgIndex;
+      const instance = container.querySelector(`input[name="org-instance-${i}"]:checked`)?.value || 'eu';
       orgs.push({
         key: container.querySelector(`#org-key-${i}`)?.value.trim() || '',
         token: container.querySelector(`#org-token-${i}`)?.value.trim() || '',
-        url: container.querySelector(`#org-url-${i}`)?.value.trim() || 'https://sonarcloud.io'
+        url: instance === 'us' ? 'https://sonarqube.us' : 'https://sonarcloud.io'
       });
     });
     this.config.sonarcloud.organizations = orgs;


### PR DESCRIPTION
- Replaced the free-text SonarCloud URL field with an EU/US radio button in all wizard screens (transfer-config.js, migrate-config.js, and inherited by verify-config.js/sync-metadata-config.js). Selecting EU resolves to https://sonarcloud.io; US resolves to https://sonarqube.us.
- Moved custom URL configuration to Advanced Settings — added a "SonarQube Cloud" card with a Custom SonarQube Cloud URL text field (adv-sqc-url) to advanced-settings/renderer.js, backed by sqcCustomUrl in defaults.js and reader.js. If set, it overrides the radio selection.
- Updated all readOrgs() methods in migrate-config.js, verify-config.js, and sync-metadata-config.js to derive the org URL from the new radio button (org-instance-N) instead of the old text field (org-url-N).