### PR TITLE
Contributors/joshuaquek/fix 99 migrated issues should split by 5k per date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ dist/desktop/
 **/*.json.journal
 **/*.json.journal.backup
 **/*.json.gz
+
+sonar-local-scan.sh

--- a/desktop/src/main/ipc-handlers.js
+++ b/desktop/src/main/ipc-handlers.js
@@ -144,12 +144,12 @@ function registerIpcHandlers(getMainWindow) {
     try {
       const parsed = new URL(url || 'https://sonarcloud.io');
       const apiBase = `${parsed.protocol}//api.${parsed.host}/enterprises`;
-      const response = await fetch(`${apiBase}/enterprises?enterpriseKey=${encodeURIComponent(key)}`, {
+      const response = await fetch(`${apiBase}?enterpriseKey=${encodeURIComponent(key)}`, {
         headers: { Authorization: `Bearer ${token}` }
       });
       if (response.ok) {
         const data = await response.json();
-        const enterprises = data.enterprises || [];
+        const enterprises = Array.isArray(data) ? data : (data.enterprises || []);
         if (enterprises.some(e => e.key === key)) {
           return { valid: true };
         }

--- a/desktop/src/main/ipc-handlers.js
+++ b/desktop/src/main/ipc-handlers.js
@@ -142,8 +142,9 @@ function registerIpcHandlers(getMainWindow) {
   // Enterprise key validation
   ipcMain.handle('enterprise:validate', async (_event, key, token, url) => {
     try {
-      const baseUrl = (url || 'https://sonarcloud.io').replace(/\/+$/, '');
-      const response = await fetch(`${baseUrl}/api/v2/enterprises?enterpriseKey=${encodeURIComponent(key)}`, {
+      const parsed = new URL(url || 'https://sonarcloud.io');
+      const apiBase = `${parsed.protocol}//api.${parsed.host}/enterprises`;
+      const response = await fetch(`${apiBase}/enterprises?enterpriseKey=${encodeURIComponent(key)}`, {
         headers: { Authorization: `Bearer ${token}` }
       });
       if (response.ok) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to CloudVoyager are documented in this file. Entries are ord
 
 ---
 
-<!-- <subsection-updated last-updated="2026-04-20T00:00:00Z" updated-by="Claude" /> -->
+<!-- <subsection-updated last-updated="2026-04-21T00:00:00Z" updated-by="Claude" /> -->
 ## Issue Batching: Distribute Large Issue Sets Across Multiple Dates (2026-04-20)
 
 Projects with more than 5,000 issues per branch now automatically split into multiple scanner reports, each with a distinct `analysis_date`. This prevents SonarCloud's Elasticsearch visualization limit (10K per date bucket) from hiding migrated issues.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to CloudVoyager are documented in this file. Entries are ord
 
 ---
 
+## Bug Fix: New Code Definitions Migration Fails with 400 Error (2026-04-22)
+<!-- updated: 2026-04-22_14:00:00 -->
+
+Fixed a bug where the "New code definitions" migration step failed with `SonarCloud API error (400): Either 'value', 'values' or 'fieldValues' must be provided`.
+
+### Root Cause
+
+`migrateNewCodePeriods` called `client.setProjectSetting(setting.key, setting.value, projectKey)`, passing a raw string as the second argument. The `setProjectSetting` function expects an object with destructured properties `{ value, values, fieldValues }`. The raw string was destructured into an empty object, so none of the required parameters were included in the API request.
+
+### Fix
+
+Changed the call to `client.setProjectSetting(setting.key, { value: setting.value }, projectKey)` in all 4 pipeline versions.
+
+### Files Changed
+
+- `src/pipelines/sq-9.9/sonarcloud/migrators/project-config/helpers/migrate-new-code-periods.js`
+- `src/pipelines/sq-10.0/sonarcloud/migrators/project-config/helpers/migrate-new-code-periods.js`
+- `src/pipelines/sq-10.4/sonarcloud/migrators/project-config/helpers/migrate-new-code-periods.js`
+- `src/pipelines/sq-2025/sonarcloud/migrators/project-config/helpers/migrate-new-code-periods.js`
+
+---
+
 <!-- <subsection-updated last-updated="2026-04-22T00:00:00Z" updated-by="Claude" /> -->
 ## Bug Fixes: Missing Imports in Verification Report Generators (2026-04-22)
 <!-- updated: 2026-04-22_00:42:00 -->

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to CloudVoyager are documented in this file. Entries are ord
 
 ---
 
+<!-- <subsection-updated last-updated="2026-04-20T00:00:00Z" updated-by="Claude" /> -->
+## Issue Batching: Distribute Large Issue Sets Across Multiple Dates (2026-04-20)
+
+Projects with more than 5,000 issues per branch now automatically split into multiple scanner reports, each with a distinct `analysis_date`. This prevents SonarCloud's Elasticsearch visualization limit (10K per date bucket) from hiding migrated issues.
+
+### New Feature
+
+- **Issue batch distribution** — When a branch has >5,000 issues, they are split into batches of 5,000 and uploaded as separate scanner reports with backdated analysis dates (going backwards from today, one day per batch). The final batch carries the original date and full project data.
+- **Shared utility** — `src/shared/utils/batch-distributor/` provides four pure-function helpers: `shouldBatch`, `computeBatchPlan`, `computeBatchDate`, `createBatchExtractedData`.
+- **All 4 pipeline versions updated** — sq-9.9, sq-10.0, sq-10.4, and sq-2025 all integrate the batch distributor via a `shouldBatch` gate in `transferBranch`.
+- **Upload size optimization** — Non-final batches strip `sources`, `changesets`, and `duplications` to minimize upload payload. `components` and `activeRules` are preserved for issue resolution.
+- **Unique SCM revision per batch** — Each batch uses `randomBytes(20).toString('hex')` to generate a unique `scmRevisionId`, preventing CE deduplication across batches.
+
+### Design Notes
+
+- Batch size is hardcoded at 5,000 (50% safety margin under the 10K ES visualization limit)
+- Batches are submitted oldest-first and always wait for CE completion before the next batch
+- Branch-level stats are computed from the original (unbatched) data for accuracy
+- No changes to the protobuf builder, encoder, or packager — batching operates at the `extractedData` level
+
+---
+
 <!-- <subsection-updated last-updated="2026-04-01T00:00:00Z" updated-by="Claude" /> -->
 ## Desktop Migration Graph: Bug Fixes (2026-04-01)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to CloudVoyager are documented in this file. Entries are ord
 
 ---
 
+<!-- <subsection-updated last-updated="2026-04-22T00:00:00Z" updated-by="Claude" /> -->
+## Bug Fixes: Missing Imports in Verification Report Generators (2026-04-22)
+<!-- updated: 2026-04-22_00:42:00 -->
+
+Fixed several missing import bugs that caused the `verify` command's report generation to fail, and a quoting bug in the build script.
+
+### Bug Fixes
+
+- **Fixed:** `formatUnmatchedSqIssues is not defined` — Added missing imports in `src/shared/verification/reports/markdown-sections/helpers/issue-details.js` for functions from `issue-list-details.js` and `issue-attr-details.js`.
+- **Fixed:** `formatHotspotCommentMismatches is not defined` — Added missing imports in `src/shared/verification/reports/markdown-sections/helpers/hotspot-details.js` for functions from `hotspot-comment-details.js`.
+- **Fixed:** `e is not a function` (PDF generation) — `buildProjectResults` in `src/shared/verification/reports/format-pdf/index.js` was called without the required `statusCell` callback. Added inline `statusCell` helper.
+- **Fixed:** `buildUnmatchedSq is not defined` (PDF generation) — Added missing imports in `src/shared/verification/reports/pdf-sections/helpers/issue-details.js` for functions from `issue-list-details.js` and `issue-attr-details.js`.
+- **Fixed:** `buildCommentMismatches is not defined` (PDF hotspot) — Added missing imports in `src/shared/verification/reports/pdf-sections/helpers/hotspot-details.js` for functions from `hotspot-extra-details.js`.
+- **Fixed:** Build script path quoting — Quoted the SEA config path in `scripts/build.js` to support project directories with spaces.
+
+---
+
 <!-- <subsection-updated last-updated="2026-04-21T00:00:00Z" updated-by="Claude" /> -->
 ## Issue Batching: Distribute Large Issue Sets Across Multiple Dates (2026-04-20)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,55 @@ All notable changes to CloudVoyager are documented in this file. Entries are ord
 
 ---
 
+## Code Review: Deep Codebase Audit (2026-04-22)
+<!-- updated: 2026-04-22_12:30:00 -->
+
+Full codebase review of 95 files across shared utilities, state management, pipelines, protobuf encoding, verification, and CLI commands. Findings documented in `REVIEW.md` at project root.
+
+### Summary
+
+- **5 Critical** — Crash/data-loss risks: atomic-save ordering, missing write lock on StateTracker, null crash in `shouldBatch`, shutdown corruption, path traversal in test-connection
+- **16 Warnings** — Incorrect behavior: overlapping search slicer windows, `mapConcurrent` abort race, missing `ACCEPTED` status normalization (SQ 10.4+), match key collisions in verification, bypassed write locks, silent effort truncation, missing null guards
+- **9 Info** — Duplicate constants, unused vars, missing tests, copy-paste across pipeline versions
+
+### Key Files Flagged
+
+- `src/shared/state/storage/helpers/atomic-save.js` — Crash-vulnerable save ordering
+- `src/shared/state/tracker/index.js` — No write lock for concurrent access
+- `src/shared/utils/batch-distributor/helpers/should-batch.js` — Null crash on all pipelines
+- `src/shared/utils/shutdown/helpers/create-shutdown-coordinator.js` — Force-exit during cleanup
+- `src/shared/utils/search-slicer/helpers/build-date-windows.js` — Overlapping boundaries
+- `src/shared/verification/checkers/issues/helpers/normalize-status.js` — Missing SQ 10.4+ status
+
+---
+
+## Feature: 4-Tier Log File Output (2026-04-22)
+<!-- updated: 2026-04-22_02:35:00 -->
+
+Every command now writes four separate log files to `migration-output/logs/`:
+
+- **`cloudvoyager-{cmd}-{timestamp}.log`** — Raw/unfiltered (all levels including debug)
+- **`cloudvoyager-{cmd}-{timestamp}.info.log`** — Only `info` entries
+- **`cloudvoyager-{cmd}-{timestamp}.warn.log`** — Only `warn` entries
+- **`cloudvoyager-{cmd}-{timestamp}.error.log`** — Only `error` entries
+
+This makes it easy to triage warnings and errors without searching through thousands of info-level lines.
+
+### Bug Fix: Logs preserved during output directory cleanup
+
+Previously, a fresh (non-resume) migration would `rm -rf` the entire `migration-output/` directory, deleting log files that were created moments earlier by `enableFileLogging`. All 4 pipeline versions now skip the `logs/` subdirectory during cleanup so logs accumulate across runs.
+
+### Files Changed
+
+- `src/shared/utils/logger/helpers/enable-file-logging.js`
+- `test/utils/logger.test.js`
+- `src/pipelines/sq-2025/migrate-pipeline/helpers/handle-resume-prompt.js`
+- `src/pipelines/sq-10.4/migrate-pipeline/helpers/prepare-output-dir.js`
+- `src/pipelines/sq-10.0/migrate-pipeline/helpers/prepare-output-dir.js`
+- `src/pipelines/sq-9.9/migrate-pipeline/helpers/setup-output-dirs.js`
+
+---
+
 ## Bug Fix: New Code Definitions Migration Fails with 400 Error (2026-04-22)
 <!-- updated: 2026-04-22_14:00:00 -->
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 # Contributing to CloudVoyager
+<!-- Last updated: 2026-04-21 -->
 
 This guide documents the architectural patterns and conventions of the CloudVoyager codebase. Contributors must follow these patterns to maintain consistency and prevent regressions.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,8 @@
 # 🏗️ Architecture
 
-<!-- Last updated: Mar 26, 2026 -->
+<!-- Last updated: Apr 21, 2026 -->
 
-<!-- Updated: Mar 25, 2026 -->
+<!-- Updated: Apr 21, 2026 -->
 ## 📁 Project Structure
 
 CloudVoyager uses a **pipeline-per-version** architecture. Each supported SonarQube version range has its own self-contained pipeline, while shared (version-independent) code lives in `src/shared/`.
@@ -74,6 +74,13 @@ src/
     │   │   │   ├── build-windows.js    # Initial window partitioning
     │   │   │   ├── fetch-window.js     # Fetch issues within a single window
     │   │   │   └── merge-results.js    # Deduplicate and merge sliced results
+    │   ├── batch-distributor/         # Issue batching for upload (5K per date bucket)
+    │   │   ├── index.js                # shouldBatch + createBatchExtractedData orchestrator
+    │   │   ├── helpers/
+    │   │   │   ├── should-batch.js     # Predicate: issues.length > 5000
+    │   │   │   ├── compute-batch-plan.js # Returns batch descriptors with start/end indices
+    │   │   │   ├── compute-batch-date.js # Computes backdated ISO date per batch
+    │   │   │   └── create-batch-extracted-data.js # Shallow-clones extracted data with sliced issues
     │   ├── issue-sync/                # Shared issue sync utilities
     │   │   ├── has-manual-changes.js   # Detects human-authored changes on an SQ issue
     │   │   ├── fetch-sq-changelogs.js  # Batch-fetches SQ changelogs concurrently
@@ -123,8 +130,8 @@ sq-{version}/
 │               └── fetch-and-sync-hotspots.js  # Fetches SQ hotspots, syncs to SC
 ├── transfer-branch.js                # Re-export → transfer-branch/index.js
 ├── transfer-branch/
-│   ├── index.js
-│   └── helpers/                       # build-and-encode-report, upload-report, compute-branch-stats, ...
+│   ├── index.js                       # Orchestrates per-branch transfer; gates to batched path when issues > 5K
+│   └── helpers/                       # build-and-encode-report, upload-report, compute-branch-stats, transfer-branch-batched, ...
 ├── migrate-pipeline.js               # Re-export → migrate-pipeline/index.js
 ├── migrate-pipeline/
 │   ├── index.js                       # Full multi-org migration orchestrator

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -248,6 +248,22 @@ sq-{version}/
 
 **404 JS files** across the sq-10.4 pipeline, all ≤50 lines. Classes converted to factory functions (`createSonarQubeClient`, `createSonarCloudClient`, `createProtobufBuilder`, `createDataExtractor`) with thin class wrappers for backward compatibility.
 
+<!-- Updated: 2026-04-22_14:30:00 -->
+### Shared Utilities — Batch Distributor
+
+The **batch-distributor** (`src/shared/utils/batch-distributor/`) is a shared utility that splits large issue sets across multiple scanner report uploads to work around SonarCloud's Elasticsearch 10K-per-date-bucket visualization limit. Without batching, branches with more than 10,000 issues on a single analysis date would have issues hidden in the SonarCloud UI.
+
+It exposes four pure-function helpers:
+
+| Function | Purpose |
+|----------|---------|
+| `shouldBatch(extractedData)` | Predicate — returns `true` when `issues.length > 5000` |
+| `computeBatchPlan(totalIssues)` | Returns an array of batch descriptors, each with `startIndex`, `endIndex`, `batchIndex`, and `isLast` |
+| `computeBatchDate(baseDateISO, batchIndex, totalBatches)` | Computes a backdated ISO date string per batch, stepping one day back per batch from the base date |
+| `createBatchExtractedData(originalData, batchDescriptor, batchDate, batchScmRevisionId)` | Shallow-clones the extracted data with a sliced issues array and overridden metadata; non-final batches strip sources, changesets, and duplications to reduce upload size |
+
+**Integration:** All four pipeline versions (`sq-9.9`, `sq-10.0`, `sq-10.4`, `sq-2025`) integrate via a `shouldBatch` gate in `transferBranch`. When a branch has more than 5,000 issues, `transferBranch` computes a batch plan and uploads each batch as a separate scanner report with a unique backdated analysis date and `scmRevisionId`. Only the final batch includes sources, changesets, and duplications.
+
 <!-- Updated: Mar 25, 2026 -->
 ## 🔄 Version Routing
 
@@ -355,7 +371,7 @@ Uses `shared/verification/verify-pipeline.js`:
      - Verify quality gate and profile assignments
      - Verify project settings, tags, links, new code periods, DevOps bindings
      - Verify project permissions
-5. **Portfolio check** — reference verification (SQ only)
+5. **Portfolio check** — reference-only verification (always skipped; requires Enterprise API access that is not available). SonarQube portfolios are listed in the report for manual reference but no SonarCloud comparison is performed.
 6. **Generate reports** — JSON, Markdown, PDF, and console summary
 
 <!-- Updated: Mar 25, 2026 -->

--- a/docs/bespoke-algorithms.md
+++ b/docs/bespoke-algorithms.md
@@ -192,17 +192,28 @@ CloudVoyager checkpoints migration progress so a run can be resumed after any in
 
 ## 5. Issue Batch Distribution (Upload-Side 10K Mitigation)
 
-<!-- <section-updated last-updated="2026-04-20T00:00:00Z" updated-by="Claude" /> -->
+<!-- updated: 2026-04-22_14:30:00 -->
+<!-- <section-updated last-updated="2026-04-22T14:30:00Z" updated-by="Claude" /> -->
 
-SonarCloud's Elasticsearch visualization layer caps results at 10,000 per date bucket. When CloudVoyager migrates a branch with tens of thousands of issues, they all land on a single `analysis_date`, making only the first 10K visible in the UI. The batch distributor splits issues across multiple scanner reports with distinct dates.
+### Problem
+
+SonarCloud's Elasticsearch visualization layer caps results at **10,000 issues per date bucket**. When CloudVoyager migrates a branch, the scanner report is uploaded with a single `analysis_date` (the `extractedAt` timestamp from the source SonarQube instance). If the branch carries more than 10K issues, only the first 10,000 are visible in the SonarCloud UI — the rest silently disappear from the Issues tab. This is an ES index-time bucketing limitation, not an API pagination issue, so it cannot be solved client-side.
+
+The batch distributor solves this by splitting the issues across multiple scanner report uploads, each assigned a **distinct analysis date**, so no single date bucket exceeds the ES cap.
 
 ### Algorithm
 
 ```
-transferBranchBatched(extractedData, opts):
-  IF extractedData.issues.length <= 5000:
-    RETURN normal single-report path
+transferBranch(extractedData, opts):
+  // --- shouldBatch gate (in each pipeline's transfer-branch.js) ---
+  IF shouldBatch(extractedData):        // i.e. issues.length > 5000
+    ceTask = transferBranchBatched(extractedData, opts)
+    RETURN { stats: computeBranchStats(extractedData), ceTask }
 
+  // Otherwise: normal single-report path
+  ...
+
+transferBranchBatched(extractedData, opts):
   plan = computeBatchPlan(extractedData.issues.length)
   // plan = [{startIndex, endIndex, batchIndex, isLast}, ...]
   // batchCount = ceil(totalIssues / 5000)
@@ -228,7 +239,7 @@ transferBranchBatched(extractedData, opts):
       batchData.changesets = empty Map
       batchData.duplications = empty Map
 
-    // Build, encode, upload — MUST wait for CE completion
+    // Build protobuf, encode, upload — MUST wait for CE completion
     ceTask = buildEncodeUpload(batchData, { wait: true })
 
   RETURN lastCeTask
@@ -236,11 +247,26 @@ transferBranchBatched(extractedData, opts):
 
 ### Key Invariants
 
-- **Batch size = 5,000 (constant)** — 50% safety margin under the 10K ES limit
-- **Oldest batch submitted first** — the final (newest) batch carries full project data (sources, changesets, duplications)
-- **Sequential upload with wait** — CE processes reports per-project sequentially; concurrent uploads would race
-- **Unique `scmRevisionId` per batch** — without this, CE deduplicates and rejects subsequent batches
-- **Stats from original data** — branch stats are computed from the full `extractedData`, not any single batch
+- **Batch size = 5,000 (constant)** — 50% safety margin under the 10K ES limit.
+- **`shouldBatch` gate** — `transferBranch` checks `issues.length > 5000` before entering the batch path; projects at or below the threshold take the normal single-report path with zero overhead.
+- **Oldest batch submitted first** — batch 0 gets the most-backdated date; the final (newest) batch carries the original `extractedAt` date and full project data (sources, changesets, duplications).
+- **Non-final batches are lightweight** — `sources`, `changesets`, and `duplications` are stripped (set to empty arrays/maps) to reduce upload size. Only the last batch carries these heavy payloads, since SonarCloud keeps only the latest analysis's source snapshots.
+- **Sequential upload with wait** — each batch calls `uploadAndWait` before the next begins. CE processes reports per-project sequentially; concurrent uploads would race and produce indeterminate results.
+- **Unique `scmRevisionId` per batch** — generated via `randomBytes(20).toString('hex')`. Without a unique revision, CE deduplicates and silently rejects subsequent batches for the same branch.
+- **Stats computed from original data** — `computeBranchStats` runs on the full `extractedData` (before slicing), not on any single batch, ensuring accurate totals.
+
+### Pipeline Integration
+
+Each pipeline version (sq-9.9, sq-10.0, sq-10.4, sq-2025) has a `transfer-branch.js` that imports `shouldBatch` from the shared batch-distributor module. The flow is:
+
+```
+transfer-branch.js
+  └── shouldBatch(extractedData)?
+        ├── YES → transfer-branch-batched.js (batch loop)
+        └── NO  → normal single-report build → encode → upload
+```
+
+The `*-batched.js` file in each pipeline wraps that pipeline's specific `ProtobufBuilder` / `ProtobufEncoder` / `ReportUploader` classes inside the batch loop. The shared utilities (`computeBatchPlan`, `computeBatchDate`, `createBatchExtractedData`) are pipeline-agnostic.
 
 ### Implementation
 
@@ -252,9 +278,11 @@ src/shared/utils/batch-distributor/
     compute-batch-plan.js                   — Returns [{startIndex, endIndex, batchIndex, isLast}]
     compute-batch-date.js                   — Backdates: baseDate - N days
     create-batch-extracted-data.js          — Shallow clone with sliced issues + metadata override
-```
 
-Each pipeline version has a `*-batched.js` file that wraps the pipeline-specific build→encode→upload in the batch loop.
+src/pipelines/<version>/transfer-pipeline/helpers/
+  transfer-branch.js                        — shouldBatch gate, delegates to batched or single path
+  transfer-branch-batched.js                — Batch loop: build → encode → uploadAndWait per batch
+```
 
 ---
 

--- a/docs/bespoke-algorithms.md
+++ b/docs/bespoke-algorithms.md
@@ -12,6 +12,7 @@ This document describes custom, non-trivial algorithms implemented from scratch 
 2. [Migration Graph Visualization (Desktop DAG Renderer)](#2-migration-graph-visualization-desktop-dag-renderer)
 3. [Atomic Checkpoint Journal](#3-atomic-checkpoint-journal)
 4. [Protobuf Report Encoding](#4-protobuf-report-encoding)
+5. [Issue Batch Distribution (Upload-Side 10K Mitigation)](#5-issue-batch-distribution-upload-side-10k-mitigation)
 
 ---
 
@@ -186,6 +187,74 @@ CloudVoyager checkpoints migration progress so a run can be resumed after any in
 ### Implementation
 
 `src/shared/state/checkpoint.js`
+
+---
+
+## 5. Issue Batch Distribution (Upload-Side 10K Mitigation)
+
+<!-- <section-updated last-updated="2026-04-20T00:00:00Z" updated-by="Claude" /> -->
+
+SonarCloud's Elasticsearch visualization layer caps results at 10,000 per date bucket. When CloudVoyager migrates a branch with tens of thousands of issues, they all land on a single `analysis_date`, making only the first 10K visible in the UI. The batch distributor splits issues across multiple scanner reports with distinct dates.
+
+### Algorithm
+
+```
+transferBranchBatched(extractedData, opts):
+  IF extractedData.issues.length <= 5000:
+    RETURN normal single-report path
+
+  plan = computeBatchPlan(extractedData.issues.length)
+  // plan = [{startIndex, endIndex, batchIndex, isLast}, ...]
+  // batchCount = ceil(totalIssues / 5000)
+
+  baseDate = extractedData.metadata.extractedAt
+
+  FOR EACH batch IN plan:
+    // Last batch gets baseDate; earlier batches are backdated
+    batchDate = baseDate - (plan.length - 1 - batch.batchIndex) days
+
+    // Unique SCM revision prevents CE deduplication
+    batchScmId = randomBytes(20).toString('hex')
+
+    // Shallow clone with sliced issues + overridden metadata
+    batchData = clone(extractedData)
+    batchData.issues = extractedData.issues[batch.startIndex..batch.endIndex]
+    batchData.metadata.extractedAt = batchDate
+    batchData.metadata.scmRevisionId = batchScmId
+
+    // Strip heavy payloads from non-final batches
+    IF NOT batch.isLast:
+      batchData.sources = []
+      batchData.changesets = empty Map
+      batchData.duplications = empty Map
+
+    // Build, encode, upload — MUST wait for CE completion
+    ceTask = buildEncodeUpload(batchData, { wait: true })
+
+  RETURN lastCeTask
+```
+
+### Key Invariants
+
+- **Batch size = 5,000 (constant)** — 50% safety margin under the 10K ES limit
+- **Oldest batch submitted first** — the final (newest) batch carries full project data (sources, changesets, duplications)
+- **Sequential upload with wait** — CE processes reports per-project sequentially; concurrent uploads would race
+- **Unique `scmRevisionId` per batch** — without this, CE deduplicates and rejects subsequent batches
+- **Stats from original data** — branch stats are computed from the full `extractedData`, not any single batch
+
+### Implementation
+
+```
+src/shared/utils/batch-distributor/
+  index.js                                  — Re-exports all helpers
+  helpers/
+    should-batch.js                         — Gate: issues.length > 5000
+    compute-batch-plan.js                   — Returns [{startIndex, endIndex, batchIndex, isLast}]
+    compute-batch-date.js                   — Backdates: baseDate - N days
+    create-batch-extracted-data.js          — Shallow clone with sliced issues + metadata override
+```
+
+Each pipeline version has a `*-batched.js` file that wraps the pipeline-specific build→encode→upload in the batch loop.
 
 ---
 

--- a/docs/bespoke-algorithms.md
+++ b/docs/bespoke-algorithms.md
@@ -1,6 +1,6 @@
 # Bespoke Algorithms
 
-<!-- <doc-updated last-updated="2026-04-01T00:00:00Z" updated-by="Claude" /> -->
+<!-- <doc-updated last-updated="2026-04-21T00:00:00Z" updated-by="Claude" /> -->
 
 This document describes custom, non-trivial algorithms implemented from scratch within CloudVoyager — logic that required deliberate design decisions rather than off-the-shelf solutions.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # ⚙️ Configuration
 
-<!-- Last updated: Mar 26, 2026 -->
+<!-- Last updated: Apr 21, 2026 -->
 
 CloudVoyager supports two configuration formats depending on the command you're using.
 

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -1,6 +1,6 @@
 # Desktop App
 
-<!-- Updated: Mar 26, 2026 -->
+<!-- Updated: Apr 21, 2026 -->
 
 CloudVoyager Desktop wraps the CLI binary in a guided wizard UI built with Electron. No terminal needed — fill in forms, click Start, and watch live logs stream in real-time. All configuration persists between app restarts with encrypted token storage.
 

--- a/docs/dry-run-csv-reference.md
+++ b/docs/dry-run-csv-reference.md
@@ -1,6 +1,6 @@
 # Dry-Run CSV Reference
 
-<!-- Last updated: Mar 25, 2026 -->
+<!-- Last updated: Apr 21, 2026 -->
 
 ## Overview
 

--- a/docs/key-capabilities.md
+++ b/docs/key-capabilities.md
@@ -878,7 +878,7 @@ Performance and rate-limit schemas are shared across all configuration types, en
 - **`--dry-run`** — Execute extraction and mapping without writing to SonarCloud
 - **`--verbose`** — Debug-level logging for troubleshooting
 
-<!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
+<!-- updated: 2026-04-22_02:05:00 -->
 ### Logging
 
 Winston-based logging with:
@@ -886,6 +886,17 @@ Winston-based logging with:
 - Optional file output via `LOG_FILE` environment variable
 - Structured timestamps and log formatting
 - `--verbose` flag sets level to `debug`
+
+**Automatic file logging** — Every command (`migrate`, `transfer`, `verify`, `sync-metadata`) writes three log files to `migration-output/logs/`:
+
+| File | Contents |
+|------|----------|
+| `cloudvoyager-{cmd}-{timestamp}.log` | All log levels (raw/unfiltered) |
+| `cloudvoyager-{cmd}-{timestamp}.info.log` | Only `info` level entries |
+| `cloudvoyager-{cmd}-{timestamp}.warn.log` | Only `warn` level entries |
+| `cloudvoyager-{cmd}-{timestamp}.error.log` | Only `error` level entries |
+
+The filtered logs make it easy to triage issues without searching through thousands of info-level lines.
 
 ---
 

--- a/docs/key-capabilities.md
+++ b/docs/key-capabilities.md
@@ -1,6 +1,6 @@
 # CloudVoyager — Key Capabilities
 
-<!-- Last updated: Apr 21, 2026 -->
+<!-- Last updated: Apr 22, 2026 -->
 
 A comprehensive overview of CloudVoyager's engineering, architecture, and capabilities for techno-functional leadership review.
 
@@ -35,6 +35,7 @@ A comprehensive overview of CloudVoyager's engineering, architecture, and capabi
 24. [Desktop Application (Electron GUI)](#24-desktop-application-electron-gui)
 25. [Pipeline Modularization](#25-pipeline-modularization)
 26. [Desktop App Progress Tracking](#26-desktop-app-progress-tracking)
+27. [Issue Batch Distribution](#27-issue-batch-distribution)
 
 ---
 
@@ -773,12 +774,12 @@ The checkpoint system consists of five cooperating components:
 
 ---
 
-<!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
+<!-- updated: 2026-04-22_14:30:00 -->
 ## 18. Comprehensive Reporting Suite
 
-The migration pipeline generates reports in **6 formats** across **3 report types**:
+The migration pipeline generates reports in **6 formats** across **3 report types**. Both the `migrate` and `verify` commands produce reports in JSON, Markdown, and PDF formats.
 
-<!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
+<!-- updated: 2026-04-22_14:30:00 -->
 ### Report Types
 
 | Report | Purpose | Audience |
@@ -1100,6 +1101,65 @@ Renders a pixel-art whale sprite that moves across the screen as progress advanc
 - Typewriter effect for phase labels
 - Dark/light theme support with distinct color palettes
 - Completion state: green trail, animation stops on spout frame
+
+---
+
+<!-- updated: 2026-04-22_14:30:00 -->
+## 27. Issue Batch Distribution
+
+<!-- updated: 2026-04-22_14:30:00 -->
+### The Problem
+
+SonarCloud's Elasticsearch-backed UI has a visualization limit that hides issues when more than 10,000 exist in a single date bucket. For large projects migrated in a single scanner report, this means a significant portion of issues become invisible in the SonarCloud interface despite being successfully ingested.
+
+<!-- updated: 2026-04-22_14:30:00 -->
+### The Solution
+
+CloudVoyager automatically detects when a branch has more than 5,000 issues and splits them into batches of 5,000, submitting each batch as a separate scanner report. This is implemented in `src/shared/utils/batch-distributor/` as four cooperating modules:
+
+| Module | Purpose |
+|--------|---------|
+| `should-batch.js` | Threshold check — returns `true` when `extractedData.issues.length > 5000` |
+| `compute-batch-plan.js` | Divides the total issue count into batch descriptors with `startIndex`, `endIndex`, `batchIndex`, and `isLast` flag |
+| `compute-batch-date.js` | Assigns each batch a distinct `analysis_date` by going backwards from the base date — one day per batch, so the earliest batch gets the oldest date |
+| `create-batch-extracted-data.js` | Creates a shallow clone of the extracted data for each batch with sliced issues, overridden metadata, and payload stripping for non-final batches |
+
+<!-- updated: 2026-04-22_14:30:00 -->
+### Batch Date Assignment
+
+Each batch receives a backdated `analysis_date` calculated as:
+
+```
+daysBack = totalBatches - 1 - batchIndex
+batchDate = baseDate - daysBack days
+```
+
+For example, with 15,000 issues and a base date of 2026-04-22, three batches are created:
+- **Batch 0** (issues 0–4999): `analysis_date = 2026-04-20`
+- **Batch 1** (issues 5000–9999): `analysis_date = 2026-04-21`
+- **Batch 2** (issues 10000–14999): `analysis_date = 2026-04-22` (original date, final batch)
+
+This ensures each batch lands in a separate Elasticsearch date bucket, keeping every batch under the 10K visualization threshold.
+
+<!-- updated: 2026-04-22_14:30:00 -->
+### Payload Optimization
+
+Non-final batches strip heavy payload data that only the latest analysis needs:
+- **Sources** — set to empty array
+- **Changesets** — set to empty Map
+- **Duplications** — set to empty Map
+
+Components and active rules are retained in all batches so that issues can be resolved against their component references. Only the final batch carries the full project data (sources, changesets, duplications) alongside the original analysis date.
+
+<!-- updated: 2026-04-22_14:30:00 -->
+### Deduplication Prevention
+
+Each batch receives a unique `scmRevisionId` generated via `randomBytes(20).toString('hex')`. This prevents SonarCloud's Compute Engine from rejecting batches as duplicate submissions, since CE uses the SCM revision to detect re-uploads.
+
+<!-- updated: 2026-04-22_14:30:00 -->
+### Submission Order
+
+Batches are submitted oldest-first (lowest `batchIndex` first). Each batch waits for its CE task to complete before the next batch is submitted, ensuring SonarCloud processes them in chronological order. The batching is transparent to the caller — `transferBranch` automatically detects when batching is needed and routes accordingly.
 
 ---
 

--- a/docs/key-capabilities.md
+++ b/docs/key-capabilities.md
@@ -216,6 +216,10 @@ The report is submitted to SonarCloud's CE endpoint as a multipart form upload w
 
 Each report includes an `scm_revision_id` (git commit hash) in its metadata. SonarCloud uses this to detect and reject duplicate submissions, preventing accidental data duplication across multiple migration runs.
 
+### Issue Batching for Large Projects
+
+When a branch has more than 5,000 issues, CloudVoyager automatically splits the issues into batches of 5,000 and submits each batch as a separate scanner report with a distinct `analysis_date` going backwards from today. This prevents hitting SonarCloud's Elasticsearch visualization limit of 10K results per date bucket, ensuring all migrated issues are visible in the UI. The batching is transparent to the caller — `transferBranch` automatically detects when batching is needed and routes accordingly. Non-final batches strip sources, changesets, and duplications to minimize upload size, while keeping components and active rules for issue resolution. Each batch uses a unique `scmRevisionId` to prevent CE deduplication.
+
 <!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
 ### Branch Name Resolution
 
@@ -1000,6 +1004,7 @@ This ensures the verification is comparing exactly the same pairs that were sync
 | Zero-dependency concurrency | Avoid bloat; the custom implementation is ~80 lines and covers all use cases |
 | Dual packaging backends (SEA + Bun) | Node.js SEA for stability (default), Bun compile as experimental alternative for faster builds |
 | Inline proto schemas | Eliminate runtime file I/O dependencies for standalone binary compatibility |
+| Issue batching (5K per date bucket) | Splits large issue sets across multiple scanner reports with backdated `analysis_date` values to stay under SonarCloud's ES 10K visualization limit |
 | Builder-encoder separation | Clean architecture; business logic in builders, serialization in encoder |
 | Non-fatal extraction | Maximize migration completeness even when individual items fail |
 | Settled-mode concurrency | Partial success is better than total failure for large-scale operations |
@@ -1012,7 +1017,7 @@ This ensures the verification is comparing exactly the same pairs that were sync
 1. **No existing tool does this.** CloudVoyager is the first to reverse-engineer SonarScanner's protobuf protocol and reconstruct it programmatically.
 2. **Zero source code access required.** The migration operates entirely at the API level — no repository cloning, no build systems, no CI/CD integration needed.
 3. **Complete fidelity.** Issues, hotspots, measures, quality gates, quality profiles, permissions, groups, templates, portfolios, settings, tags, links, bindings, and new code periods are all preserved.
-4. **Handles projects with 10,000+ issues.** SonarQube caps `/api/issues/search` at 10K results; CloudVoyager automatically detects this and uses date-window bisection (search slicing) to retrieve every issue without data loss.
+4. **Handles projects with 10,000+ issues.** SonarQube caps `/api/issues/search` at 10K results; CloudVoyager automatically detects this and uses date-window bisection (search slicing) to retrieve every issue without data loss. On the upload side, issues are batched into groups of 5,000 with distinct `analysis_date` values to stay under SonarCloud's Elasticsearch visualization limit.
 5. **Robust external issue detection.** Third-party plugin issues are reliably detected even when the SonarCloud rule-repository API is unreachable, using a built-in fallback set of 43 known repositories with retry and exponential backoff.
 6. **Production-proven at scale.** Successfully migrated 29 projects with 16,000+ issues in a single automated run.
 7. **Single binary, zero dependencies.** Distributed as a standalone executable — no runtime, no package manager, no setup.

--- a/docs/key-capabilities.md
+++ b/docs/key-capabilities.md
@@ -1,6 +1,6 @@
 # CloudVoyager — Key Capabilities
 
-<!-- Last updated: Mar 26, 2026 -->
+<!-- Last updated: Apr 21, 2026 -->
 
 A comprehensive overview of CloudVoyager's engineering, architecture, and capabilities for techno-functional leadership review.
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,6 +1,6 @@
 # 🛠️ Local Development
 
-<!-- Last updated: Mar 26, 2026 — updated build pipeline, testing, CI/CD details, SonarCloud scanning -->
+<!-- Last updated: Apr 21, 2026 — updated build pipeline, testing, CI/CD details, SonarCloud scanning -->
 
 Use this guide to build and run CloudVoyager locally. All developers should **build the binary and run that** — do not run directly from source. This ensures consistent behavior across environments and eliminates "works on my machine" issues.
 

--- a/docs/pseudocode-explanation.md
+++ b/docs/pseudocode-explanation.md
@@ -152,6 +152,10 @@ FUNCTION transferProject(sonarqubeConfig, sonarcloudConfig, transferConfig, perf
 
 FUNCTION transferBranch(extractedData, branch, scConfig, scProfiles, scRepos, ...):
 
+  // --- Batch Gate ---
+  IF shouldBatch(extractedData):    // issues.length > 5000
+    RETURN transferBranchBatched(extractedData, branch, scConfig, ...)
+
   // Step 1: Build protobuf messages from extracted data
   builder = new ProtobufBuilder(extractedData, scConfig, scProfiles, options)
   messages = builder.buildAll()
@@ -165,7 +169,25 @@ FUNCTION transferBranch(extractedData, branch, scConfig, scProfiles, scRepos, ..
   uploader = new ReportUploader(scClient)
   ceTask = uploader.upload(encodedReport, metadata)
 
-  RETURN { stats, ceTask }
+  RETURN { stats: computeBranchStats(extractedData), ceTask }
+
+
+FUNCTION transferBranchBatched(extractedData, branch, scConfig, ...):
+
+  // Split issues into batches of 5,000 with backdated analysis dates
+  plan = computeBatchPlan(extractedData.issues.length)
+  baseDate = extractedData.metadata.extractedAt
+
+  FOR EACH batch IN plan:
+    batchDate = computeBatchDate(baseDate, batch.batchIndex, plan.length)
+    batchScmId = randomBytes(20).toString('hex')
+    batchData = createBatchExtractedData(extractedData, batch, batchDate, batchScmId)
+
+    // Build, encode, upload — wait for CE completion before next batch
+    ceTask = buildEncodeUpload(batchData, { wait: true })
+
+  // Stats use ORIGINAL data (all issues), not any single batch
+  RETURN { stats: computeBranchStats(extractedData), ceTask: lastCeTask }
 ```
 
 ---

--- a/docs/scenario-multi-org.md
+++ b/docs/scenario-multi-org.md
@@ -1,6 +1,6 @@
 # 🏢 Migrate Everything to Multiple SonarCloud Organizations
 
-<!-- Last updated: Mar 20, 2026 -->
+<!-- Last updated: Apr 21, 2026 -->
 
 Use this when you want to migrate **all projects and configuration** from your SonarQube server to **multiple** SonarCloud organizations — for example, when different teams or business units each have their own SonarCloud org.
 

--- a/docs/scenario-single-org.md
+++ b/docs/scenario-single-org.md
@@ -1,6 +1,6 @@
 # 🏢 Migrate Everything to One SonarCloud Organization
 
-<!-- Last updated: Mar 20, 2026 -->
+<!-- Last updated: Apr 21, 2026 -->
 
 Use this when you want to migrate **all projects and configuration** from your SonarQube server to a **single** SonarCloud organization.
 

--- a/docs/scenario-single-project.md
+++ b/docs/scenario-single-project.md
@@ -1,6 +1,6 @@
 # 📦 Migrate a Single Project
 
-<!-- Last updated: Mar 20, 2026 -->
+<!-- Last updated: Apr 21, 2026 -->
 
 Use this when you want to migrate **one specific project** from SonarQube to SonarCloud.
 

--- a/docs/technical-details.md
+++ b/docs/technical-details.md
@@ -252,6 +252,57 @@ The extractors handle these lower limits automatically.
 
 **metricKeys batching**: SQ 9.9 through 10.8 limits `metricKeys` to 15 per request (must batch). SQ 2025.1+ has no batching limit.
 
+<!-- Updated: Apr 20, 2026 -->
+## 📦 Issue Batching for Upload (5K Per Date Bucket)
+
+SonarCloud's Elasticsearch caps **visualization** at 10,000 results per date bucket. When a branch has more than 5,000 issues, submitting them all in a single scanner report (with one `analysis_date`) means only 10K are visible — even though all issues exist in the database.
+
+**Solution:** `src/shared/utils/batch-distributor/` splits large issue sets into batches of up to 5,000, each submitted as a separate scanner report with a distinct `analysis_date` going backwards from today.
+
+### Algorithm
+
+1. **Gate** — `should-batch.js`: if `extractedData.issues.length > 5000`, batching activates
+2. **Plan** — `compute-batch-plan.js`: `batchCount = ceil(totalIssues / 5000)`, returns `[{startIndex, endIndex, batchIndex, isLast}]`
+3. **Date** — `compute-batch-date.js`: last batch (newest) gets the original date; earlier batches are backdated one day each (`baseDate - (totalBatches - 1 - batchIndex)` days)
+4. **Clone** — `create-batch-extracted-data.js`: shallow-clones `extractedData` with sliced `issues` array, overridden `metadata.extractedAt` and unique `metadata.scmRevisionId` (via `randomBytes(20)`)
+5. **Trim** — Non-final batches strip `sources`, `changesets`, and `duplications` (set to `[]` / `new Map()`) to reduce upload size. `components` and `activeRules` are kept for issue resolution.
+6. **Upload** — Each batch is built, encoded, and uploaded sequentially with `wait: true` (CE must complete before the next batch)
+
+### Example
+
+A branch with 20,590 issues on 2026-05-12:
+
+| Batch | Issues | analysis_date | Submitted |
+|-------|--------|---------------|-----------|
+| 1/5 | 1–5,000 | 2026-05-08 | First (oldest) |
+| 2/5 | 5,001–10,000 | 2026-05-09 | |
+| 3/5 | 10,001–15,000 | 2026-05-10 | |
+| 4/5 | 15,001–20,000 | 2026-05-11 | |
+| 5/5 | 20,001–20,590 | 2026-05-12 | Last (newest, carries full project data) |
+
+### Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Batch size = 5,000 (hardcoded) | 50% safety margin under ES 10K visualization limit |
+| Submit oldest batch first | Final (newest) analysis carries full project data for UI display |
+| Strip sources from non-final batches | Biggest payload reduction; components stay for issue resolution |
+| Unique `scmRevisionId` per batch | Prevents CE deduplication across batches |
+| Always wait between batches | CE processes reports sequentially per project; avoids race conditions |
+
+### Helper Files (`src/shared/utils/batch-distributor/helpers/`)
+
+| File | Role |
+|------|------|
+| `should-batch.js` | Predicate: `issues.length > 5000` |
+| `compute-batch-plan.js` | Returns batch descriptors with start/end indices |
+| `compute-batch-date.js` | Computes backdated ISO date per batch |
+| `create-batch-extracted-data.js` | Shallow-clones extracted data with sliced issues + overridden metadata |
+
+### Pipeline Integration
+
+All 4 pipeline versions (sq-9.9, sq-10.0, sq-10.4, sq-2025) integrate batching via a `shouldBatch` gate in the `transferBranch` entry point. Each pipeline has a `*-batched.js` sibling file containing the batch loop. The batching is transparent to callers — `transferBranch` automatically routes to the batched path when issues exceed 5,000.
+
 <!-- Updated: Mar 28, 2026 -->
 ## 🔍 Search Slicing for 10K+ Issues
 

--- a/docs/technical-details.md
+++ b/docs/technical-details.md
@@ -1,8 +1,8 @@
 # 🔬 Technical Details
 
-<!-- Last updated: Apr 21, 2026 (issue batching 5K per date bucket, issue sync pre-filter optimization, SC indexing wait, SonarCloud 10K issue slicing, githubactions language support, SQC US instance, enterprise key optional, search-slicer for SQC, fallback rule repositories, protobuf details, external issues, enum values, error hierarchy, state management, API gotchas, CE retry, issue status mapping, checkpoint extraction, CSV filtering) -->
+<!-- Last updated: Apr 22, 2026 (batch-distributor in pipeline flow diagram, backdating strategy docs, scmRevisionId per-batch note, issue batching 5K per date bucket, issue sync pre-filter optimization, SC indexing wait, SonarCloud 10K issue slicing, githubactions language support, SQC US instance, enterprise key optional, search-slicer for SQC, fallback rule repositories, protobuf details, external issues, enum values, error hierarchy, state management, API gotchas, CE retry, issue status mapping, checkpoint extraction, CSV filtering) -->
 
-<!-- Updated: Apr 18, 2026 -->
+<!-- updated: 2026-04-22_14:30:00 -->
 ## 🗺️ Main Flow Sequence Diagram
 
 The diagram below shows the high-level flows for the four main commands. The **➕** markers reference the drill-down prompts in the table that follows — paste any prompt into a new chat (with this codebase in context) to generate a detailed diagram for that subsystem.
@@ -33,13 +33,27 @@ sequenceDiagram
         SQ-->>CLI: extracted data (gzipped cache per phase)
 
         Note over CLI: ➕B  Build & encode protobuf report
-        CLI->>CLI: build Issue / ExternalIssue / AdHocRule messages
-        CLI->>CLI: build Measure / Component / Changeset messages
-        CLI->>CLI: zip → scanner-report.zip
 
-        Note over CLI,SC: ➕C  Upload & CE retry
-        CLI->>SC: POST /api/ce/submit (scanner-report.zip)
-        SC-->>CLI: CE task ID (or timeout → poll /api/ce/activity)
+        alt issues > 5,000 (batch distribution)
+            CLI->>CLI: shouldBatch() → true
+            CLI->>CLI: computeBatchPlan(totalIssues) → N batches of ≤5,000
+            loop For each batch (oldest first)
+                CLI->>CLI: computeBatchDate() → backdated analysis_date
+                CLI->>CLI: createBatchExtractedData() (slice issues, unique scmRevisionId)
+                CLI->>CLI: build protobuf messages + zip → scanner-report.zip
+                Note over CLI,SC: ➕C  Upload & CE retry (per batch)
+                CLI->>SC: POST /api/ce/submit (batch scanner-report.zip)
+                SC-->>CLI: CE task ID → wait for completion before next batch
+            end
+        else issues ≤ 5,000 (single upload)
+            CLI->>CLI: build Issue / ExternalIssue / AdHocRule messages
+            CLI->>CLI: build Measure / Component / Changeset messages
+            CLI->>CLI: zip → scanner-report.zip
+
+            Note over CLI,SC: ➕C  Upload & CE retry
+            CLI->>SC: POST /api/ce/submit (scanner-report.zip)
+            SC-->>CLI: CE task ID (or timeout → poll /api/ce/activity)
+        end
 
         Note over CLI,SC: ➕D  Issue & hotspot metadata sync
         CLI->>SQ: fetch issues + changelogs (sliced for >10K)
@@ -135,6 +149,7 @@ sequenceDiagram
 | ➕D | Issue sync | `Generate a mermaid sequence diagram showing the full issue sync pipeline in CloudVoyager including pre-filter, SC indexing wait, and changelog replay` |
 | ➕E | Org mapping / CSVs | `Generate a mermaid sequence diagram showing how CloudVoyager maps SonarQube projects to SonarCloud organizations and generates dry-run CSV files` |
 | ➕F | Quality profiles | `Generate a mermaid sequence diagram for CloudVoyager quality profile migration including backup XML, rename of built-in profiles, and diff report` |
+| ➕G | Batch distribution | `Generate a mermaid sequence diagram showing how CloudVoyager batch-distributor splits large issue sets into ≤5K batches with backdated analysis dates and sequential CE uploads` |
 
 <!-- Updated: Mar 25, 2026 -->
 ## 📡 Protobuf Encoding
@@ -219,10 +234,12 @@ Measures use typed value fields based on metric type:
 
 Components use a flat structure - all files are direct children of the project component (no directory components). Line counts are derived from actual source file content rather than SonarQube measures API values.
 
-<!-- Updated: Mar 25, 2026 -->
+<!-- updated: 2026-04-22_14:30:00 -->
 ## 🔖 SCM Revision Tracking
 
 The tool includes `scm_revision_id` (git commit hash) in metadata. SonarCloud uses this to detect and reject duplicate reports, enabling proper analysis history tracking.
+
+**Batch uploads**: When issue batching is active (>5,000 issues), each batch receives a unique `scmRevisionId` generated via `randomBytes(20).toString('hex')` instead of the original git commit hash. This prevents the SonarCloud CE from deduplicating successive batch uploads as identical reports. See [Issue Batching for Upload](#-issue-batching-for-upload-5k-per-date-bucket) for details.
 
 <!-- Updated: Mar 25, 2026 -->
 ## 🌿 Branch Sync
@@ -252,7 +269,7 @@ The extractors handle these lower limits automatically.
 
 **metricKeys batching**: SQ 9.9 through 10.8 limits `metricKeys` to 15 per request (must batch). SQ 2025.1+ has no batching limit.
 
-<!-- Updated: Apr 20, 2026 -->
+<!-- updated: 2026-04-22_14:30:00 -->
 ## 📦 Issue Batching for Upload (5K Per Date Bucket)
 
 SonarCloud's Elasticsearch caps **visualization** at 10,000 results per date bucket. When a branch has more than 5,000 issues, submitting them all in a single scanner report (with one `analysis_date`) means only 10K are visible — even though all issues exist in the database.
@@ -280,6 +297,16 @@ A branch with 20,590 issues on 2026-05-12:
 | 4/5 | 15,001–20,000 | 2026-05-11 | |
 | 5/5 | 20,001–20,590 | 2026-05-12 | Last (newest, carries full project data) |
 
+### Backdating Strategy
+<!-- updated: 2026-04-22_14:30:00 -->
+
+Each batch needs a distinct `analysis_date` so that SonarCloud's Elasticsearch distributes issues across separate date buckets (each bucket can display up to 10K results). The dates are computed by `computeBatchDate()` going **backwards from the original date**:
+
+- The **final batch** (highest index, newest) keeps the **original `analysis_date`** from the extraction. This ensures the latest analysis in SonarCloud carries the full project data (sources, changesets, duplications) and represents the "current" state.
+- **Earlier batches** are backdated by one calendar day each: `originalDate - (totalBatches - 1 - batchIndex)` days. Batch 0 (first submitted) gets the oldest date; batch N-1 (last submitted) gets the original date.
+
+This means for 5 batches with an original date of 2026-05-12, the dates are 2026-05-08, 2026-05-09, 2026-05-10, 2026-05-11, 2026-05-12. The sequential submission (oldest first) ensures SonarCloud's analysis timeline reads chronologically.
+
 ### Design Decisions
 
 | Decision | Rationale |
@@ -287,8 +314,9 @@ A branch with 20,590 issues on 2026-05-12:
 | Batch size = 5,000 (hardcoded) | 50% safety margin under ES 10K visualization limit |
 | Submit oldest batch first | Final (newest) analysis carries full project data for UI display |
 | Strip sources from non-final batches | Biggest payload reduction; components stay for issue resolution |
-| Unique `scmRevisionId` per batch | Prevents CE deduplication across batches |
+| Unique `scmRevisionId` per batch | Prevents CE deduplication across batches — each batch uses `randomBytes(20).toString('hex')` |
 | Always wait between batches | CE processes reports sequentially per project; avoids race conditions |
+| Backdate one day per batch | Distributes issues across separate ES date buckets; final batch retains the real date |
 
 ### Helper Files (`src/shared/utils/batch-distributor/helpers/`)
 

--- a/docs/technical-details.md
+++ b/docs/technical-details.md
@@ -1,6 +1,6 @@
 # 🔬 Technical Details
 
-<!-- Last updated: Apr 18, 2026 (issue sync pre-filter optimization, SC indexing wait, SonarCloud 10K issue slicing, githubactions language support, SQC US instance, enterprise key optional, search-slicer for SQC, fallback rule repositories, protobuf details, external issues, enum values, error hierarchy, state management, API gotchas, CE retry, issue status mapping, checkpoint extraction, CSV filtering) -->
+<!-- Last updated: Apr 21, 2026 (issue batching 5K per date bucket, issue sync pre-filter optimization, SC indexing wait, SonarCloud 10K issue slicing, githubactions language support, SQC US instance, enterprise key optional, search-slicer for SQC, fallback rule repositories, protobuf details, external issues, enum values, error hierarchy, state management, API gotchas, CE retry, issue status mapping, checkpoint extraction, CSV filtering) -->
 
 <!-- Updated: Apr 18, 2026 -->
 ## 🗺️ Main Flow Sequence Diagram

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -614,6 +614,35 @@ The search slicer algorithm:
 
 ---
 
+<!-- Updated: Apr 20, 2026 -->
+## 📦 Issue Batching (Multiple Scanner Reports Per Branch)
+
+When a branch has more than 5,000 issues, CloudVoyager automatically splits them into batches of 5,000 and submits each batch as a separate scanner report with a distinct `analysis_date`. This prevents SonarCloud's Elasticsearch visualization limit (10K per date bucket) from hiding issues.
+
+### Why am I seeing multiple uploads for one branch?
+
+**Expected behavior (v1.3+).** If a branch has more than 5,000 issues, CloudVoyager logs:
+
+```
+Splitting 20590 issues into 5 batches of up to 5,000
+```
+
+Each batch is uploaded sequentially (the tool waits for CE completion before sending the next batch). The final batch carries the original analysis date and full project data (sources, changesets, duplications). Earlier batches are backdated by one day each and carry only issues + components + active rules.
+
+### Upload interrupted mid-batch
+
+If a transfer is interrupted between batches, re-run the same command. The branch status stays `started` in the checkpoint journal, so all batches will be re-uploaded from the beginning. This is safe — each batch uses a unique `scmRevisionId`, so CE will not reject them as duplicates.
+
+### Issue counts look correct in the API but not in the UI
+
+This is the exact problem batching solves. Without batching, all issues share one `analysis_date` and SonarCloud's Elasticsearch only visualizes the first 10K per date bucket. If you migrated before v1.3 and have this problem, re-transfer the affected projects — the batch distributor will split the issues automatically.
+
+### Can I change the batch size?
+
+The batch size is hardcoded at 5,000 (50% safety margin under the 10K ES limit). It is not configurable.
+
+---
+
 ## 🔌 Third-Party Issues Not Appearing in SonarCloud
 
 External (third-party) issues from SonarQube plugins not available in SonarCloud (e.g., MuleSoft, ABAP) may be silently dropped if the rule-repository detection fails.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -417,8 +417,10 @@ You can also sync just one type of metadata at a time:
 ./cloudvoyager sync-metadata -c migrate-config.json --skip-issue-metadata-sync --verbose
 ```
 
-<!-- Updated: Feb 28, 2026 at 12:00:00 PM -->
+<!-- updated: 2026-04-22_14:30:00 -->
 ## ✅ Verification Reports
+
+> **Import bug fixes (v1.3):** Earlier versions had missing imports in `issue-details.js`, `hotspot-details.js`, and `format-pdf/index.js` that could cause report generation to fail with `ReferenceError` or produce incomplete output. These have been fixed in v1.3. If you encountered report generation errors on a prior version, upgrade and re-run `verify`.
 
 After migration, use the `verify` command to generate a detailed pass/fail comparison of SonarQube vs SonarCloud data:
 
@@ -583,10 +585,12 @@ The modern statuses (`FALSE_POSITIVE`, `ACCEPTED`, `FIXED`) do **not** exist in 
 
 ---
 
-<!-- Updated: Mar 28, 2026 -->
+<!-- updated: 2026-04-22_14:30:00 -->
 ## 📊 Projects with 10,000+ Issues
 
 SonarQube's `/api/issues/search` endpoint caps results at 10,000 due to an Elasticsearch hard limit.
+
+> **Note (v1.3+):** Large-project issue handling now has two complementary mechanisms. The **search slicer** handles retrieval of >10K issues from SonarQube by splitting the date range into windows that each stay under the 10K API limit. The **batch distributor** handles uploading >5K issues to SonarCloud by splitting them into multiple scanner reports with distinct `analysis_date` values, preventing the Elasticsearch visualization limit (10K per date bucket) from hiding issues in the UI. Together, these two features ensure that projects of any size are fully extracted from SonarQube and fully visible in SonarCloud.
 
 ### Error: `10001th result asked`
 
@@ -614,10 +618,12 @@ The search slicer algorithm:
 
 ---
 
-<!-- Updated: Apr 20, 2026 -->
+<!-- updated: 2026-04-22_14:30:00 -->
 ## 📦 Issue Batching (Multiple Scanner Reports Per Branch)
 
 When a branch has more than 5,000 issues, CloudVoyager automatically splits them into batches of 5,000 and submits each batch as a separate scanner report with a distinct `analysis_date`. This prevents SonarCloud's Elasticsearch visualization limit (10K per date bucket) from hiding issues.
+
+> **This is automatic and transparent.** Batching is a built-in feature of the upload pipeline, not a workaround. Users do not need to enable it, configure it, or take any special action. The batch distributor detects when a branch exceeds 5,000 issues and handles the splitting, date assignment, and sequential upload internally.
 
 ### Why am I seeing multiple uploads for one branch?
 
@@ -629,9 +635,10 @@ Splitting 20590 issues into 5 batches of up to 5,000
 
 Each batch is uploaded sequentially (the tool waits for CE completion before sending the next batch). The final batch carries the original analysis date and full project data (sources, changesets, duplications). Earlier batches are backdated by one day each and carry only issues + components + active rules.
 
+<!-- updated: 2026-04-22_14:30:00 -->
 ### Upload interrupted mid-batch
 
-If a transfer is interrupted between batches, re-run the same command. The branch status stays `started` in the checkpoint journal, so all batches will be re-uploaded from the beginning. This is safe — each batch uses a unique `scmRevisionId`, so CE will not reject them as duplicates.
+If a transfer is interrupted between batches, re-run the same command. The checkpoint journal tracks batch progress and the branch status stays `started`, so the migration can be safely resumed. All batches for that branch will be re-uploaded from the beginning. This is safe -- each batch uses a unique `scmRevisionId`, so SonarCloud's CE will not reject them as duplicates. No data is lost or corrupted by the interruption.
 
 ### Issue counts look correct in the API but not in the UI
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # 🔧 Troubleshooting
 
-<!-- Last updated: Mar 26, 2026 -->
+<!-- Last updated: Apr 21, 2026 -->
 
 <!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
 ## 🐛 Debugging a Migration Run

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,6 +1,6 @@
 # Verification
 
-<!-- Updated: Mar 25, 2026 -->
+<!-- Updated: Apr 21, 2026 -->
 
 After running a migration, use the `verify` command to compare your SonarQube instance against SonarCloud and confirm that all data was transferred correctly. The verification pipeline is implemented in `src/shared/verification/verify-pipeline.js` and is entirely **read-only** — it does not modify any data on either SonarQube or SonarCloud.
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -374,6 +374,24 @@ SQ may have plugins that add languages not available in SC (e.g., MuleSoft's `mu
 | Line counts (`lines`, `ncloc`) | 1% tolerance — different scanner implementations count lines slightly differently |
 | SQ-only metrics (`statements`, `functions`, `classes`, `coverage`, `line_coverage`) | Informational only — SC may not report these |
 
+### Batch-Distributed Issues and Multiple Analysis Dates
+<!-- updated: 2026-04-22_14:30:00 -->
+
+When a branch has more than 5,000 issues, the migration uses **batch distribution** to split those issues into chunks of up to 5,000 and assigns each chunk a separate `analysis_date` (computed by stepping backwards one day per batch from the original analysis date). This means a single branch that had one analysis in SonarQube may appear in SonarCloud with issues spread across multiple `analysis_date` values.
+
+**This is expected behavior, not a verification failure.** The batch distribution is a migration-time strategy to stay within SonarCloud's import limits and does not affect the correctness of the migrated data.
+
+The verification pipeline compares **total issue counts and attributes** (rule, file, line, status, comments, tags, etc.) across the entire branch — it does not compare per-date counts. As a result, batch distribution should never cause false verification failures. If verification reports an issue-count mismatch, the cause is not the batching itself but a genuine migration gap.
+
+For reference, the batching logic lives in `src/shared/utils/batch-distributor/` and works as follows:
+
+| Concept | Detail |
+|---------|--------|
+| **Threshold** | Batching triggers when a branch has > 5,000 issues |
+| **Chunk size** | Each batch contains up to 5,000 issues |
+| **Date assignment** | Each batch receives a unique date, counting backwards from the original analysis date (batch 0 = oldest, last batch = original date) |
+| **Batch plan** | `computeBatchPlan(totalIssues)` returns an array of `{ startIndex, endIndex, batchIndex, isLast }` descriptors |
+
 ### Tag Differences on Issues
 
 SC may add its own tags to issues that SQ doesn't have (e.g., `type-dependent` on `typescript:S7755`). The verifier only flags tags that are **missing** from SC (SQ tags not found in SC), not extra SC tags.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,5 +1,5 @@
 # Versioning
-<!-- <section-updated last-updated="2026-03-30T00:00:00Z" updated-by="Claude" /> -->
+<!-- <section-updated last-updated="2026-04-21T00:00:00Z" updated-by="Claude" /> -->
 
 How CloudVoyager versions are managed, bumped, and released.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloudvoyager",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cloudvoyager",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.16",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -134,7 +134,7 @@ function seaPackage(distDir, binDir, overridePlatform) {
   writeFileSync(seaConfigPath, JSON.stringify(seaConfig, null, 2));
 
   console.log('Generating SEA blob...');
-  execSync(`node --experimental-sea-config ${seaConfigPath}`, {
+  execSync(`node --experimental-sea-config "${seaConfigPath}"`, {
     cwd: rootDir,
     stdio: 'inherit',
   });

--- a/src/pipelines/sq-10.0/migrate-pipeline/helpers/prepare-output-dir.js
+++ b/src/pipelines/sq-10.0/migrate-pipeline/helpers/prepare-output-dir.js
@@ -1,4 +1,5 @@
-import { mkdir, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { mkdir, readdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import logger from '../../../../shared/utils/logger.js';
 
@@ -8,7 +9,13 @@ export async function prepareOutputDir(outputDir, isResume) {
   const dirs = [outputDir, join(outputDir, 'state'), join(outputDir, 'quality-profiles'), join(outputDir, 'logs')];
   if (!isResume) {
     logger.info(`Cleaning output directory: ${outputDir}`);
-    await rm(outputDir, { recursive: true, force: true });
+    if (existsSync(outputDir)) {
+      const entries = await readdir(outputDir);
+      for (const entry of entries) {
+        if (entry === 'logs') continue;
+        await rm(join(outputDir, entry), { recursive: true, force: true });
+      }
+    }
   }
   for (const dir of dirs) {
     await mkdir(dir, { recursive: true });

--- a/src/pipelines/sq-10.0/sonarcloud/migrators/project-config/helpers/migrate-new-code-periods.js
+++ b/src/pipelines/sq-10.0/sonarcloud/migrators/project-config/helpers/migrate-new-code-periods.js
@@ -20,7 +20,7 @@ export async function migrateNewCodePeriods(projectKey, newCodeData, client) {
   logger.info(`Setting new code definition for ${projectKey}: ${settings.map(s => `${s.key}=${s.value}`).join(', ')} (from ${sourceLabel})`);
 
   try {
-    for (const setting of settings) await client.setProjectSetting(setting.key, setting.value, projectKey);
+    for (const setting of settings) await client.setProjectSetting(setting.key, { value: setting.value }, projectKey);
   } catch (error) {
     logger.warn(`Failed to set new code definition for ${projectKey}: ${error.message}`);
     throw error;

--- a/src/pipelines/sq-10.0/transfer-branch/helpers/transfer-branch-batched.js
+++ b/src/pipelines/sq-10.0/transfer-branch/helpers/transfer-branch-batched.js
@@ -1,0 +1,43 @@
+import { randomBytes } from 'node:crypto';
+import { computeBatchPlan, computeBatchDate, createBatchExtractedData } from '../../../../shared/utils/batch-distributor.js';
+import { buildAndEncodeReport } from './build-and-encode-report.js';
+import logger from '../../../../shared/utils/logger.js';
+import { ReportUploader } from '../../sonarcloud/uploader.js';
+
+// -------- Batched Branch Transfer --------
+
+/** Split issues into batches and upload each as a separate scanner report. */
+export async function transferBranchBatched(opts) {
+  const { extractedData, sonarcloudConfig, sonarCloudProfiles, branchName,
+    referenceBranchName, sonarCloudClient, label, isMainBranch,
+    sonarCloudRepos, ruleEnrichmentMap } = opts;
+
+  const plan = computeBatchPlan(extractedData.issues.length);
+  const baseDate = extractedData.metadata.extractedAt;
+
+  logger.info(`[${label}] Splitting ${extractedData.issues.length} issues into ${plan.length} batches of up to 5,000`);
+
+  let lastCeTask;
+  for (const batch of plan) {
+    const batchDate = computeBatchDate(baseDate, batch.batchIndex, plan.length);
+    const batchData = createBatchExtractedData(extractedData, batch, batchDate, randomBytes(20).toString('hex'));
+    const batchLabel = `${label} batch ${batch.batchIndex + 1}/${plan.length}`;
+
+    logger.info(`[${batchLabel}] Issues ${batch.startIndex + 1}-${batch.endIndex} | date=${batchDate}`);
+
+    const encodedReport = buildAndEncodeReport({
+      extractedData: batchData, sonarcloudConfig, sonarCloudProfiles,
+      branchName, referenceBranchName, sonarCloudRepos, ruleEnrichmentMap, label: batchLabel,
+    });
+    const uploader = new ReportUploader(sonarCloudClient);
+    const metadata = {
+      projectKey: sonarcloudConfig.projectKey, organization: sonarcloudConfig.organization,
+      version: '1.0.0', ...(!isMainBranch && branchName ? { branchName } : {}),
+    };
+
+    lastCeTask = await uploader.uploadAndWait(encodedReport, metadata);
+    logger.info(`[${batchLabel}] CE task completed: ${lastCeTask.id}`);
+  }
+
+  return lastCeTask;
+}

