### PR TITLE
Contributors/joshuaquek/fix 98 verify on large project with more than 10k issues

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to CloudVoyager are documented in this file. Entries are ord
 
 ---
 
+## Bug Fix: Duplicate Log Folders on Heap Respawn (2026-04-22)
+<!-- updated: 2026-04-22_11:22:00 -->
+
+`enableFileLogging` was called in each command handler **before** `ensureHeapSize` in the action handler. When the process respawned for more heap memory, the child process called `enableFileLogging` again, creating a second per-run log folder. The initial process's folder contained only startup messages; all real logs went to the child's folder.
+
+**Fix:** Moved `enableFileLogging` from the 4 command handlers (`migrate`, `verify`, `transfer`, `sync-metadata`) into their respective action handlers, immediately after `ensureHeapSize`. Since `ensureHeapSize` either respawns (never returns) or returns normally, `enableFileLogging` now runs exactly once — in the process that does the actual work.
+
+### Files Changed (8)
+
+- `src/commands/migrate/index.js` — removed `enableFileLogging` call
+- `src/commands/migrate/helpers/handle-migrate-action.js` — added `enableFileLogging` after `ensureHeapSize`
+- `src/commands/verify/index.js` — removed `enableFileLogging` call
+- `src/commands/verify/helpers/handle-verify-action.js` — added `enableFileLogging` after `ensureHeapSize`
+- `src/commands/transfer/index.js` — removed `enableFileLogging` call
+- `src/commands/transfer/helpers/handle-transfer-action.js` — added `enableFileLogging` after `ensureHeapSize`
+- `src/commands/sync-metadata/index.js` — removed `enableFileLogging` call
+- `src/commands/sync-metadata/helpers/handle-sync-metadata-action.js` — added `enableFileLogging` after `ensureHeapSize`
+
+---
+
 ## Issue #98: Additional Bug Fixes from Deep Code Review (2026-04-22)
 <!-- updated: 2026-04-22_02:45:00 -->
 

--- a/docs/key-capabilities.md
+++ b/docs/key-capabilities.md
@@ -878,7 +878,7 @@ Performance and rate-limit schemas are shared across all configuration types, en
 - **`--dry-run`** — Execute extraction and mapping without writing to SonarCloud
 - **`--verbose`** — Debug-level logging for troubleshooting
 
-<!-- updated: 2026-04-22_02:05:00 -->
+<!-- updated: 2026-04-22_11:10:00 -->
 ### Logging
 
 Winston-based logging with:
@@ -887,16 +887,16 @@ Winston-based logging with:
 - Structured timestamps and log formatting
 - `--verbose` flag sets level to `debug`
 
-**Automatic file logging** — Every command (`migrate`, `transfer`, `verify`, `sync-metadata`) writes three log files to `migration-output/logs/`:
+**Automatic per-run log folders** — Every command (`migrate`, `transfer`, `verify`, `sync-metadata`) creates a timestamped subfolder under `migration-output/logs/` (e.g., `migration-output/logs/2026-04-22T03-01-00-123Z/`), making it easy to find and compare logs across different runs. Within each run folder, four log files are written:
 
 | File | Contents |
 |------|----------|
-| `cloudvoyager-{cmd}-{timestamp}.log` | All log levels (raw/unfiltered) |
-| `cloudvoyager-{cmd}-{timestamp}.info.log` | Only `info` level entries |
-| `cloudvoyager-{cmd}-{timestamp}.warn.log` | Only `warn` level entries |
-| `cloudvoyager-{cmd}-{timestamp}.error.log` | Only `error` level entries |
+| `cloudvoyager-{cmd}.log` | All log levels (raw/unfiltered) |
+| `cloudvoyager-{cmd}.info.log` | Only `info` level entries |
+| `cloudvoyager-{cmd}.warn.log` | Only `warn` level entries |
+| `cloudvoyager-{cmd}.error.log` | Only `error` level entries |
 
-The filtered logs make it easy to triage issues without searching through thousands of info-level lines.
+The filtered logs make it easy to triage issues without searching through thousands of info-level lines. The `logs/` subdirectory is preserved during output directory cleanup so logs accumulate across runs.
 
 ---
 

