### PR TITLE
chore: add transfer test script and document debugging scripts

### DIFF
--- a/.debugging/test-transfer.sh
+++ b/.debugging/test-transfer.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./dist/bin/cloudvoyager-macos-arm64 transfer -c config.json --force-restart

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ debug/
 proto/
 compliance/sonar_scan_local.sh
 migrate-config.json
+transfer-config.json
 .claude/
 
 # Desktop app
@@ -69,6 +70,7 @@ dist/desktop/
 **/*.json.journal
 **/*.json.journal.backup
 **/*.json.gz
+*.lock
 
 sonar-local-scan.sh
 *.backup

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -889,6 +889,24 @@ The following npm scripts are available for building, testing, and linting:
 
 ---
 
+<!-- updated: 2026-04-29_14:50:00 -->
+## 🐛 Debugging Scripts
+
+The `.debugging/` folder contains convenience scripts for local testing:
+
+| Script | What it does |
+|--------|-------------|
+| `test-migrate.sh` | Run `migrate` command with `migrate-config.json` |
+| `test-transfer.sh` | Run `transfer` command with `transfer-config.json` |
+| `test-verify.sh` | Run `verify` command with `migrate-config.json` |
+| `build-desktop.sh` | Build the Electron desktop app |
+| `run-desktop.sh` | Launch the desktop app in dev mode |
+| `delete-all-sonarcloud-projects.sh` | Delete all projects from a SonarCloud org (for cleanup) |
+
+These scripts expect the binary at `./dist/bin/cloudvoyager-macos-arm64` and config files at the repo root. Both `migrate-config.json` and `transfer-config.json` are gitignored since they contain credentials.
+
+---
+
 <!-- Updated: Feb 20, 2026 at 04:02:35 PM -->
 ## 📚 Further Reading
 


### PR DESCRIPTION
## Summary
- Add `.debugging/test-transfer.sh` for quick local testing of the `transfer` command
- Gitignore `transfer-config.json` (credentials) and `*.lock` files
- Document all `.debugging/` scripts in `docs/local-development.md`

## Test plan
- [ ] Verify `transfer-config.json` is not tracked by git
- [ ] Run `.debugging/test-transfer.sh` with a valid `config.json` to confirm it invokes the transfer command correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit be3ec486c7e2597772d78a05e05fde126e4fa7c6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->