--- a/src/pipelines/sq-10.0/transfer-branch/index.js
+++ b/src/pipelines/sq-10.0/transfer-branch/index.js
@@ -4,8 +4,19 @@ import logger from '../../../shared/utils/logger.js';
 import { buildAndEncodeReport } from './helpers/build-and-encode-report.js';
 import { uploadReport } from './helpers/upload-report.js';
 import { computeBranchStats } from './helpers/compute-branch-stats.js';
+import { transferBranchBatched } from './helpers/transfer-branch-batched.js';
+import { shouldBatch } from '../../../shared/utils/batch-distributor.js';
 
 export async function transferBranch({ extractedData, sonarcloudConfig, sonarCloudProfiles, branchName, referenceBranchName, wait, sonarCloudClient, label, isMainBranch = false, sonarCloudRepos = new Set(), ruleEnrichmentMap = new Map() }) {
+  if (shouldBatch(extractedData)) {
+    const ceTask = await transferBranchBatched({
+      extractedData, sonarcloudConfig, sonarCloudProfiles, branchName,
+      referenceBranchName, sonarCloudClient, label, isMainBranch,
+      sonarCloudRepos, ruleEnrichmentMap,
+    });
+    return { stats: computeBranchStats(extractedData), ceTask };
+  }
+
   const encodedReport = buildAndEncodeReport({
     extractedData, sonarcloudConfig, sonarCloudProfiles,
     branchName, referenceBranchName, sonarCloudRepos, ruleEnrichmentMap, label

--- a/src/pipelines/sq-10.0/transfer-pipeline/helpers/transfer-branch-batched.js
+++ b/src/pipelines/sq-10.0/transfer-pipeline/helpers/transfer-branch-batched.js
@@ -1,0 +1,47 @@
+import { randomBytes } from 'node:crypto';
+import { computeBatchPlan, computeBatchDate, createBatchExtractedData } from '../../../../shared/utils/batch-distributor.js';
+import { ProtobufBuilder } from '../../protobuf/builder.js';
+import { ProtobufEncoder } from '../../protobuf/encoder.js';
+import { ReportUploader } from '../../sonarcloud/uploader.js';
+import logger from '../../../../shared/utils/logger.js';
+
+// -------- Batched Branch Transfer --------
+
+/** Split issues into batches and upload each as a separate scanner report. */
+export async function transferBranchBatched(opts) {
+  const { extractedData, sonarcloudConfig, sonarCloudProfiles, branchName,
+    referenceBranchName, sonarCloudClient, label, isMainBranch,
+    sonarCloudRepos, ruleEnrichmentMap } = opts;
+
+  const plan = computeBatchPlan(extractedData.issues.length);
+  const baseDate = extractedData.metadata.extractedAt;
+
+  logger.info(`[${label}] Splitting ${extractedData.issues.length} issues into ${plan.length} batches of up to 5,000`);
+
+  let lastCeTask;
+  for (const batch of plan) {
+    const batchDate = computeBatchDate(baseDate, batch.batchIndex, plan.length);
+    const batchData = createBatchExtractedData(extractedData, batch, batchDate, randomBytes(20).toString('hex'));
+    const batchLabel = `${label} batch ${batch.batchIndex + 1}/${plan.length}`;
+
+    logger.info(`[${batchLabel}] Issues ${batch.startIndex + 1}-${batch.endIndex} | date=${batchDate}`);
+
+    const builder = new ProtobufBuilder(batchData, sonarcloudConfig, sonarCloudProfiles, {
+      sonarCloudBranchName: branchName, referenceBranchName, sonarCloudRepos, ruleEnrichmentMap,
+    });
+    const messages = builder.buildAll();
+    const encoder = new ProtobufEncoder();
+    await encoder.loadSchemas();
+    const encodedReport = encoder.encodeAll(messages);
+    const uploader = new ReportUploader(sonarCloudClient);
+    const metadata = {
+      projectKey: sonarcloudConfig.projectKey, organization: sonarcloudConfig.organization,
+      version: '1.0.0', ...(!isMainBranch && branchName ? { branchName } : {}),
+    };
+
+    lastCeTask = await uploader.uploadAndWait(encodedReport, metadata);
+    logger.info(`[${batchLabel}] CE task completed: ${lastCeTask.id}`);
+  }
+
+  return lastCeTask;
+}

--- a/src/pipelines/sq-10.0/transfer-pipeline/helpers/transfer-branch.js
+++ b/src/pipelines/sq-10.0/transfer-pipeline/helpers/transfer-branch.js
@@ -3,6 +3,8 @@ import { ProtobufBuilder } from '../../protobuf/builder.js';
 import { ProtobufEncoder } from '../../protobuf/encoder.js';
 import { ReportUploader } from '../../sonarcloud/uploader.js';
 import { computeBranchStats } from './compute-branch-stats.js';
+import { transferBranchBatched } from './transfer-branch-batched.js';
+import { shouldBatch } from '../../../../shared/utils/batch-distributor.js';
 
 // -------- Transfer Single Branch --------
 
@@ -10,6 +12,15 @@ import { computeBranchStats } from './compute-branch-stats.js';
  * Build, encode, and upload a single branch report to SonarCloud.
  */
 export async function transferBranch({ extractedData, sonarcloudConfig, sonarCloudProfiles, branchName, referenceBranchName, wait, sonarCloudClient, label, isMainBranch = false, sonarCloudRepos = new Set(), ruleEnrichmentMap = new Map() }) {
+  if (shouldBatch(extractedData)) {
+    const ceTask = await transferBranchBatched({
+      extractedData, sonarcloudConfig, sonarCloudProfiles, branchName,
+      referenceBranchName, sonarCloudClient, label, isMainBranch,
+      sonarCloudRepos, ruleEnrichmentMap,
+    });
+    return { stats: computeBranchStats(extractedData), ceTask };
+  }
+
   logger.info(`[${label}] Building protobuf messages...`);
   const builder = new ProtobufBuilder(extractedData, sonarcloudConfig, sonarCloudProfiles, {
     sonarCloudBranchName: branchName, referenceBranchName, sonarCloudRepos, ruleEnrichmentMap,

--- a/src/pipelines/sq-10.4/migrate-pipeline/helpers/prepare-output-dir.js
+++ b/src/pipelines/sq-10.4/migrate-pipeline/helpers/prepare-output-dir.js
@@ -1,4 +1,5 @@
-import { mkdir, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { mkdir, readdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import logger from '../../../../shared/utils/logger.js';
 
@@ -17,7 +18,13 @@ export async function prepareOutputDir(outputDir, isResume) {
   }
 
   logger.info(`Cleaning output directory: ${outputDir}`);
-  await rm(outputDir, { recursive: true, force: true });
+  if (existsSync(outputDir)) {
+    const entries = await readdir(outputDir);
+    for (const entry of entries) {
+      if (entry === 'logs') continue;
+      await rm(join(outputDir, entry), { recursive: true, force: true });
+    }
+  }
   await mkdir(outputDir, { recursive: true });
   for (const sub of subdirs) await mkdir(join(outputDir, sub), { recursive: true });
 }

--- a/src/pipelines/sq-10.4/sonarcloud/migrators/project-config/helpers/migrate-new-code-periods.js
+++ b/src/pipelines/sq-10.4/sonarcloud/migrators/project-config/helpers/migrate-new-code-periods.js
@@ -18,7 +18,7 @@ export async function migrateNewCodePeriods(projectKey, newCodeData, client) {
 
   logger.info(`Setting new code definition for ${projectKey}: ${settings.map(s => `${s.key}=${s.value}`).join(', ')} (from ${sourceLabel})`);
   try {
-    for (const setting of settings) await client.setProjectSetting(setting.key, setting.value, projectKey);
+    for (const setting of settings) await client.setProjectSetting(setting.key, { value: setting.value }, projectKey);
   } catch (error) {
     logger.warn(`Failed to set new code definition for ${projectKey}: ${error.message}`);
     throw error;

--- a/src/pipelines/sq-10.4/transfer-branch/helpers/transfer-branch-batched.js
+++ b/src/pipelines/sq-10.4/transfer-branch/helpers/transfer-branch-batched.js
@@ -1,0 +1,39 @@
+import { randomBytes } from 'node:crypto';
+import { computeBatchPlan, computeBatchDate, createBatchExtractedData } from '../../../../shared/utils/batch-distributor.js';
+import { buildAndEncodeReport } from './build-and-encode-report.js';
+import { uploadReport } from './upload-report.js';
+import logger from '../../../../shared/utils/logger.js';
+
+// -------- Batched Branch Transfer --------
+
+/** Split issues into batches and upload each as a separate scanner report. */
+export async function transferBranchBatched(opts) {
+  const { extractedData, sonarcloudConfig, sonarCloudProfiles, branchName,
+    referenceBranchName, sonarCloudClient, label, isMainBranch,
+    sonarCloudRepos, ruleEnrichmentMap } = opts;
+
+  const plan = computeBatchPlan(extractedData.issues.length);
+  const baseDate = extractedData.metadata.extractedAt;
+
+  logger.info(`[${label}] Splitting ${extractedData.issues.length} issues into ${plan.length} batches of up to 5,000`);
+
+  let lastCeTask;
+  for (const batch of plan) {
+    const batchDate = computeBatchDate(baseDate, batch.batchIndex, plan.length);
+    const batchData = createBatchExtractedData(extractedData, batch, batchDate, randomBytes(20).toString('hex'));
+    const batchLabel = `${label} batch ${batch.batchIndex + 1}/${plan.length}`;
+
+    logger.info(`[${batchLabel}] Issues ${batch.startIndex + 1}-${batch.endIndex} | date=${batchDate}`);
+
+    const encodedReport = await buildAndEncodeReport({
+      extractedData: batchData, sonarcloudConfig, sonarCloudProfiles,
+      branchName, referenceBranchName, label: batchLabel, sonarCloudRepos, ruleEnrichmentMap,
+    });
+    lastCeTask = await uploadReport({
+      encodedReport, sonarcloudConfig, sonarCloudClient, branchName, isMainBranch, wait: true, label: batchLabel,
+    });
+    logger.info(`[${batchLabel}] CE task completed: ${lastCeTask.id}`);
+  }
+
+  return lastCeTask;
+}

--- a/src/pipelines/sq-10.4/transfer-branch/helpers/transfer-branch.js
+++ b/src/pipelines/sq-10.4/transfer-branch/helpers/transfer-branch.js
@@ -1,11 +1,22 @@
 import { buildAndEncodeReport } from './build-and-encode-report.js';
 import { uploadReport } from './upload-report.js';
 import { computeBranchStats } from './compute-branch-stats.js';
+import { transferBranchBatched } from './transfer-branch-batched.js';
+import { shouldBatch } from '../../../../shared/utils/batch-distributor.js';
 
 // -------- Main Logic --------
 
 // Build, encode, and upload a single branch report to SonarCloud.
 export async function transferBranch({ extractedData, sonarcloudConfig, sonarCloudProfiles, branchName, referenceBranchName, wait, sonarCloudClient, label, isMainBranch = false, sonarCloudRepos = new Set(), ruleEnrichmentMap = new Map() }) {
+  if (shouldBatch(extractedData)) {
+    const ceTask = await transferBranchBatched({
+      extractedData, sonarcloudConfig, sonarCloudProfiles, branchName,
+      referenceBranchName, sonarCloudClient, label, isMainBranch,
+      sonarCloudRepos, ruleEnrichmentMap,
+    });
+    return { stats: computeBranchStats(extractedData), ceTask };
+  }
+
   const encodedReport = await buildAndEncodeReport({
     extractedData, sonarcloudConfig, sonarCloudProfiles,
     branchName, referenceBranchName, label, sonarCloudRepos, ruleEnrichmentMap

--- a/src/pipelines/sq-10.4/transfer-pipeline/helpers/transfer-branch-batched.js
+++ b/src/pipelines/sq-10.4/transfer-pipeline/helpers/transfer-branch-batched.js
@@ -1,0 +1,47 @@
+import { randomBytes } from 'node:crypto';
+import { computeBatchPlan, computeBatchDate, createBatchExtractedData } from '../../../../shared/utils/batch-distributor.js';
+import { ProtobufBuilder } from '../../protobuf/builder.js';
+import { ProtobufEncoder } from '../../protobuf/encoder.js';
+import { ReportUploader } from '../../sonarcloud/uploader.js';
+import logger from '../../../../shared/utils/logger.js';
+
+// -------- Batched Branch Transfer --------
+
+/** Split issues into batches and upload each as a separate scanner report. */
+export async function transferBranchBatched(opts) {
+  const { extractedData, sonarcloudConfig, sonarCloudProfiles, branchName,
+    referenceBranchName, sonarCloudClient, label, isMainBranch,
+    sonarCloudRepos, ruleEnrichmentMap } = opts;
+
+  const plan = computeBatchPlan(extractedData.issues.length);
+  const baseDate = extractedData.metadata.extractedAt;
+
+  logger.info(`[${label}] Splitting ${extractedData.issues.length} issues into ${plan.length} batches of up to 5,000`);
+
+  let lastCeTask;
+  for (const batch of plan) {
+    const batchDate = computeBatchDate(baseDate, batch.batchIndex, plan.length);
+    const batchData = createBatchExtractedData(extractedData, batch, batchDate, randomBytes(20).toString('hex'));
+    const batchLabel = `${label} batch ${batch.batchIndex + 1}/${plan.length}`;
+
+    logger.info(`[${batchLabel}] Issues ${batch.startIndex + 1}-${batch.endIndex} | date=${batchDate}`);
+
+    const builder = new ProtobufBuilder(batchData, sonarcloudConfig, sonarCloudProfiles, {
+      sonarCloudBranchName: branchName, referenceBranchName, sonarCloudRepos, ruleEnrichmentMap,
+    });
+    const messages = builder.buildAll();
+    const encoder = new ProtobufEncoder();
+    await encoder.loadSchemas();
+    const encodedReport = encoder.encodeAll(messages);
+    const uploader = new ReportUploader(sonarCloudClient);
+    const metadata = {
+      projectKey: sonarcloudConfig.projectKey, organization: sonarcloudConfig.organization,
+      version: '1.0.0', ...(!isMainBranch && branchName ? { branchName } : {}),
+    };
+
+    lastCeTask = await uploader.uploadAndWait(encodedReport, metadata);
+    logger.info(`[${batchLabel}] CE task completed: ${lastCeTask.id}`);
+  }
+
+  return lastCeTask;
+}

--- a/src/pipelines/sq-10.4/transfer-pipeline/helpers/transfer-branch.js
+++ b/src/pipelines/sq-10.4/transfer-pipeline/helpers/transfer-branch.js
@@ -2,17 +2,25 @@ import { ProtobufBuilder } from '../../protobuf/builder.js';
 import { ProtobufEncoder } from '../../protobuf/encoder.js';
 import { ReportUploader } from '../../sonarcloud/uploader.js';
 import { computeBranchStats } from './compute-branch-stats.js';
+import { transferBranchBatched } from './transfer-branch-batched.js';
+import { shouldBatch } from '../../../../shared/utils/batch-distributor.js';
 import logger from '../../../../shared/utils/logger.js';
 
 // -------- Main Logic --------
 
 /**
  * Build, encode, and upload a single branch report to SonarCloud.
- *
- * @param {object} options - Transfer options
- * @returns {Promise<object>} { stats, ceTask }
  */
 export async function transferBranch({ extractedData, sonarcloudConfig, sonarCloudProfiles, branchName, referenceBranchName, wait, sonarCloudClient, label, isMainBranch = false, sonarCloudRepos = new Set(), ruleEnrichmentMap = new Map() }) {
+  if (shouldBatch(extractedData)) {
+    const ceTask = await transferBranchBatched({
+      extractedData, sonarcloudConfig, sonarCloudProfiles, branchName,
+      referenceBranchName, sonarCloudClient, label, isMainBranch,
+      sonarCloudRepos, ruleEnrichmentMap,
+    });
+    return { stats: computeBranchStats(extractedData), ceTask };
+  }
+
   logger.info(`[${label}] Building protobuf messages...`);
   const builder = new ProtobufBuilder(extractedData, sonarcloudConfig, sonarCloudProfiles, {
     sonarCloudBranchName: branchName, referenceBranchName, sonarCloudRepos, ruleEnrichmentMap,

--- a/src/pipelines/sq-2025/migrate-pipeline/helpers/handle-resume-prompt.js
+++ b/src/pipelines/sq-2025/migrate-pipeline/helpers/handle-resume-prompt.js
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { mkdir, rm } from 'node:fs/promises';
+import { mkdir, readdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { MigrationJournal } from '../../../../shared/state/migration-journal.js';
 import { promptMigrationResume } from '../../../../shared/utils/prompt.js';
@@ -31,7 +31,13 @@ export async function setupOutputDir(outputDir, isResume) {
   const dirs = [outputDir, join(outputDir, 'state'), join(outputDir, 'quality-profiles'), join(outputDir, 'logs')];
   if (!isResume) {
     logger.info(`Cleaning output directory: ${outputDir}`);
-    await rm(outputDir, { recursive: true, force: true });
+    if (existsSync(outputDir)) {
+      const entries = await readdir(outputDir);
+      for (const entry of entries) {
+        if (entry === 'logs') continue;
+        await rm(join(outputDir, entry), { recursive: true, force: true });
+      }
+    }
   }
   for (const dir of dirs) await mkdir(dir, { recursive: true });
 }

--- a/src/pipelines/sq-2025/sonarcloud/migrators/project-config/helpers/migrate-new-code-periods.js
+++ b/src/pipelines/sq-2025/sonarcloud/migrators/project-config/helpers/migrate-new-code-periods.js
@@ -36,7 +36,7 @@ export async function migrateNewCodePeriods(projectKey, newCodeData, client) {
   logger.info(`Setting new code definition for ${projectKey}: ${settingsDesc} (from ${sourceLabel})`);
 
   try {
-    for (const setting of settings) await client.setProjectSetting(setting.key, setting.value, projectKey);
+    for (const setting of settings) await client.setProjectSetting(setting.key, { value: setting.value }, projectKey);
   } catch (error) {
     logger.warn(`Failed to set new code definition for ${projectKey}: ${error.message}`);
     throw error;

--- a/src/pipelines/sq-2025/transfer-branch/helpers/build-and-upload-batched.js
+++ b/src/pipelines/sq-2025/transfer-branch/helpers/build-and-upload-batched.js
@@ -1,0 +1,29 @@
+import { randomBytes } from 'node:crypto';
+import { computeBatchPlan, computeBatchDate, createBatchExtractedData } from '../../../../shared/utils/batch-distributor.js';
+import { buildAndUpload } from './build-and-upload.js';
+import logger from '../../../../shared/utils/logger.js';
+
+// -------- Batched Build and Upload --------
+
+/** Split issues into batches and upload each as a separate scanner report. */
+export async function buildAndUploadBatched(opts) {
+  const { extractedData, label } = opts;
+  const plan = computeBatchPlan(extractedData.issues.length);
+  const baseDate = extractedData.metadata.extractedAt;
+
+  logger.info(`[${label}] Splitting ${extractedData.issues.length} issues into ${plan.length} batches of up to 5,000`);
+
+  let lastCeTask;
+  for (const batch of plan) {
+    const batchDate = computeBatchDate(baseDate, batch.batchIndex, plan.length);
+    const batchData = createBatchExtractedData(extractedData, batch, batchDate, randomBytes(20).toString('hex'));
+    const batchLabel = `${label} batch ${batch.batchIndex + 1}/${plan.length}`;
+
+    logger.info(`[${batchLabel}] Issues ${batch.startIndex + 1}-${batch.endIndex} | date=${batchDate}`);
+
+    lastCeTask = await buildAndUpload({ ...opts, extractedData: batchData, label: batchLabel, wait: true });
+    logger.info(`[${batchLabel}] CE task completed: ${lastCeTask.id}`);
+  }
+
+  return lastCeTask;
+}

--- a/src/pipelines/sq-2025/transfer-branch/index.js
+++ b/src/pipelines/sq-2025/transfer-branch/index.js
@@ -1,5 +1,7 @@
 import { buildAndUpload } from './helpers/build-and-upload.js';
+import { buildAndUploadBatched } from './helpers/build-and-upload-batched.js';
 import { computeBranchStats } from './helpers/compute-branch-stats.js';
+import { shouldBatch } from '../../../shared/utils/batch-distributor.js';
 
 // -------- Transfer Branch --------
 
@@ -10,11 +12,15 @@ export async function transferBranch(options) {
     label, isMainBranch = false, sonarCloudRepos = new Set(),
     ruleEnrichmentMap = new Map() } = options;
 
-  const ceTask = await buildAndUpload({
+  const uploadOpts = {
     extractedData, sonarcloudConfig, sonarCloudProfiles,
     branchName, referenceBranchName, sonarCloudRepos,
     ruleEnrichmentMap, isMainBranch, wait, sonarCloudClient, label,
-  });
+  };
+
+  const ceTask = shouldBatch(extractedData)
+    ? await buildAndUploadBatched(uploadOpts)
+    : await buildAndUpload(uploadOpts);
 
   return { stats: computeBranchStats(extractedData), ceTask };
 }

--- a/src/pipelines/sq-2025/transfer-pipeline/helpers/transfer-branch/helpers/transfer-batched.js
+++ b/src/pipelines/sq-2025/transfer-pipeline/helpers/transfer-branch/helpers/transfer-batched.js
@@ -1,0 +1,35 @@
+import { randomBytes } from 'node:crypto';
+import { computeBatchPlan, computeBatchDate, createBatchExtractedData } from '../../../../../../shared/utils/batch-distributor.js';
+import { buildProtobufMessages, encodeMessages } from './build-and-encode.js';
+import { uploadReport } from './upload-report.js';
+import logger from '../../../../../../shared/utils/logger.js';
+
+// -------- Batched Branch Transfer --------
+
+/** Split issues into batches and upload each as a separate scanner report. */
+export async function transferBatched(opts) {
+  const { extractedData, sonarcloudConfig, sonarCloudProfiles, branchName,
+    referenceBranchName, sonarCloudClient, label, isMainBranch,
+    sonarCloudRepos, ruleEnrichmentMap } = opts;
+
+  const plan = computeBatchPlan(extractedData.issues.length);
+  const baseDate = extractedData.metadata.extractedAt;
+
+  logger.info(`[${label}] Splitting ${extractedData.issues.length} issues into ${plan.length} batches of up to 5,000`);
+
+  let lastCeTask;
+  for (const batch of plan) {
+    const batchDate = computeBatchDate(baseDate, batch.batchIndex, plan.length);
+    const batchData = createBatchExtractedData(extractedData, batch, batchDate, randomBytes(20).toString('hex'));
+    const batchLabel = `${label} batch ${batch.batchIndex + 1}/${plan.length}`;
+
+    logger.info(`[${batchLabel}] Issues ${batch.startIndex + 1}-${batch.endIndex} | date=${batchDate}`);
+
+    const messages = buildProtobufMessages(batchData, sonarcloudConfig, sonarCloudProfiles, branchName, referenceBranchName, sonarCloudRepos, ruleEnrichmentMap, batchLabel);
+    const encodedReport = await encodeMessages(messages, batchLabel);
+    lastCeTask = await uploadReport(encodedReport, sonarcloudConfig, sonarCloudClient, branchName, isMainBranch, true, batchLabel);
+    logger.info(`[${batchLabel}] CE task completed: ${lastCeTask.id}`);
+  }
+
+  return lastCeTask;
+}

--- a/src/pipelines/sq-2025/transfer-pipeline/helpers/transfer-branch/index.js
+++ b/src/pipelines/sq-2025/transfer-pipeline/helpers/transfer-branch/index.js
@@ -1,5 +1,7 @@
 import { buildProtobufMessages, encodeMessages } from './helpers/build-and-encode.js';
 import { uploadReport } from './helpers/upload-report.js';
+import { transferBatched } from './helpers/transfer-batched.js';
+import { shouldBatch } from '../../../../../shared/utils/batch-distributor.js';
 
 // -------- Branch Transfer --------
 
@@ -11,6 +13,15 @@ export async function transferBranch(options) {
     isMainBranch = false, sonarCloudRepos = new Set(),
     ruleEnrichmentMap = new Map(),
   } = options;
+
+  if (shouldBatch(extractedData)) {
+    const ceTask = await transferBatched({
+      extractedData, sonarcloudConfig, sonarCloudProfiles, branchName,
+      referenceBranchName, sonarCloudClient, label, isMainBranch,
+      sonarCloudRepos, ruleEnrichmentMap,
+    });
+    return { stats: computeBranchStats(extractedData), ceTask };
+  }
 
   const messages = buildProtobufMessages(extractedData, sonarcloudConfig, sonarCloudProfiles, branchName, referenceBranchName, sonarCloudRepos, ruleEnrichmentMap, label);
   const encodedReport = await encodeMessages(messages, label);

--- a/src/pipelines/sq-9.9/migrate-pipeline/helpers/setup-output-dirs.js
+++ b/src/pipelines/sq-9.9/migrate-pipeline/helpers/setup-output-dirs.js
@@ -1,4 +1,5 @@
-import { mkdir, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { mkdir, readdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import logger from '../../../../shared/utils/logger.js';
 
@@ -7,7 +8,13 @@ import logger from '../../../../shared/utils/logger.js';
 export async function setupOutputDirs(outputDir, isResume) {
   if (!isResume) {
     logger.info(`Cleaning output directory: ${outputDir}`);
-    await rm(outputDir, { recursive: true, force: true });
+    if (existsSync(outputDir)) {
+      const entries = await readdir(outputDir);
+      for (const entry of entries) {
+        if (entry === 'logs') continue;
+        await rm(join(outputDir, entry), { recursive: true, force: true });
+      }
+    }
   }
 
   await mkdir(outputDir, { recursive: true });

--- a/src/pipelines/sq-9.9/sonarcloud/migrators/project-config/helpers/migrate-new-code-periods.js
+++ b/src/pipelines/sq-9.9/sonarcloud/migrators/project-config/helpers/migrate-new-code-periods.js
@@ -22,7 +22,7 @@ export async function migrateNewCodePeriods(projectKey, newCodeData, client) {
 
   try {
     for (const setting of settings.values) {
-      await client.setProjectSetting(setting.key, setting.value, projectKey);
+      await client.setProjectSetting(setting.key, { value: setting.value }, projectKey);
     }
   } catch (error) {
     logger.warn(`Failed to set new code definition for ${projectKey}: ${error.message}`);

--- a/src/pipelines/sq-9.9/transfer-pipeline/helpers/transfer-branch-batched.js
+++ b/src/pipelines/sq-9.9/transfer-pipeline/helpers/transfer-branch-batched.js
@@ -1,0 +1,36 @@
+import { randomBytes } from 'node:crypto';
+import { computeBatchPlan, computeBatchDate, createBatchExtractedData } from '../../../../shared/utils/batch-distributor.js';
+import { buildProtobufMessages } from './build-protobuf-messages.js';
+import { encodeReport } from './encode-report.js';
+import { uploadReport } from './upload-report.js';
+import logger from '../../../../shared/utils/logger.js';
+
+// -------- Batched Branch Transfer --------
+
+/** Split issues into batches and upload each as a separate scanner report. */
+export async function transferBranchBatched(opts) {
+  const { extractedData, sonarcloudConfig, sonarCloudProfiles, branchName,
+    referenceBranchName, sonarCloudClient, label, isMainBranch,
+    sonarCloudRepos, ruleEnrichmentMap } = opts;
+
+  const plan = computeBatchPlan(extractedData.issues.length);
+  const baseDate = extractedData.metadata.extractedAt;
+
+  logger.info(`[${label}] Splitting ${extractedData.issues.length} issues into ${plan.length} batches of up to 5,000`);
+
+  let lastCeTask;
+  for (const batch of plan) {
+    const batchDate = computeBatchDate(baseDate, batch.batchIndex, plan.length);
+    const batchData = createBatchExtractedData(extractedData, batch, batchDate, randomBytes(20).toString('hex'));
+    const batchLabel = `${label} batch ${batch.batchIndex + 1}/${plan.length}`;
+
+    logger.info(`[${batchLabel}] Issues ${batch.startIndex + 1}-${batch.endIndex} | date=${batchDate}`);
+
+    const messages = buildProtobufMessages(batchData, sonarcloudConfig, sonarCloudProfiles, branchName, referenceBranchName, sonarCloudRepos, ruleEnrichmentMap, batchLabel);
+    const encodedReport = await encodeReport(messages, batchLabel);
+    lastCeTask = await uploadReport(encodedReport, sonarcloudConfig, sonarCloudClient, branchName, isMainBranch, true, batchLabel);
+    logger.info(`[${batchLabel}] CE task completed: ${lastCeTask.id}`);
+  }
+
+  return lastCeTask;
+}

--- a/src/pipelines/sq-9.9/transfer-pipeline/helpers/transfer-branch.js
+++ b/src/pipelines/sq-9.9/transfer-pipeline/helpers/transfer-branch.js
@@ -2,10 +2,21 @@ import { buildProtobufMessages } from './build-protobuf-messages.js';
 import { encodeReport } from './encode-report.js';
 import { uploadReport } from './upload-report.js';
 import { buildBranchResult } from './build-branch-result.js';
+import { transferBranchBatched } from './transfer-branch-batched.js';
+import { shouldBatch } from '../../../../shared/utils/batch-distributor.js';
 
 // -------- Single Branch Transfer (build, encode, upload) --------
 
 export async function transferBranch({ extractedData, sonarcloudConfig, sonarCloudProfiles, branchName, referenceBranchName, wait, sonarCloudClient, label, isMainBranch = false, sonarCloudRepos = new Set(), ruleEnrichmentMap = new Map() }) {
+  if (shouldBatch(extractedData)) {
+    const ceTask = await transferBranchBatched({
+      extractedData, sonarcloudConfig, sonarCloudProfiles, branchName,
+      referenceBranchName, sonarCloudClient, label, isMainBranch,
+      sonarCloudRepos, ruleEnrichmentMap,
+    });
+    return buildBranchResult(extractedData, ceTask);
+  }
+
   const messages = buildProtobufMessages(extractedData, sonarcloudConfig, sonarCloudProfiles, branchName, referenceBranchName, sonarCloudRepos, ruleEnrichmentMap, label);
   const encodedReport = await encodeReport(messages, label);
   const ceTask = await uploadReport(encodedReport, sonarcloudConfig, sonarCloudClient, branchName, isMainBranch, wait, label);

--- a/src/shared/reports/pdf-helpers/helpers/create-printer.js
+++ b/src/shared/reports/pdf-helpers/helpers/create-printer.js
@@ -1,8 +1,9 @@
 // -------- Create PDF Printer --------
 import PdfPrinterModule from 'pdfmake/js/Printer.js';
-import vfs from 'pdfmake/build/vfs_fonts.js';
+import vfsModule from 'pdfmake/build/vfs_fonts.js';
 
-const PdfPrinter = PdfPrinterModule.default;
+const PdfPrinter = typeof PdfPrinterModule === 'function' ? PdfPrinterModule : (PdfPrinterModule.default || PdfPrinterModule);
+const vfs = vfsModule.pdfMake?.vfs || vfsModule;
 
 function createVirtualFs(vfsData) {
   return {

--- a/src/shared/utils/batch-distributor.js
+++ b/src/shared/utils/batch-distributor.js
@@ -1,0 +1,3 @@
+// -------- Batch Distributor Re-export --------
+
+export { shouldBatch, computeBatchPlan, computeBatchDate, createBatchExtractedData } from './batch-distributor/index.js';

--- a/src/shared/utils/batch-distributor/helpers/compute-batch-date.js
+++ b/src/shared/utils/batch-distributor/helpers/compute-batch-date.js
@@ -1,0 +1,14 @@
+// -------- Compute Batch Date --------
+
+/** Compute an ISO date string for a batch, going backwards from the base date. */
+export function computeBatchDate(baseDateISO, batchIndex, totalBatches) {
+  if (totalBatches <= 1) return baseDateISO;
+
+  const baseDate = new Date(baseDateISO);
+  const daysBack = totalBatches - 1 - batchIndex;
+  const batchDate = new Date(baseDate);
+
+  batchDate.setDate(baseDate.getDate() - daysBack);
+
+  return batchDate.toISOString();
+}

--- a/src/shared/utils/batch-distributor/helpers/compute-batch-plan.js
+++ b/src/shared/utils/batch-distributor/helpers/compute-batch-plan.js
@@ -1,0 +1,20 @@
+// -------- Compute Batch Plan --------
+
+const ISSUE_BATCH_SIZE = 5000;
+
+/** Compute batch descriptors for splitting issues into chunks. */
+export function computeBatchPlan(totalIssues) {
+  const batchCount = Math.max(1, Math.ceil(totalIssues / ISSUE_BATCH_SIZE));
+  const batches = [];
+
+  for (let i = 0; i < batchCount; i++) {
+    batches.push({
+      startIndex: i * ISSUE_BATCH_SIZE,
+      endIndex: Math.min((i + 1) * ISSUE_BATCH_SIZE, totalIssues),
+      batchIndex: i,
+      isLast: i === batchCount - 1,
+    });
+  }
+
+  return batches;
+}

--- a/src/shared/utils/batch-distributor/helpers/create-batch-extracted-data.js
+++ b/src/shared/utils/batch-distributor/helpers/create-batch-extracted-data.js
@@ -1,0 +1,31 @@
+// -------- Create Batch Extracted Data --------
+
+/**
+ * Create a shallow clone of extractedData with sliced issues and overridden metadata.
+ * Non-final batches strip sources, changesets, and duplications to reduce upload size.
+ */
+export function createBatchExtractedData(originalData, batchDescriptor, batchDate, batchScmRevisionId) {
+  const batch = { ...originalData };
+
+  // Slice the issues array for this batch
+  batch.issues = originalData.issues.slice(
+    batchDescriptor.startIndex,
+    batchDescriptor.endIndex,
+  );
+
+  // Override metadata with batch-specific date and unique scmRevisionId
+  batch.metadata = {
+    ...originalData.metadata,
+    extractedAt: batchDate,
+    scmRevisionId: batchScmRevisionId,
+  };
+
+  // Non-final batches: strip heavy payload that only the latest analysis needs
+  if (!batchDescriptor.isLast) {
+    batch.sources = [];
+    batch.changesets = new Map();
+    batch.duplications = new Map();
+  }
+
+  return batch;
+}

--- a/src/shared/utils/batch-distributor/helpers/should-batch.js
+++ b/src/shared/utils/batch-distributor/helpers/should-batch.js
@@ -1,0 +1,8 @@
+// -------- Should Batch --------
+
+const ISSUE_BATCH_SIZE = 5000;
+
+/** Returns true if the extracted data has more issues than the batch threshold. */
+export function shouldBatch(extractedData) {
+  return extractedData.issues.length > ISSUE_BATCH_SIZE;
+}

--- a/src/shared/utils/batch-distributor/index.js
+++ b/src/shared/utils/batch-distributor/index.js
@@ -1,0 +1,6 @@
+// -------- Batch Distributor --------
+
+export { shouldBatch } from './helpers/should-batch.js';
+export { computeBatchPlan } from './helpers/compute-batch-plan.js';
+export { computeBatchDate } from './helpers/compute-batch-date.js';
+export { createBatchExtractedData } from './helpers/create-batch-extracted-data.js';

--- a/src/shared/utils/logger/helpers/enable-file-logging.js
+++ b/src/shared/utils/logger/helpers/enable-file-logging.js
@@ -7,23 +7,49 @@ import { logFormat } from './log-format.js';
 
 const { combine, timestamp } = winston.format;
 
+function filterByLevel(level) {
+  return winston.format((info) => info.level === level ? info : false)();
+}
+
 export function enableFileLogging(commandName) {
   const logsDir = path.resolve('migration-output', 'logs');
   if (!fs.existsSync(logsDir)) fs.mkdirSync(logsDir, { recursive: true });
 
-  // Remove existing file transports to prevent duplicates
   const existing = logger.transports.filter(t => t instanceof winston.transports.File);
   for (const t of existing) logger.remove(t);
 
   const ts = new Date().toISOString().replace(/[:.]/g, '-');
-  const logFileName = `cloudvoyager-${commandName}-${ts}.log`;
-  const logFilePath = path.join(logsDir, logFileName);
+  const fileFormat = combine(timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }), logFormat);
+
+  const rawLogPath = path.join(logsDir, `cloudvoyager-${commandName}-${ts}.log`);
+  const infoLogPath = path.join(logsDir, `cloudvoyager-${commandName}-${ts}.info.log`);
+  const warnLogPath = path.join(logsDir, `cloudvoyager-${commandName}-${ts}.warn.log`);
+  const errorLogPath = path.join(logsDir, `cloudvoyager-${commandName}-${ts}.error.log`);
 
   logger.add(new winston.transports.File({
-    filename: logFilePath, level: 'debug',
-    format: combine(timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }), logFormat)
+    filename: rawLogPath, level: 'debug',
+    format: fileFormat
   }));
 
-  logger.info(`Full logs will be written to: ${logFilePath}`);
-  return logFilePath;
+  logger.add(new winston.transports.File({
+    filename: infoLogPath, level: 'info',
+    format: combine(filterByLevel('info'), fileFormat)
+  }));
+
+  logger.add(new winston.transports.File({
+    filename: warnLogPath, level: 'warn',
+    format: combine(filterByLevel('warn'), fileFormat)
+  }));
+
+  logger.add(new winston.transports.File({
+    filename: errorLogPath, level: 'error',
+    format: combine(filterByLevel('error'), fileFormat)
+  }));
+
+  logger.info(`Logs directory: ${logsDir}`);
+  logger.info(`  Raw logs:   ${rawLogPath}`);
+  logger.info(`  Info logs:  ${infoLogPath}`);
+  logger.info(`  Warn logs:  ${warnLogPath}`);
+  logger.info(`  Error logs: ${errorLogPath}`);
+  return { rawLogPath, infoLogPath, warnLogPath, errorLogPath };
 }

--- a/src/shared/verification/reports/format-pdf/index.js
+++ b/src/shared/verification/reports/format-pdf/index.js
@@ -16,7 +16,11 @@ export async function generateVerificationPdf(results) {
   content.push(...buildHeader(results));
   content.push(...buildSummaryTable(results));
   content.push(...buildOrgResults(results));
-  content.push(...buildProjectResults(results));
+  const statusCell = (status) => {
+    const styleMap = { pass: 'statusPass', fail: 'statusFail', skipped: 'statusSkip', error: 'statusWarn' };
+    return { text: (status || '').toUpperCase(), style: styleMap[status] || 'tableCell' };
+  };
+  content.push(...buildProjectResults(results, statusCell));
 
   return generatePdfBuffer(buildDocDefinition(content));
 }

--- a/src/shared/verification/reports/markdown-sections/helpers/hotspot-details.js
+++ b/src/shared/verification/reports/markdown-sections/helpers/hotspot-details.js
@@ -1,4 +1,5 @@
 // -------- Hotspot Detail Sections --------
+import { formatHotspotCommentMismatches, formatUnsyncableAssignments } from './hotspot-comment-details.js';
 
 /**
  * Format hotspot-related detail sections.

--- a/src/shared/verification/reports/markdown-sections/helpers/issue-details.js
+++ b/src/shared/verification/reports/markdown-sections/helpers/issue-details.js
@@ -1,4 +1,6 @@
 // -------- Issue Detail Sections --------
+import { formatUnmatchedSqIssues, formatScOnlyIssues, formatStatusMismatches, formatHistoryMismatches } from './issue-list-details.js';
+import { formatAssignmentMismatches, formatCommentMismatches, formatTagMismatches, formatUnsyncableTypeChanges, formatUnsyncableSeverityChanges } from './issue-attr-details.js';
 
 /**
  * Format issue-related detail sections.

--- a/src/shared/verification/reports/pdf-sections/helpers/hotspot-details.js
+++ b/src/shared/verification/reports/pdf-sections/helpers/hotspot-details.js
@@ -1,6 +1,7 @@
 // -------- PDF Hotspot Detail Sections --------
 
 import { h, truncate, smallTable } from './pdf-table-utils.js';
+import { buildCommentMismatches, buildUnsyncableAssignments } from './hotspot-extra-details.js';
 
 /**
  * Build hotspot-related detail PDF nodes.

--- a/src/shared/verification/reports/pdf-sections/helpers/issue-details.js
+++ b/src/shared/verification/reports/pdf-sections/helpers/issue-details.js
@@ -1,6 +1,8 @@
 // -------- PDF Issue Detail Sections --------
 
 import { h, truncate, smallTable } from './pdf-table-utils.js';
+import { buildUnmatchedSq, buildScOnly, buildStatusMismatches, buildHistoryMismatches } from './issue-list-details.js';
+import { buildAssignmentMismatches, buildCommentMismatches, buildTagMismatches, buildUnsyncableTypes, buildUnsyncableSeverity } from './issue-attr-details.js';
 
 /**
  * Build issue-related detail PDF nodes.

--- a/test/utils/logger.test.js
+++ b/test/utils/logger.test.js
@@ -33,40 +33,39 @@ import { enableFileLogging } from '../../src/shared/utils/logger.js';
 import { existsSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 
-test.serial('enableFileLogging creates log directory and adds file transport', t => {
+test.serial('enableFileLogging creates log directory and adds 3 file transports', t => {
   const logsDir = join(process.cwd(), 'migration-output', 'logs');
 
-  // Remove logs dir if it exists so we exercise the mkdir path (lines 56-57)
   if (existsSync(logsDir)) {
     rmSync(logsDir, { recursive: true });
   }
 
   const initialTransportCount = logger.transports.length;
-  const logFilePath = enableFileLogging('test-cmd');
+  const result = enableFileLogging('test-cmd');
 
-  t.truthy(logFilePath);
-  t.true(typeof logFilePath === 'string');
-  t.true(logFilePath.includes('cloudvoyager-test-cmd-'));
-  t.true(logFilePath.endsWith('.log'));
+  t.truthy(result);
+  t.true(typeof result === 'object');
+  t.true(result.rawLogPath.includes('cloudvoyager-test-cmd-'));
+  t.true(result.rawLogPath.endsWith('.log'));
+  t.true(result.infoLogPath.endsWith('.info.log'));
+  t.true(result.warnLogPath.endsWith('.warn.log'));
+  t.true(result.errorLogPath.endsWith('.error.log'));
   t.true(existsSync(logsDir));
-  t.true(logger.transports.length > initialTransportCount);
+  t.is(logger.transports.length, initialTransportCount + 4);
 
-  // Clean up: remove the transport we just added
-  const addedTransport = logger.transports.find(
-    tr => tr.constructor.name === 'File' && tr.filename === logFilePath
-  );
-  if (addedTransport) logger.remove(addedTransport);
+  const fileTransports = logger.transports.filter(tr => tr.constructor.name === 'File');
+  for (const ft of fileTransports) logger.remove(ft);
 });
 
 test.serial('enableFileLogging with custom command name prefix', t => {
-  const logFilePath = enableFileLogging('migrate');
+  const result = enableFileLogging('migrate');
 
-  t.true(logFilePath.includes('cloudvoyager-migrate-'));
-  t.true(logFilePath.endsWith('.log'));
+  t.true(result.rawLogPath.includes('cloudvoyager-migrate-'));
+  t.true(result.rawLogPath.endsWith('.log'));
+  t.true(result.infoLogPath.includes('cloudvoyager-migrate-'));
+  t.true(result.warnLogPath.includes('cloudvoyager-migrate-'));
+  t.true(result.errorLogPath.includes('cloudvoyager-migrate-'));
 
-  // Clean up: remove the transport we just added
-  const addedTransport = logger.transports.find(
-    tr => tr.constructor.name === 'File' && tr.filename === logFilePath
-  );
-  if (addedTransport) logger.remove(addedTransport);
+  const fileTransports = logger.transports.filter(tr => tr.constructor.name === 'File');
+  for (const ft of fileTransports) logger.remove(ft);
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core transfer/migration upload behavior by splitting branches into multiple sequential report uploads and altering output directory cleanup, which could affect migration correctness/performance for large projects. Also adjusts API endpoint construction and logging outputs, so regressions would be user-visible but are scoped and guarded by thresholds.
> 
> **Overview**
> Adds **issue batch distribution on upload**: when a branch has more than 5,000 issues, `transferBranch` now routes to a batched path that slices issues into 5k chunks, backdates `analysis_date` per batch, assigns a unique `scmRevisionId`, strips heavy payloads for non-final batches, and uploads batches **sequentially with CE wait** across all four pipelines (`sq-9.9`, `sq-10.0`, `sq-10.4`, `sq-2025`).
> 
> Improves operational robustness: output directory cleanup no longer deletes `migration-output/logs/` on fresh runs, file logging now writes **four** separate log files (raw/info/warn/error), and verification report generation fixes missing imports/callbacks plus a `pdfmake` import compatibility tweak. Also fixes new-code-period migration by passing `{ value }` to `setProjectSetting`, quotes the SEA build config path, updates desktop enterprise validation to use the `api.<host>/enterprises` endpoint with more flexible response parsing, bumps version to `1.3.0`, and adds `sonar-local-scan.sh` to `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b24581637aedeeb39a875d8627b864ad2a83c22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->