### PR TITLE
Centralize version in package.json — bump to 1.3.0

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -60,16 +60,11 @@ jobs:
           cd desktop
           npm version ${{ steps.version.outputs.new }} --no-git-tag-version
 
-      # -------- Sync version to src/index.js --------
-      - name: Update CLI hardcoded version
-        run: |
-          sed -i "s/.version('[^']*')/.version('${{ steps.version.outputs.new }}')/" src/index.js
-
       # -------- Commit and Push --------
       - name: Commit version bump
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json desktop/package.json desktop/package-lock.json src/index.js
+          git add package.json package-lock.json desktop/package.json desktop/package-lock.json
           git commit -m "chore: bump version to ${{ steps.version.outputs.new }}"
           git push

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloudvoyager-desktop",
-  "version": "1.1.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cloudvoyager-desktop",
-      "version": "1.1.1",
+      "version": "1.3.0",
       "dependencies": {
         "electron-store": "^8.2.0"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudvoyager-desktop",
   "productName": "CloudVoyager Desktop",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "commonjs",
   "description": "Desktop UI for CloudVoyager — migrate SonarQube to SonarCloud",
   "main": "src/main/main.js",

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -16,6 +16,10 @@ package.json  →  "version" field  (root of repo)
 
 Every workflow reads the version from this file. The version-bump workflow writes to this file. All downstream release artifacts (CLI binaries, desktop apps, GitHub Release tags) derive their version from it.
 
+The CLI (`src/index.js`) reads the version dynamically rather than hardcoding it:
+- **Production builds**: esbuild injects the version at build time via `define: { '__APP_VERSION__': ... }` in `scripts/build.js`
+- **Dev mode** (`node src/index.js`): falls back to reading `package.json` directly via `createRequire`
+
 ---
 
 <!-- <subsection-updated last-updated="2026-03-30T00:00:00Z" updated-by="Claude" /> -->
@@ -25,11 +29,11 @@ Every workflow reads the version from this file. The version-bump workflow write
 |----------|------|------------|
 | **Root package.json** | `package.json` | `version-bump.yml` (automatic) |
 | **Root package-lock.json** | `package-lock.json` | `version-bump.yml` (automatic, via `npm version`) |
-| **CLI `--version` flag** | `src/index.js` (line 20, hardcoded) | `version-bump.yml` (automatic, via `sed`) |
+| **CLI `--version` flag** | `src/index.js` (dynamic, from `package.json`) | Automatic — reads `package.json` at build/runtime |
 | **Desktop app version** | `desktop/package.json` | `version-bump.yml` (automatic, via `npm version`) |
 | **Desktop lock file** | `desktop/package-lock.json` | `version-bump.yml` (automatic, via `npm version`) |
 
-All five locations are updated automatically by the version-bump workflow.
+The package.json files are updated automatically by the version-bump workflow. The CLI version is derived at build time (no manual update needed).
 
 ---
 
@@ -60,8 +64,8 @@ The workflow (`.github/workflows/version-bump.yml`) compares the milestone title
 1. Reads the milestone title from the merged PR
 2. Reads the current version from `package.json`
 3. Computes the new version using the logic above
-4. Runs `npm version <NEW_VERSION> --no-git-tag-version`
-5. Commits `package.json` and `package-lock.json` with message: `chore: bump version to <NEW_VERSION>`
+4. Runs `npm version <NEW_VERSION> --no-git-tag-version` (root and desktop)
+5. Commits `package.json`, `package-lock.json`, `desktop/package.json`, and `desktop/package-lock.json` with message: `chore: bump version to <NEW_VERSION>`
 6. Pushes the commit to `main`
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudvoyager",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A CLI tool to migrate all projects from SonarQube Server to SonarCloud.io",
   "main": "src/index.js",
   "bin": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { mkdirSync, rmSync, copyFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, copyFileSync, writeFileSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
@@ -70,6 +70,7 @@ function bunCompile(sourceFile, outDir, binaryName, target) {
  */
 async function esbuildBundle(entryPoint, distDir) {
   const esbuild = await import('esbuild');
+  const { version } = JSON.parse(readFileSync(join(rootDir, 'package.json'), 'utf8'));
   await esbuild.build({
     entryPoints: [entryPoint],
     outfile: join(distDir, 'cli.cjs'),
@@ -81,7 +82,7 @@ async function esbuildBundle(entryPoint, distDir) {
     minify: true,
     treeShaking: true,
     loader: { '.proto': 'text' },
-    define: { 'import.meta.url': 'importMetaUrl' },
+    define: { 'import.meta.url': 'importMetaUrl', '__APP_VERSION__': JSON.stringify(version) },
     banner: {
       js: 'const importMetaUrl = require("url").pathToFileURL(__filename).href;',
     },

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 // -------- CLI Entry Point --------
 
+import { createRequire } from 'node:module';
 import { Command } from 'commander';
 import { registerTransferCommand } from './commands/transfer.js';
 import { registerMigrateCommand } from './commands/migrate.js';
@@ -12,12 +13,16 @@ import { registerStatusCommand } from './commands/status/index.js';
 import { registerResetCommand } from './commands/reset/index.js';
 import { registerTestCommand } from './commands/test-connection/index.js';
 
+const _require = createRequire(import.meta.url);
+// Build injects __APP_VERSION__ via esbuild define; dev mode falls back to package.json
+const appVersion = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : _require('../package.json').version; // eslint-disable-line no-undef
+
 const program = new Command();
 
 program
   .name('cloudvoyager')
   .description('CloudVoyager CLI — Migrate data from SonarQube to SonarCloud')
-  .version('1.2.0');
+  .version(appVersion);
 
 registerTransferCommand(program);
 registerMigrateCommand(program);


### PR DESCRIPTION
Replace hardcoded version string in src/index.js with dynamic version reading: esbuild injects __APP_VERSION__ at build time for production binaries, createRequire fallback reads package.json in dev mode.

Remove fragile sed command from version-bump.yml workflow. Bump desktop/package.json and desktop/package-lock.json to 1.3.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect release/version propagation and build-time injection, so a misconfiguration could produce incorrect CLI versions in packaged binaries. The code changes are small but touch CI/release automation.
> 
> **Overview**
> Centralizes versioning on the root `package.json` and bumps the root and desktop app versions to `1.3.0`.
> 
> The CLI `--version` output is no longer hardcoded in `src/index.js`; it now uses a build-injected `__APP_VERSION__` (from `scripts/build.js`) with a dev-mode fallback to reading `package.json`. The `version-bump.yml` workflow is simplified by removing the `sed` step and no longer stages `src/index.js` during automated version bumps, with docs updated to reflect the new flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5194894dacb986458dc3d60eadbce2030340f32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->