### PR TITLE
Auto stash before checking out "origin/main"

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -69,15 +69,17 @@ Full codebase review of 95 files across shared utilities, state management, pipe
 
 ---
 
-## Feature: 4-Tier Log File Output (2026-04-22)
-<!-- updated: 2026-04-22_02:35:00 -->
+## Feature: Per-Run Log Folders (2026-04-22)
+<!-- updated: 2026-04-22_03:01:00 -->
 
-Every command now writes four separate log files to `migration-output/logs/`:
+Each migration run now creates a **timestamped subfolder** under `migration-output/logs/`, e.g. `migration-output/logs/2026-04-22T03-01-00-123Z/`. This makes it easy to find and compare logs across different runs.
 
-- **`cloudvoyager-{cmd}-{timestamp}.log`** — Raw/unfiltered (all levels including debug)
-- **`cloudvoyager-{cmd}-{timestamp}.info.log`** — Only `info` entries
-- **`cloudvoyager-{cmd}-{timestamp}.warn.log`** — Only `warn` entries
-- **`cloudvoyager-{cmd}-{timestamp}.error.log`** — Only `error` entries
+Within each run folder, four log files are written:
+
+- **`cloudvoyager-{cmd}.log`** — Raw/unfiltered (all levels including debug)
+- **`cloudvoyager-{cmd}.info.log`** — Only `info` entries
+- **`cloudvoyager-{cmd}.warn.log`** — Only `warn` entries
+- **`cloudvoyager-{cmd}.error.log`** — Only `error` entries
 
 This makes it easy to triage warnings and errors without searching through thousands of info-level lines.
 

--- a/src/shared/utils/logger/helpers/enable-file-logging.js
+++ b/src/shared/utils/logger/helpers/enable-file-logging.js
@@ -12,20 +12,20 @@ function filterByLevel(level) {
 }
 
 export function enableFileLogging(commandName) {
-  const logsDir = path.resolve('migration-output', 'logs');
-  if (!fs.existsSync(logsDir)) fs.mkdirSync(logsDir, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const runDir = path.resolve('migration-output', 'logs', ts);
+  if (!fs.existsSync(runDir)) fs.mkdirSync(runDir, { recursive: true });
 
   const existing = logger.transports.filter(t => t instanceof winston.transports.File);
   for (const t of existing) logger.remove(t);
 
   const safeName = commandName.replace(/[^a-zA-Z0-9_-]/g, '_');
-  const ts = new Date().toISOString().replace(/[:.]/g, '-');
   const fileFormat = combine(timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }), logFormat);
 
-  const rawLogPath = path.join(logsDir, `cloudvoyager-${safeName}-${ts}.log`);
-  const infoLogPath = path.join(logsDir, `cloudvoyager-${safeName}-${ts}.info.log`);
-  const warnLogPath = path.join(logsDir, `cloudvoyager-${safeName}-${ts}.warn.log`);
-  const errorLogPath = path.join(logsDir, `cloudvoyager-${safeName}-${ts}.error.log`);
+  const rawLogPath = path.join(runDir, `cloudvoyager-${safeName}.log`);
+  const infoLogPath = path.join(runDir, `cloudvoyager-${safeName}.info.log`);
+  const warnLogPath = path.join(runDir, `cloudvoyager-${safeName}.warn.log`);
+  const errorLogPath = path.join(runDir, `cloudvoyager-${safeName}.error.log`);
 
   logger.add(new winston.transports.File({
     filename: rawLogPath, level: 'debug',
@@ -47,7 +47,7 @@ export function enableFileLogging(commandName) {
     format: combine(filterByLevel('error'), fileFormat)
   }));
 
-  logger.info(`Logs directory: ${logsDir}`);
+  logger.info(`Logs directory: ${runDir}`);
   logger.info(`  Raw logs:   ${rawLogPath}`);
   logger.info(`  Info logs:  ${infoLogPath}`);
   logger.info(`  Warn logs:  ${warnLogPath}`);

--- a/test/utils/logger.test.js
+++ b/test/utils/logger.test.js
@@ -45,7 +45,7 @@ test.serial('enableFileLogging creates log directory and adds 3 file transports'
 
   t.truthy(result);
   t.true(typeof result === 'object');
-  t.true(result.rawLogPath.includes('cloudvoyager-test-cmd-'));
+  t.true(result.rawLogPath.includes('cloudvoyager-test-cmd'));
   t.true(result.rawLogPath.endsWith('.log'));
   t.true(result.infoLogPath.endsWith('.info.log'));
   t.true(result.warnLogPath.endsWith('.warn.log'));
@@ -60,11 +60,11 @@ test.serial('enableFileLogging creates log directory and adds 3 file transports'
 test.serial('enableFileLogging with custom command name prefix', t => {
   const result = enableFileLogging('migrate');
 
-  t.true(result.rawLogPath.includes('cloudvoyager-migrate-'));
+  t.true(result.rawLogPath.includes('cloudvoyager-migrate'));
   t.true(result.rawLogPath.endsWith('.log'));
-  t.true(result.infoLogPath.includes('cloudvoyager-migrate-'));
-  t.true(result.warnLogPath.includes('cloudvoyager-migrate-'));
-  t.true(result.errorLogPath.includes('cloudvoyager-migrate-'));
+  t.true(result.infoLogPath.includes('cloudvoyager-migrate'));
+  t.true(result.warnLogPath.includes('cloudvoyager-migrate'));
+  t.true(result.errorLogPath.includes('cloudvoyager-migrate'));
 
   const fileTransports = logger.transports.filter(tr => tr.constructor.name === 'File');
   for (const ft of fileTransports) logger.remove(ft);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to log file path/naming and related tests/documentation; main impact is any tooling that relied on the previous timestamp-in-filename convention.
> 
> **Overview**
> Switches file logging to create a *per-run timestamped directory* under `migration-output/logs/` and writes the four level-split log files there, instead of embedding timestamps in each filename.
> 
> Updates log output messaging and unit tests to match the new path/filename convention, and refreshes the changelog entry describing the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0b841bdd29a7c57c8509e95fad20af6b245a819. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->