--- a/src/commands/migrate/helpers/handle-migrate-action.js
+++ b/src/commands/migrate/helpers/handle-migrate-action.js
@@ -3,7 +3,7 @@
 import { loadMigrateConfig } from '../../../shared/config/loader.js';
 import { detectAndRoute } from '../../../version-router.js';
 import { logSystemInfo, ensureHeapSize } from '../../../shared/utils/concurrency.js';
-import logger from '../../../shared/utils/logger.js';
+import logger, { enableFileLogging } from '../../../shared/utils/logger.js';
 import { applyMigrateOptions } from './apply-migrate-options.js';
 import { buildMigratePerfConfig } from './build-migrate-perf-config.js';
 
@@ -16,6 +16,7 @@ export async function handleMigrateAction(options, shutdownCoordinator) {
 
   const perfConfig = buildMigratePerfConfig(config, options);
   ensureHeapSize(perfConfig.maxMemoryMB);
+  enableFileLogging('migrate');
   logSystemInfo(perfConfig);
 
   const { migrateAll, pipelineId } = await detectAndRoute(config.sonarqube);

--- a/src/commands/migrate/index.js
+++ b/src/commands/migrate/index.js
@@ -1,6 +1,6 @@
 // -------- Migrate Command --------
 
-import logger, { enableFileLogging } from '../../shared/utils/logger.js';
+import logger from '../../shared/utils/logger.js';
 import { ShutdownCoordinator } from '../../shared/utils/shutdown.js';
 import { handleMigrateAction } from './helpers/handle-migrate-action.js';
 import { handleCommandError } from '../transfer/helpers/handle-command-error.js';
@@ -36,7 +36,6 @@ export function registerMigrateCommand(program) {
 
       try {
         if (options.verbose) logger.level = 'debug';
-        enableFileLogging('migrate');
         logger.info('=== CloudVoyager - Full Organization Migration ===');
         await handleMigrateAction(options, shutdownCoordinator);
         logger.info('=== Migration completed successfully ===');

--- a/src/commands/sync-metadata/helpers/handle-sync-metadata-action.js
+++ b/src/commands/sync-metadata/helpers/handle-sync-metadata-action.js
@@ -3,7 +3,7 @@
 import { loadMigrateConfig } from '../../../shared/config/loader.js';
 import { detectAndRoute } from '../../../version-router.js';
 import { resolvePerformanceConfig, logSystemInfo, ensureHeapSize } from '../../../shared/utils/concurrency.js';
-import logger from '../../../shared/utils/logger.js';
+import logger, { enableFileLogging } from '../../../shared/utils/logger.js';
 
 export async function handleSyncMetadataAction(options, shutdownCoordinator) {
   const config = await loadMigrateConfig(options.config);
@@ -22,6 +22,7 @@ export async function handleSyncMetadataAction(options, shutdownCoordinator) {
     ...(options.maxMemory && { maxMemoryMB: options.maxMemory })
   });
   ensureHeapSize(perfConfig.maxMemoryMB);
+  enableFileLogging('sync-metadata');
   logSystemInfo(perfConfig);
 
   migrateConfig.dryRun = false;

--- a/src/commands/sync-metadata/index.js
+++ b/src/commands/sync-metadata/index.js
@@ -1,6 +1,6 @@
 // -------- Sync Metadata Command --------
 
-import logger, { enableFileLogging } from '../../shared/utils/logger.js';
+import logger from '../../shared/utils/logger.js';
 import { ShutdownCoordinator } from '../../shared/utils/shutdown.js';
 import { handleSyncMetadataAction } from './helpers/handle-sync-metadata-action.js';
 import { handleCommandError } from '../transfer/helpers/handle-command-error.js';
@@ -28,7 +28,6 @@ export function registerSyncMetadataCommand(program) {
 
       try {
         if (options.verbose) logger.level = 'debug';
-        enableFileLogging('sync-metadata');
         logger.info('=== CloudVoyager - Issue & Hotspot Metadata Sync ===');
         await handleSyncMetadataAction(options, shutdownCoordinator);
         logger.info('=== Metadata sync completed successfully ===');

--- a/src/commands/transfer/helpers/handle-transfer-action.js
+++ b/src/commands/transfer/helpers/handle-transfer-action.js
@@ -4,7 +4,7 @@ import { loadConfig, requireProjectKeys } from '../../../shared/config/loader.js
 import { detectAndRoute } from '../../../version-router.js';
 import { resolvePerformanceConfig, logSystemInfo, ensureHeapSize } from '../../../shared/utils/concurrency.js';
 import { ProgressTracker } from '../../../shared/utils/progress.js';
-import logger from '../../../shared/utils/logger.js';
+import logger, { enableFileLogging } from '../../../shared/utils/logger.js';
 
 export async function handleTransferAction(options, shutdownCoordinator) {
   const config = await loadConfig(options.config);
@@ -30,6 +30,7 @@ export async function handleTransferAction(options, shutdownCoordinator) {
     ...(options.maxMemory && { maxMemoryMB: options.maxMemory }),
   });
   ensureHeapSize(perfConfig.maxMemoryMB);
+  enableFileLogging('transfer');
   logSystemInfo(perfConfig);
 
   const { transferProject, pipelineId } = await detectAndRoute(config.sonarqube);

--- a/src/commands/transfer/index.js
+++ b/src/commands/transfer/index.js
@@ -1,6 +1,6 @@
 // -------- Transfer Command --------
 
-import logger, { enableFileLogging } from '../../shared/utils/logger.js';
+import logger from '../../shared/utils/logger.js';
 import { ShutdownCoordinator } from '../../shared/utils/shutdown.js';
 import { handleTransferAction } from './helpers/handle-transfer-action.js';
 import { handleCommandError } from './helpers/handle-command-error.js';
@@ -30,7 +30,6 @@ export function registerTransferCommand(program) {
 
       try {
         if (options.verbose) logger.level = 'debug';
-        enableFileLogging('transfer');
         await handleTransferAction(options, shutdownCoordinator);
         logger.info('=== Transfer completed successfully ===');
         process.exit(0);

--- a/src/commands/verify/helpers/handle-verify-action.js
+++ b/src/commands/verify/helpers/handle-verify-action.js
@@ -3,7 +3,7 @@
 import { loadMigrateConfig } from '../../../shared/config/loader.js';
 import { verifyAll } from '../../../shared/verification/verify-pipeline.js';
 import { resolvePerformanceConfig, logSystemInfo, ensureHeapSize } from '../../../shared/utils/concurrency.js';
-import logger from '../../../shared/utils/logger.js';
+import logger, { enableFileLogging } from '../../../shared/utils/logger.js';
 import { parseOnlyComponents } from './parse-only-components.js';
 
 export async function handleVerifyAction(options) {
@@ -21,6 +21,7 @@ export async function handleVerifyAction(options) {
     ...(options.maxMemory && { maxMemoryMB: options.maxMemory })
   });
   ensureHeapSize(perfConfig.maxMemoryMB);
+  enableFileLogging('verify');
   logSystemInfo(perfConfig);
 
   const results = await verifyAll({

--- a/src/commands/verify/index.js
+++ b/src/commands/verify/index.js
@@ -1,6 +1,6 @@
 // -------- Verify Command --------
 
-import logger, { enableFileLogging } from '../../shared/utils/logger.js';
+import logger from '../../shared/utils/logger.js';
 import { CloudVoyagerError } from '../../shared/utils/errors.js';
 import { handleVerifyAction } from './helpers/handle-verify-action.js';
 
@@ -22,7 +22,6 @@ export function registerVerifyCommand(program) {
     .action(async (options) => {
       try {
         if (options.verbose) logger.level = 'debug';
-        enableFileLogging('verify');
         logger.info('=== CloudVoyager - Migration Verification ===');
         await handleVerifyAction(options);
         logger.info('=== Verification completed successfully — all checks passed ===');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small control-flow change to when `enableFileLogging` runs, limited to CLI command startup and should only affect log folder creation during `ensureHeapSize` respawns.
> 
> **Overview**
> Fixes duplicate per-run log folders when `ensureHeapSize` triggers a respawn by moving `enableFileLogging()` out of the `migrate`, `transfer`, `verify`, and `sync-metadata` command handlers and into their action handlers immediately after `ensureHeapSize`.
> 
> Updates docs (`CHANGELOG.md`, `key-capabilities.md`) to describe the heap-respawn logging bug and the corrected per-run log folder behavior/naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f6de01e941b51f17e203b3a584e020c5aae587a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->