### PR TITLE
Issue #70/#88 - Fix bugs from Sonar Review agent

### DIFF
--- a/desktop/src/renderer/js/components/config-form.js
+++ b/desktop/src/renderer/js/components/config-form.js
@@ -284,6 +284,15 @@ window.ConfigForm = {
   },
 
   /**
+   * Resolve a SonarQube Cloud instance radio value to a URL.
+   * A non-empty customUrl (from Advanced Settings) always takes precedence.
+   */
+  instanceToUrl(instance, customUrl) {
+    if (customUrl) return customUrl;
+    return instance === 'us' ? 'https://sonarqube.us' : 'https://sonarcloud.io';
+  },
+
+  /**
    * Attach event listeners for interactive form elements
    */
   attachHandlers(container) {

--- a/desktop/src/renderer/js/screens/advanced-settings/renderer.js
+++ b/desktop/src/renderer/js/screens/advanced-settings/renderer.js
@@ -42,6 +42,7 @@ window.AdvancedSettingsScreen = {
       <div class="card">
         <div class="card-header">SonarQube Cloud</div>
         ${ConfigForm.textField('adv-sqc-url', 'Custom SonarQube Cloud URL', this.config.sqcCustomUrl || '', { placeholder: 'https://sonarcloud.io', hint: 'Override the EU/US instance selection with a custom URL, e.g. for staging environments. Leave blank to use the standard EU/US selection.' })}
+        ${ConfigForm.checkbox('allow-no-enterprise-key', 'Allow migration without enterprise key', this.config.allowNoEnterpriseKey || false, { hint: 'When enabled, the enterprise key becomes optional. Portfolios will not be migrated without an enterprise key. Intended for team/free plan migrations.' })}
       </div>
     `;
   },

--- a/desktop/src/renderer/js/screens/migrate-config.js
+++ b/desktop/src/renderer/js/screens/migrate-config.js
@@ -24,6 +24,7 @@ window.MigrateConfigScreen = {
     };
     const advancedConfig = await window.cloudvoyager.config.loadKey('advancedConfig');
     this.allowNoEnterpriseKey = advancedConfig?.allowNoEnterpriseKey || false;
+    this.sqcCustomUrl = advancedConfig?.sqcCustomUrl?.trim() || '';
   },
 
   async render(container) {
@@ -212,7 +213,7 @@ window.MigrateConfigScreen = {
       orgs.push({
         key: container.querySelector(`#org-key-${i}`)?.value.trim() || '',
         token: container.querySelector(`#org-token-${i}`)?.value.trim() || '',
-        url: instance === 'us' ? 'https://sonarqube.us' : 'https://sonarcloud.io'
+        url: ConfigForm.instanceToUrl(instance, this.sqcCustomUrl)
       });
     });
     this.config.sonarcloud.organizations = orgs;

--- a/desktop/src/renderer/js/screens/sync-metadata-config.js
+++ b/desktop/src/renderer/js/screens/sync-metadata-config.js
@@ -28,6 +28,8 @@ window.SyncMetadataConfigScreen = {
     this.config._skipHotspotSync = this.config._skipHotspotSync || false;
     this.config._skipQPSync = this.config._skipQPSync || false;
     this.config._skipBranches = this.config._skipBranches || false;
+    const adv = await window.cloudvoyager.config.loadKey('advancedConfig');
+    this.sqcCustomUrl = adv?.sqcCustomUrl?.trim() || '';
   },
 
   async render(container) {
@@ -125,7 +127,7 @@ window.SyncMetadataConfigScreen = {
       orgs.push({
         key: container.querySelector(`#org-key-${i}`)?.value.trim() || '',
         token: container.querySelector(`#org-token-${i}`)?.value.trim() || '',
-        url: instance === 'us' ? 'https://sonarqube.us' : 'https://sonarcloud.io'
+        url: ConfigForm.instanceToUrl(instance, this.sqcCustomUrl)
       });
     });
     this.config.sonarcloud.organizations = orgs;

--- a/desktop/src/renderer/js/screens/verify-config.js
+++ b/desktop/src/renderer/js/screens/verify-config.js
@@ -26,6 +26,8 @@ window.VerifyConfigScreen = {
     // Verify-specific transient options
     this.config._onlyComponents = this.config._onlyComponents || [];
     this.config._verbose = this.config._verbose || false;
+    const adv = await window.cloudvoyager.config.loadKey('advancedConfig');
+    this.sqcCustomUrl = adv?.sqcCustomUrl?.trim() || '';
   },
 
   async render(container) {
@@ -123,7 +125,7 @@ window.VerifyConfigScreen = {
       orgs.push({
         key: container.querySelector(`#org-key-${i}`)?.value.trim() || '',
         token: container.querySelector(`#org-token-${i}`)?.value.trim() || '',
-        url: instance === 'us' ? 'https://sonarqube.us' : 'https://sonarcloud.io'
+        url: ConfigForm.instanceToUrl(instance, this.sqcCustomUrl)
       });
     });
     this.config.sonarcloud.organizations = orgs;


### PR DESCRIPTION

**Bug 1 — `allowNoEnterpriseKey` restored:**
- `advanced-settings/renderer.js`: Added the "Allow migration without enterprise key" checkbox back into `renderSqcCard()`, grouped with the custom URL field under the same "SonarQube Cloud" card header. The `defaults.js` and `reader.js` already had the field correctly — only the renderer was missing it.

**Bug 2 — `sqcCustomUrl` now applied in all `readOrgs()` calls:**
- `migrate-config.js`: Extended the existing `advancedConfig` load in `init()` to also capture `this.sqcCustomUrl`.
- `verify-config.js` and `sync-metadata-config.js`: Added an `advancedConfig` load at the end of their `init()` methods, storing `this.sqcCustomUrl`.

**Bug 3 — URL mapping extracted to a single shared helper:**
- `config-form.js`: Added `ConfigForm.instanceToUrl(instance, customUrl)` — returns `customUrl` if set, otherwise maps `'us'` → `https://sonarqube.us` and anything else → `https://sonarcloud.io`.
- `migrate-config.js`, `verify-config.js`, `sync-metadata-config.js`: All three `readOrgs()` methods now call `ConfigForm.instanceToUrl(instance, this.sqcCustomUrl)` instead of the inline ternary.