### PR TITLE
fix: use sonar.core.serverBaseURL for source links in issue/hotspot comments (Issue #134)

### DIFF
--- a/src/pipelines/sq-10.0/pipeline/project-metadata-sync/helpers/sync-project-hotspots.js
+++ b/src/pipelines/sq-10.0/pipeline/project-metadata-sync/helpers/sync-project-hotspots.js
@@ -12,7 +12,7 @@ export async function syncProjectHotspots(projectResult, results, reportUploadOk
   try {
     logger.info(`[${projectKey}] Syncing hotspot metadata...`);
     const sqHotspots = await extractHotspots(projectSqClient, null, { concurrency: ctx.perfConfig.hotspotExtraction.concurrency });
-    const hotspotStats = await syncHotspots(scProjectKey, sqHotspots, projectScClient, { concurrency: ctx.perfConfig.hotspotSync.concurrency, sonarqubeUrl: projectSqClient.baseURL, sonarqubeProjectKey: projectSqClient.projectKey });
+    const hotspotStats = await syncHotspots(scProjectKey, sqHotspots, projectScClient, { concurrency: ctx.perfConfig.hotspotSync.concurrency, sonarqubeUrl: projectSqClient.baseURL, sonarqubeProjectKey: projectSqClient.projectKey, sqClient: projectSqClient });
     logger.info(`[${projectKey}] Hotspot sync: ${hotspotStats.matched} matched, ${hotspotStats.statusChanged} status changed`);
     results.hotspotSyncStats.matched += hotspotStats.matched;
     results.hotspotSyncStats.statusChanged += hotspotStats.statusChanged;

--- a/src/pipelines/sq-10.0/pipeline/project-migration/helpers/sync-project-hotspots.js
+++ b/src/pipelines/sq-10.0/pipeline/project-migration/helpers/sync-project-hotspots.js
@@ -17,7 +17,7 @@ export async function syncProjectHotspots(projectResult, results, reportUploadOk
   try {
     logger.info(`[${projectKey}] Syncing hotspot metadata...`);
     const sqHotspots = await extractHotspots(projectSqClient, null, { concurrency: ctx.perfConfig.hotspotExtraction.concurrency });
-    const stats = await syncHotspots(scProjectKey, sqHotspots, projectScClient, { concurrency: ctx.perfConfig.hotspotSync.concurrency, sonarqubeUrl: projectSqClient.baseURL, sonarqubeProjectKey: projectSqClient.projectKey });
+    const stats = await syncHotspots(scProjectKey, sqHotspots, projectScClient, { concurrency: ctx.perfConfig.hotspotSync.concurrency, sonarqubeUrl: projectSqClient.baseURL, sonarqubeProjectKey: projectSqClient.projectKey, sqClient: projectSqClient });
     logger.info(`[${projectKey}] Hotspot sync: ${stats.matched} matched, ${stats.statusChanged} status changed`);
     results.hotspotSyncStats.matched += stats.matched;
     results.hotspotSyncStats.statusChanged += stats.statusChanged;

--- a/src/pipelines/sq-10.0/sonarcloud/migrators/hotspot-sync/helpers/add-hotspot-source-link.js
+++ b/src/pipelines/sq-10.0/sonarcloud/migrators/hotspot-sync/helpers/add-hotspot-source-link.js
@@ -1,4 +1,5 @@
 import logger from '../../../../../../shared/utils/logger.js';
+import { buildHotspotSourceComment } from '../../../../../../shared/utils/source-link/build-source-comments.js';
 
 // -------- Add Hotspot Source Link --------
 
@@ -7,8 +8,8 @@ export async function addHotspotSourceLink(sqHotspot, scHotspot, client, options
   if (!sonarqubeUrl || !sonarqubeProjectKey) return false;
 
   try {
-    const sqUrl = `${sonarqubeUrl}/security_hotspots?id=${encodeURIComponent(sonarqubeProjectKey)}&hotspots=${encodeURIComponent(sqHotspot.key)}`;
-    await client.addHotspotComment(scHotspot.key, `[SonarQube Source] Original hotspot: ${sqUrl}`);
+    const text = buildHotspotSourceComment(sonarqubeUrl, sonarqubeProjectKey, sqHotspot.key);
+    await client.addHotspotComment(scHotspot.key, text);
     return true;
   } catch (error) {
     logger.debug(`Failed to add source link comment to hotspot ${scHotspot.key}: ${error.message}`);

--- a/src/pipelines/sq-10.0/sonarcloud/migrators/hotspot-sync/index.js
+++ b/src/pipelines/sq-10.0/sonarcloud/migrators/hotspot-sync/index.js
@@ -1,6 +1,7 @@
 import logger from '../../../../../shared/utils/logger.js';
 import { mapConcurrent, createProgressLogger } from '../../../../../shared/utils/concurrency.js';
 import { waitForScIndexing } from '../../../../../shared/utils/issue-sync/wait-for-sc-indexing.js';
+import { resolveSourceBaseURL } from '../../../../../shared/utils/source-link/resolve-source-base-url.js';
 import { matchHotspots } from './helpers/match-hotspots.js';
 import { syncSingleHotspot } from './helpers/sync-single-hotspot.js';
 import { createEmptyHotspotStats } from './helpers/create-empty-hotspot-stats.js';
@@ -15,6 +16,10 @@ export { mapHotspotChangelogDiffToAction, extractHotspotTransitionsFromChangelog
 export async function syncHotspots(projectKey, sqHotspots, client, options = {}) {
   const concurrency = options.concurrency || 3;
   const stats = createEmptyHotspotStats();
+
+  if (options.sqClient && options.sonarqubeProjectKey) {
+    options.sonarqubeUrl = await resolveSourceBaseURL(options.sqClient);
+  }
 
   let scHotspots = await client.searchHotspots(projectKey);
   if (scHotspots.length === 0 && sqHotspots.length > 0) {

--- a/src/pipelines/sq-10.0/sonarcloud/migrators/issue-sync/helpers/add-source-link.js
+++ b/src/pipelines/sq-10.0/sonarcloud/migrators/issue-sync/helpers/add-source-link.js
@@ -1,12 +1,15 @@
 import logger from '../../../../../../shared/utils/logger.js';
+import { resolveSourceBaseURL } from '../../../../../../shared/utils/source-link/resolve-source-base-url.js';
+import { buildIssueSourceComment } from '../../../../../../shared/utils/source-link/build-source-comments.js';
 
 // -------- Add Source Link Comment --------
 
 export async function addSourceLink(sqIssue, scIssue, client, sqClient, stats) {
   if (!sqClient?.baseURL || !sqClient?.projectKey) return;
   try {
-    const sqUrl = `${sqClient.baseURL}/project/issues?id=${encodeURIComponent(sqClient.projectKey)}&issues=${encodeURIComponent(sqIssue.key)}&open=${encodeURIComponent(sqIssue.key)}`;
-    await client.addIssueComment(scIssue.key, `[SonarQube Source] Original issue: ${sqUrl}`);
+    const baseURL = await resolveSourceBaseURL(sqClient);
+    const text = buildIssueSourceComment(baseURL, sqClient.projectKey, sqIssue.key);
+    await client.addIssueComment(scIssue.key, text);
     stats.sourceLinked++;
   } catch (error) {
     logger.debug(`Failed to add source link comment to issue ${scIssue.key}: ${error.message}`);

--- a/src/pipelines/sq-10.0/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-hotspots.js
+++ b/src/pipelines/sq-10.0/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-hotspots.js
@@ -27,5 +27,6 @@ export async function fetchAndSyncHotspots(opts) {
     concurrency: syncConcurrency,
     sonarqubeUrl: sonarQubeClient.baseURL,
     sonarqubeProjectKey: sonarQubeClient.projectKey,
+    sqClient: sonarQubeClient,
   });
 }

--- a/src/pipelines/sq-10.4/pipeline/project-migration/helpers/sync-project-hotspots.js
+++ b/src/pipelines/sq-10.4/pipeline/project-migration/helpers/sync-project-hotspots.js
@@ -21,7 +21,7 @@ export async function syncProjectHotspots(projectResult, results, reportUploadOk
   try {
     logger.info(`[${projectKey}] Syncing hotspot metadata...`);
     const sqHotspots = await extractHotspots(projectSqClient, null, { concurrency: ctx.perfConfig.hotspotExtraction.concurrency });
-    const stats = await syncHotspots(scProjectKey, sqHotspots, projectScClient, { concurrency: ctx.perfConfig.hotspotSync.concurrency, sonarqubeUrl: projectSqClient.baseURL, sonarqubeProjectKey: projectSqClient.projectKey });
+    const stats = await syncHotspots(scProjectKey, sqHotspots, projectScClient, { concurrency: ctx.perfConfig.hotspotSync.concurrency, sonarqubeUrl: projectSqClient.baseURL, sonarqubeProjectKey: projectSqClient.projectKey, sqClient: projectSqClient });
 
     logger.info(`[${projectKey}] Hotspot sync: ${stats.matched} matched, ${stats.statusChanged} status changed`);
     results.hotspotSyncStats.matched += stats.matched;

--- a/src/pipelines/sq-10.4/sonarcloud/migrators/hotspot-sync/helpers/add-source-link-comment.js
+++ b/src/pipelines/sq-10.4/sonarcloud/migrators/hotspot-sync/helpers/add-source-link-comment.js
@@ -1,4 +1,5 @@
 import logger from '../../../../../../shared/utils/logger.js';
+import { buildHotspotSourceComment } from '../../../../../../shared/utils/source-link/build-source-comments.js';
 
 // -------- Main Logic --------
 
@@ -8,8 +9,8 @@ export async function addSourceLinkComment(sqHotspot, scHotspot, client, stats, 
   if (!sonarqubeUrl || !sonarqubeProjectKey) return;
 
   try {
-    const sqUrl = `${sonarqubeUrl}/security_hotspots?id=${encodeURIComponent(sonarqubeProjectKey)}&hotspots=${encodeURIComponent(sqHotspot.key)}`;
-    await client.addHotspotComment(scHotspot.key, `[SonarQube Source] Original hotspot: ${sqUrl}`);
+    const text = buildHotspotSourceComment(sonarqubeUrl, sonarqubeProjectKey, sqHotspot.key);
+    await client.addHotspotComment(scHotspot.key, text);
     stats.sourceLinked++;
   } catch (error) {
     logger.debug(`Failed to add source link comment to hotspot ${scHotspot.key}: ${error.message}`);

--- a/src/pipelines/sq-10.4/sonarcloud/migrators/hotspot-sync/helpers/sync-hotspots.js
+++ b/src/pipelines/sq-10.4/sonarcloud/migrators/hotspot-sync/helpers/sync-hotspots.js
@@ -1,6 +1,7 @@
 import logger from '../../../../../../shared/utils/logger.js';
 import { mapConcurrent, createProgressLogger } from '../../../../../../shared/utils/concurrency.js';
 import { waitForScIndexing } from '../../../../../../shared/utils/issue-sync/wait-for-sc-indexing.js';
+import { resolveSourceBaseURL } from '../../../../../../shared/utils/source-link/resolve-source-base-url.js';
 import { matchHotspots } from './match-hotspots.js';
 import { createSyncStats } from './create-sync-stats.js';
 import { syncSingleHotspot } from './sync-single-hotspot.js';
@@ -11,6 +12,10 @@ import { syncSingleHotspot } from './sync-single-hotspot.js';
 export async function syncHotspots(projectKey, sqHotspots, client, options = {}) {
   const concurrency = options.concurrency || 3;
   const stats = createSyncStats();
+
+  if (options.sqClient && options.sonarqubeProjectKey) {
+    options.sonarqubeUrl = await resolveSourceBaseURL(options.sqClient);
+  }
 
   let scHotspots = await client.searchHotspots(projectKey);
   if (scHotspots.length === 0 && sqHotspots.length > 0) {

--- a/src/pipelines/sq-10.4/sonarcloud/migrators/issue-sync/helpers/sync-issue-metadata.js
+++ b/src/pipelines/sq-10.4/sonarcloud/migrators/issue-sync/helpers/sync-issue-metadata.js
@@ -1,4 +1,6 @@
 import logger from '../../../../../../shared/utils/logger.js';
+import { resolveSourceBaseURL } from '../../../../../../shared/utils/source-link/resolve-source-base-url.js';
+import { buildIssueSourceComment } from '../../../../../../shared/utils/source-link/build-source-comments.js';
 
 // -------- Main Logic --------
 
@@ -33,8 +35,9 @@ export async function syncIssueMetadata(sqIssue, scIssue, client, sqClient, stat
   // Add source link comment
   if (sqClient?.baseURL && sqClient?.projectKey) {
     try {
-      const sqUrl = `${sqClient.baseURL}/project/issues?id=${encodeURIComponent(sqClient.projectKey)}&issues=${encodeURIComponent(sqIssue.key)}&open=${encodeURIComponent(sqIssue.key)}`;
-      await client.addIssueComment(scIssue.key, `[SonarQube Source] Original issue: ${sqUrl}`);
+      const baseURL = await resolveSourceBaseURL(sqClient);
+      const text = buildIssueSourceComment(baseURL, sqClient.projectKey, sqIssue.key);
+      await client.addIssueComment(scIssue.key, text);
       stats.sourceLinked++;
     } catch (e) { logger.debug(`Failed to add source link comment to issue ${scIssue.key}: ${e.message}`); }
   }

--- a/src/pipelines/sq-10.4/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-hotspots.js
+++ b/src/pipelines/sq-10.4/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-hotspots.js
@@ -27,5 +27,6 @@ export async function fetchAndSyncHotspots(opts) {
     concurrency: syncConcurrency,
     sonarqubeUrl: sonarQubeClient.baseURL,
     sonarqubeProjectKey: sonarQubeClient.projectKey,
+    sqClient: sonarQubeClient,
   });
 }

--- a/src/pipelines/sq-2025/pipeline/project-metadata-sync/helpers/sync-project-hotspots.js
+++ b/src/pipelines/sq-2025/pipeline/project-metadata-sync/helpers/sync-project-hotspots.js
@@ -19,7 +19,7 @@ export async function syncProjectHotspots(projectResult, results, reportUploadOk
   try {
     logger.info(`[${projectKey}] Syncing hotspot metadata...`);
     const sqHotspots = await extractHotspots(projectSqClient, null, { concurrency: ctx.perfConfig.hotspotExtraction.concurrency });
-    const hotspotStats = await syncHotspots(scProjectKey, sqHotspots, projectScClient, { concurrency: ctx.perfConfig.hotspotSync.concurrency, sonarqubeUrl: projectSqClient.baseURL, sonarqubeProjectKey: projectSqClient.projectKey });
+    const hotspotStats = await syncHotspots(scProjectKey, sqHotspots, projectScClient, { concurrency: ctx.perfConfig.hotspotSync.concurrency, sonarqubeUrl: projectSqClient.baseURL, sonarqubeProjectKey: projectSqClient.projectKey, sqClient: projectSqClient });
     logger.info(`[${projectKey}] Hotspot sync: ${hotspotStats.matched} matched, ${hotspotStats.statusChanged} status changed`);
     results.hotspotSyncStats.matched += hotspotStats.matched;
     results.hotspotSyncStats.statusChanged += hotspotStats.statusChanged;

--- a/src/pipelines/sq-2025/pipeline/project-migration/helpers/migrate-one-project-metadata/helpers/sync-hotspot-metadata.js
+++ b/src/pipelines/sq-2025/pipeline/project-migration/helpers/migrate-one-project-metadata/helpers/sync-hotspot-metadata.js
@@ -27,7 +27,7 @@ async function syncProjectHotspots(projectResult, results, reportUploadOk, ctx, 
   try {
     logger.info(`[${projectKey}] Syncing hotspot metadata...`);
     const sqHotspots = await extractHotspots(projectSqClient, null, { concurrency: ctx.perfConfig.hotspotExtraction.concurrency });
-    const hotspotStats = await syncHotspots(scProjectKey, sqHotspots, projectScClient, { concurrency: ctx.perfConfig.hotspotSync.concurrency, sonarqubeUrl: projectSqClient.baseURL, sonarqubeProjectKey: projectSqClient.projectKey });
+    const hotspotStats = await syncHotspots(scProjectKey, sqHotspots, projectScClient, { concurrency: ctx.perfConfig.hotspotSync.concurrency, sonarqubeUrl: projectSqClient.baseURL, sonarqubeProjectKey: projectSqClient.projectKey, sqClient: projectSqClient });
     logger.info(`[${projectKey}] Hotspot sync: ${hotspotStats.matched} matched, ${hotspotStats.statusChanged} status changed`);
     results.hotspotSyncStats.matched += hotspotStats.matched;
     results.hotspotSyncStats.statusChanged += hotspotStats.statusChanged;

--- a/src/pipelines/sq-2025/sonarcloud/migrators/hotspot-sync/helpers/sync-one-hotspot.js
+++ b/src/pipelines/sq-2025/sonarcloud/migrators/hotspot-sync/helpers/sync-one-hotspot.js
@@ -1,4 +1,5 @@
 import logger from '../../../../../../shared/utils/logger.js';
+import { buildHotspotSourceComment } from '../../../../../../shared/utils/source-link/build-source-comments.js';
 import { syncHotspotStatus } from './sync-hotspot-status.js';
 
 // -------- Sync One Hotspot --------
@@ -24,8 +25,8 @@ export async function syncOneHotspot({ sqHotspot, scHotspot }, client, options, 
 
     if (options.sonarqubeUrl && options.sonarqubeProjectKey) {
       try {
-        const sqUrl = `${options.sonarqubeUrl}/security_hotspots?id=${encodeURIComponent(options.sonarqubeProjectKey)}&hotspots=${encodeURIComponent(sqHotspot.key)}`;
-        await client.addHotspotComment(scHotspot.key, `[SonarQube Source] Original hotspot: ${sqUrl}`);
+        const text = buildHotspotSourceComment(options.sonarqubeUrl, options.sonarqubeProjectKey, sqHotspot.key);
+        await client.addHotspotComment(scHotspot.key, text);
         stats.sourceLinked++;
       } catch (error) { logger.debug(`Failed to add source link to hotspot ${scHotspot.key}: ${error.message}`); }
     }

--- a/src/pipelines/sq-2025/sonarcloud/migrators/hotspot-sync/index.js
+++ b/src/pipelines/sq-2025/sonarcloud/migrators/hotspot-sync/index.js
@@ -1,6 +1,7 @@
 import logger from '../../../../../shared/utils/logger.js';
 import { mapConcurrent, createProgressLogger } from '../../../../../shared/utils/concurrency.js';
 import { waitForScIndexing } from '../../../../../shared/utils/issue-sync/wait-for-sc-indexing.js';
+import { resolveSourceBaseURL } from '../../../../../shared/utils/source-link/resolve-source-base-url.js';
 import { matchHotspots } from './helpers/match-hotspots.js';
 import { syncOneHotspot } from './helpers/sync-one-hotspot.js';
 
@@ -14,6 +15,10 @@ export { mapHotspotChangelogDiffToAction, extractHotspotTransitionsFromChangelog
 export async function syncHotspots(projectKey, sqHotspots, client, options = {}) {
   const concurrency = options.concurrency || 3;
   const stats = { matched: 0, statusChanged: 0, commented: 0, metadataSyncCommented: 0, sourceLinked: 0, failed: 0 };
+
+  if (options.sqClient && options.sonarqubeProjectKey) {
+    options.sonarqubeUrl = await resolveSourceBaseURL(options.sqClient);
+  }
 
   let scHotspots = await client.searchHotspots(projectKey);
   if (scHotspots.length === 0 && sqHotspots.length > 0) {

--- a/src/pipelines/sq-2025/sonarcloud/migrators/issue-sync/helpers/add-source-link.js
+++ b/src/pipelines/sq-2025/sonarcloud/migrators/issue-sync/helpers/add-source-link.js
@@ -1,4 +1,6 @@
 import logger from '../../../../../../shared/utils/logger.js';
+import { resolveSourceBaseURL } from '../../../../../../shared/utils/source-link/resolve-source-base-url.js';
+import { buildIssueSourceComment } from '../../../../../../shared/utils/source-link/build-source-comments.js';
 
 // -------- Add Source Link --------
 
@@ -7,8 +9,9 @@ export async function addSourceLink(sqIssue, scIssue, client, sqClient, stats) {
   if (!sqClient || !sqClient.baseURL || !sqClient.projectKey) return;
 
   try {
-    const sqUrl = `${sqClient.baseURL}/project/issues?id=${encodeURIComponent(sqClient.projectKey)}&issues=${encodeURIComponent(sqIssue.key)}&open=${encodeURIComponent(sqIssue.key)}`;
-    await client.addIssueComment(scIssue.key, `[SonarQube Source] Original issue: ${sqUrl}`);
+    const baseURL = await resolveSourceBaseURL(sqClient);
+    const text = buildIssueSourceComment(baseURL, sqClient.projectKey, sqIssue.key);
+    await client.addIssueComment(scIssue.key, text);
     stats.sourceLinked++;
   } catch (error) {
     logger.debug(`Failed to add source link comment to issue ${scIssue.key}: ${error.message}`);

--- a/src/pipelines/sq-2025/sonarcloud/migrators/issue-sync/index.js
+++ b/src/pipelines/sq-2025/sonarcloud/migrators/issue-sync/index.js
@@ -4,6 +4,7 @@ import { parallelSyncIssues } from '../../../../../shared/utils/concurrency/help
 import { isClosedOrFixed } from '../../../../../shared/utils/issue-filters/is-closed-or-fixed.js';
 import { applyManualChangesPreFilter } from '../../../../../shared/utils/issue-sync/apply-pre-filter.js';
 import { waitForScIndexing } from '../../../../../shared/utils/issue-sync/wait-for-sc-indexing.js';
+import { resolveSourceBaseURL } from '../../../../../shared/utils/source-link/resolve-source-base-url.js';
 import { matchIssues } from './helpers/match-issues.js';
 import { syncOneIssue } from './helpers/sync-one-issue.js';
 import { createSyncStats } from './helpers/create-sync-stats.js';
@@ -58,7 +59,11 @@ export async function syncIssues(projectKey, sqIssues, client, options = {}) {
   const PARALLEL_THRESHOLD = 500;
   if (matchedPairs.length >= PARALLEL_THRESHOLD) {
     const scConfig = { baseURL: client.baseURL, token: client.token, organization: client.organization, projectKey };
-    const sqClientConfig = sqClient ? { baseURL: sqClient.baseURL, token: sqClient.token, projectKey: sqClient.projectKey } : null;
+    let sqClientConfig = null;
+    if (sqClient) {
+      const resolvedBaseURL = await resolveSourceBaseURL(sqClient);
+      sqClientConfig = { baseURL: resolvedBaseURL, token: sqClient.token, projectKey: sqClient.projectKey };
+    }
     const mergedStats = await parallelSyncIssues(matchedPairs, scConfig, sqClientConfig, userMappings);
     Object.assign(stats, mergedStats);
   } else {

--- a/src/pipelines/sq-2025/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-hotspots.js
+++ b/src/pipelines/sq-2025/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-hotspots.js
@@ -27,5 +27,6 @@ export async function fetchAndSyncHotspots(opts) {
     concurrency: syncConcurrency,
     sonarqubeUrl: sonarQubeClient.baseURL,
     sonarqubeProjectKey: sonarQubeClient.projectKey,
+    sqClient: sonarQubeClient,
   });
 }

--- a/src/pipelines/sq-9.9/pipeline/project-migration/helpers/sync-project-hotspots.js
+++ b/src/pipelines/sq-9.9/pipeline/project-migration/helpers/sync-project-hotspots.js
@@ -17,7 +17,7 @@ export async function syncProjectHotspots(projectResult, results, reportUploadOk
   try {
     logger.info(`[${projectKey}] Syncing hotspot metadata...`);
     const sqHotspots = await extractHotspots(projectSqClient, null, { concurrency: ctx.perfConfig.hotspotExtraction.concurrency });
-    const hotspotStats = await syncHotspots(scProjectKey, sqHotspots, projectScClient, { concurrency: ctx.perfConfig.hotspotSync.concurrency, sonarqubeUrl: projectSqClient.baseURL, sonarqubeProjectKey: projectSqClient.projectKey });
+    const hotspotStats = await syncHotspots(scProjectKey, sqHotspots, projectScClient, { concurrency: ctx.perfConfig.hotspotSync.concurrency, sonarqubeUrl: projectSqClient.baseURL, sonarqubeProjectKey: projectSqClient.projectKey, sqClient: projectSqClient });
     logger.info(`[${projectKey}] Hotspot sync: ${hotspotStats.matched} matched, ${hotspotStats.statusChanged} status changed`);
     results.hotspotSyncStats.matched += hotspotStats.matched;
     results.hotspotSyncStats.statusChanged += hotspotStats.statusChanged;

--- a/src/pipelines/sq-9.9/sonarcloud/migrators/hotspot-sync/helpers/sync-hotspot-comments.js
+++ b/src/pipelines/sq-9.9/sonarcloud/migrators/hotspot-sync/helpers/sync-hotspot-comments.js
@@ -1,4 +1,5 @@
 import logger from '../../../../../../shared/utils/logger.js';
+import { buildHotspotSourceComment } from '../../../../../../shared/utils/source-link/build-source-comments.js';
 
 // -------- Sync Hotspot Comments, Metadata Marker, and Source Link --------
 
@@ -18,8 +19,8 @@ export async function syncHotspotComments(scHotspot, sqHotspot, client, stats, o
 
   if (options.sonarqubeUrl && options.sonarqubeProjectKey) {
     try {
-      const sqUrl = `${options.sonarqubeUrl}/security_hotspots?id=${encodeURIComponent(options.sonarqubeProjectKey)}&hotspots=${encodeURIComponent(sqHotspot.key)}`;
-      await client.addHotspotComment(scHotspot.key, `[SonarQube Source] Original hotspot: ${sqUrl}`);
+      const text = buildHotspotSourceComment(options.sonarqubeUrl, options.sonarqubeProjectKey, sqHotspot.key);
+      await client.addHotspotComment(scHotspot.key, text);
       stats.sourceLinked++;
     } catch (e) { logger.debug(`Failed to add source link to hotspot ${scHotspot.key}: ${e.message}`); }
   }

--- a/src/pipelines/sq-9.9/sonarcloud/migrators/hotspot-sync/helpers/sync-hotspots.js
+++ b/src/pipelines/sq-9.9/sonarcloud/migrators/hotspot-sync/helpers/sync-hotspots.js
@@ -1,6 +1,7 @@
 import logger from '../../../../../../shared/utils/logger.js';
 import { mapConcurrent, createProgressLogger } from '../../../../../../shared/utils/concurrency.js';
 import { waitForScIndexing } from '../../../../../../shared/utils/issue-sync/wait-for-sc-indexing.js';
+import { resolveSourceBaseURL } from '../../../../../../shared/utils/source-link/resolve-source-base-url.js';
 import { matchHotspots } from './match-hotspots.js';
 import { syncHotspotStatus } from './sync-hotspot-status.js';
 import { syncHotspotComments } from './sync-hotspot-comments.js';
@@ -10,6 +11,10 @@ import { syncHotspotComments } from './sync-hotspot-comments.js';
 export async function syncHotspots(projectKey, sqHotspots, client, options = {}) {
   const concurrency = options.concurrency || 3;
   const stats = { matched: 0, statusChanged: 0, commented: 0, metadataSyncCommented: 0, sourceLinked: 0, failed: 0 };
+
+  if (options.sqClient && options.sonarqubeProjectKey) {
+    options.sonarqubeUrl = await resolveSourceBaseURL(options.sqClient);
+  }
 
   let scHotspots = await client.searchHotspots(projectKey);
   if (scHotspots.length === 0 && sqHotspots.length > 0) {

--- a/src/pipelines/sq-9.9/sonarcloud/migrators/issue-sync/helpers/sync-issue-comments-and-tags.js
+++ b/src/pipelines/sq-9.9/sonarcloud/migrators/issue-sync/helpers/sync-issue-comments-and-tags.js
@@ -1,4 +1,6 @@
 import logger from '../../../../../../shared/utils/logger.js';
+import { resolveSourceBaseURL } from '../../../../../../shared/utils/source-link/resolve-source-base-url.js';
+import { buildIssueSourceComment } from '../../../../../../shared/utils/source-link/build-source-comments.js';
 
 // -------- Sync Issue Comments, Tags, and Source Link --------
 
@@ -34,8 +36,9 @@ export async function syncIssueCommentsAndTags(scIssue, sqIssue, client, stats, 
   // Add source link comment
   if (sqClient?.baseURL && sqClient?.projectKey) {
     try {
-      const sqUrl = `${sqClient.baseURL}/project/issues?id=${encodeURIComponent(sqClient.projectKey)}&issues=${encodeURIComponent(sqIssue.key)}&open=${encodeURIComponent(sqIssue.key)}`;
-      await client.addIssueComment(scIssue.key, `[SonarQube Source] Original issue: ${sqUrl}`);
+      const baseURL = await resolveSourceBaseURL(sqClient);
+      const text = buildIssueSourceComment(baseURL, sqClient.projectKey, sqIssue.key);
+      await client.addIssueComment(scIssue.key, text);
       stats.sourceLinked++;
     } catch (error) {
       logger.debug(`Failed to add source link comment to issue ${scIssue.key}: ${error.message}`);

--- a/src/pipelines/sq-9.9/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-hotspots.js
+++ b/src/pipelines/sq-9.9/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-hotspots.js
@@ -27,5 +27,6 @@ export async function fetchAndSyncHotspots(opts) {
     concurrency: syncConcurrency,
     sonarqubeUrl: sonarQubeClient.baseURL,
     sonarqubeProjectKey: sonarQubeClient.projectKey,
+    sqClient: sonarQubeClient,
   });
 }

--- a/src/shared/utils/concurrency/helpers/parallel-issue-sync.js
+++ b/src/shared/utils/concurrency/helpers/parallel-issue-sync.js
@@ -128,7 +128,8 @@ async function addSourceLink(sqIssue, scIssue, stats) {
   if (!sqConfig || !sqConfig.baseURL || !sqConfig.projectKey) return;
   try {
     const sqUrl = sqConfig.baseURL + '/project/issues?id=' + encodeURIComponent(sqConfig.projectKey) + '&issues=' + encodeURIComponent(sqIssue.key) + '&open=' + encodeURIComponent(sqIssue.key);
-    await scPost('/api/issues/add_comment', { issue: scIssue.key, text: '[SonarQube Source] Original issue: ' + sqUrl });
+    const text = 'Link to [Original issue](' + sqUrl + ')';
+    await scPost('/api/issues/add_comment', { issue: scIssue.key, text });
     stats.sourceLinked++;
   } catch { stats.apiErrors++; }
 }

--- a/src/shared/utils/source-link/build-source-comments.js
+++ b/src/shared/utils/source-link/build-source-comments.js
@@ -1,0 +1,16 @@
+/**
+ * Build the comment text linking back to a source SonarQube issue.
+ * Renders as: Link to Original issue (with URL hyperlink) in markdown-aware UIs.
+ */
+export function buildIssueSourceComment(baseURL, projectKey, issueKey) {
+  const url = `${baseURL}/project/issues?id=${encodeURIComponent(projectKey)}&issues=${encodeURIComponent(issueKey)}&open=${encodeURIComponent(issueKey)}`;
+  return `Link to [Original issue](${url})`;
+}
+
+/**
+ * Build the comment text linking back to a source SonarQube hotspot.
+ */
+export function buildHotspotSourceComment(baseURL, projectKey, hotspotKey) {
+  const url = `${baseURL}/security_hotspots?id=${encodeURIComponent(projectKey)}&hotspots=${encodeURIComponent(hotspotKey)}`;
+  return `Link to [Original hotspot](${url})`;
+}

--- a/src/shared/utils/source-link/resolve-source-base-url.js
+++ b/src/shared/utils/source-link/resolve-source-base-url.js
@@ -1,0 +1,36 @@
+import logger from '../logger.js';
+
+const SETTING_KEY = 'sonar.core.serverBaseURL';
+const CACHE_PROP = '_resolvedSourceBaseURL';
+
+/**
+ * Resolve the source SonarQube base URL to use when building links to source issues/hotspots.
+ *
+ * Prefers the value of the `sonar.core.serverBaseURL` server setting on the source SQS
+ * (e.g. https://sonar.example.com when the server is fronted by a reverse proxy or tunnel),
+ * falling back to the URL configured on the sqClient. The resolved value is cached on the
+ * client instance so repeated calls within a sync run only hit the API once.
+ *
+ * Returns the configured baseURL on any error or when the setting is unset/blank.
+ */
+export async function resolveSourceBaseURL(sqClient) {
+  if (!sqClient || !sqClient.baseURL) return null;
+  if (sqClient[CACHE_PROP]) return sqClient[CACHE_PROP];
+
+  let resolved = sqClient.baseURL;
+  if (typeof sqClient.getServerSettings === 'function') {
+    try {
+      const settings = await sqClient.getServerSettings();
+      const setting = (settings || []).find(s => s && s.key === SETTING_KEY);
+      const value = setting && (setting.value || (Array.isArray(setting.values) ? setting.values[0] : null));
+      if (value && typeof value === 'string' && value.trim()) {
+        resolved = value.trim().replace(/\/+$/, '');
+      }
+    } catch (error) {
+      logger.debug(`Failed to read ${SETTING_KEY} from source SonarQube, falling back to configured URL: ${error.message}`);
+    }
+  }
+
+  sqClient[CACHE_PROP] = resolved;
+  return resolved;
+}

--- a/test/utils/source-link.test.js
+++ b/test/utils/source-link.test.js
@@ -1,0 +1,112 @@
+import test from 'ava';
+import sinon from 'sinon';
+import { resolveSourceBaseURL } from '../../src/shared/utils/source-link/resolve-source-base-url.js';
+import { buildIssueSourceComment, buildHotspotSourceComment } from '../../src/shared/utils/source-link/build-source-comments.js';
+
+test.afterEach(() => sinon.restore());
+
+// ============================================================================
+// resolveSourceBaseURL
+// ============================================================================
+
+test('resolveSourceBaseURL prefers sonar.core.serverBaseURL when set', async t => {
+  const sqClient = {
+    baseURL: 'http://localhost:9000',
+    getServerSettings: sinon.stub().resolves([
+      { key: 'sonar.core.id', value: 'abc' },
+      { key: 'sonar.core.serverBaseURL', value: 'https://sonar.example.com' },
+    ]),
+  };
+  const url = await resolveSourceBaseURL(sqClient);
+  t.is(url, 'https://sonar.example.com');
+});
+
+test('resolveSourceBaseURL strips trailing slashes from setting value', async t => {
+  const sqClient = {
+    baseURL: 'http://localhost:9000',
+    getServerSettings: sinon.stub().resolves([
+      { key: 'sonar.core.serverBaseURL', value: 'https://sonar.example.com/' },
+    ]),
+  };
+  const url = await resolveSourceBaseURL(sqClient);
+  t.is(url, 'https://sonar.example.com');
+});
+
+test('resolveSourceBaseURL falls back to sqClient.baseURL when setting unset', async t => {
+  const sqClient = {
+    baseURL: 'http://localhost:9000',
+    getServerSettings: sinon.stub().resolves([{ key: 'sonar.core.id', value: 'abc' }]),
+  };
+  const url = await resolveSourceBaseURL(sqClient);
+  t.is(url, 'http://localhost:9000');
+});
+
+test('resolveSourceBaseURL falls back when setting has empty value', async t => {
+  const sqClient = {
+    baseURL: 'http://localhost:9000',
+    getServerSettings: sinon.stub().resolves([{ key: 'sonar.core.serverBaseURL', value: '   ' }]),
+  };
+  const url = await resolveSourceBaseURL(sqClient);
+  t.is(url, 'http://localhost:9000');
+});
+
+test('resolveSourceBaseURL falls back when getServerSettings throws', async t => {
+  const sqClient = {
+    baseURL: 'http://localhost:9000',
+    getServerSettings: sinon.stub().rejects(new Error('forbidden')),
+  };
+  const url = await resolveSourceBaseURL(sqClient);
+  t.is(url, 'http://localhost:9000');
+});
+
+test('resolveSourceBaseURL caches the resolved value', async t => {
+  const stub = sinon.stub().resolves([{ key: 'sonar.core.serverBaseURL', value: 'https://cached.example.com' }]);
+  const sqClient = { baseURL: 'http://localhost:9000', getServerSettings: stub };
+  const first = await resolveSourceBaseURL(sqClient);
+  const second = await resolveSourceBaseURL(sqClient);
+  t.is(first, 'https://cached.example.com');
+  t.is(second, 'https://cached.example.com');
+  t.is(stub.callCount, 1);
+});
+
+test('resolveSourceBaseURL returns null for falsy client', async t => {
+  t.is(await resolveSourceBaseURL(null), null);
+  t.is(await resolveSourceBaseURL(undefined), null);
+  t.is(await resolveSourceBaseURL({}), null);
+});
+
+test('resolveSourceBaseURL handles client without getServerSettings', async t => {
+  const url = await resolveSourceBaseURL({ baseURL: 'http://localhost:9000' });
+  t.is(url, 'http://localhost:9000');
+});
+
+// ============================================================================
+// buildIssueSourceComment
+// ============================================================================
+
+test('buildIssueSourceComment builds markdown comment with link', t => {
+  const text = buildIssueSourceComment('https://sonar.example.com', 'proj-key', 'issue-uuid');
+  t.is(
+    text,
+    'Link to [Original issue](https://sonar.example.com/project/issues?id=proj-key&issues=issue-uuid&open=issue-uuid)',
+  );
+});
+
+test('buildIssueSourceComment URL-encodes project and issue keys', t => {
+  const text = buildIssueSourceComment('https://sonar.example.com', 'group:proj', 'AY/key+1');
+  t.true(text.includes('id=group%3Aproj'));
+  t.true(text.includes('issues=AY%2Fkey%2B1'));
+  t.true(text.includes('open=AY%2Fkey%2B1'));
+});
+
+// ============================================================================
+// buildHotspotSourceComment
+// ============================================================================
+
+test('buildHotspotSourceComment builds markdown comment with link', t => {
+  const text = buildHotspotSourceComment('https://sonar.example.com', 'proj-key', 'hotspot-uuid');
+  t.is(
+    text,
+    'Link to [Original hotspot](https://sonar.example.com/security_hotspots?id=proj-key&hotspots=hotspot-uuid)',
+  );
+});


### PR DESCRIPTION
## Summary

Closes #134.

When migrating issues and hotspots, the comment linking back to the source SonarQube Server is now built from the source server's `sonar.core.serverBaseURL` setting (when set), falling back to the URL configured in the cloudvoyager config or the Desktop UI. This matches what users see in SQS itself when the server is fronted by a reverse proxy or tunnel.

The comment text is also shortened to a markdown link:
- Before: `[SonarQube Source] Original issue: http://localhost:10000/project/issues?...`
- After: `Link to [Original issue](https://latest.olivierk.ngrok.io/project/issues?...)`

## Implementation

- New shared helpers under `src/shared/utils/source-link/`:
  - `resolve-source-base-url.js` — fetches `sonar.core.serverBaseURL` via the existing `getServerSettings()` API, caches per-client, falls back to `sqClient.baseURL` on unset / blank / API failure.
  - `build-source-comments.js` — builds the markdown comment for issues and hotspots.
- Wired into all 4 pipeline versions (sq-9.9, sq-10.0, sq-10.4, sq-2025), for both issue-sync and hotspot-sync.
- For hotspots, resolution happens once at the `syncHotspots` entry; existing call sites pass `sqClient` through options.
- For the parallel issue-sync worker, the URL is resolved in the parent before workers spawn — workers don't make extra API calls.

## Test plan

- [x] 11 new unit tests in `test/utils/source-link.test.js` covering the resolver (cache, fallback paths, error handling) and the comment builders (markdown shape, URL encoding).
- [x] Full suite has identical pass/fail count to `main` (no regressions; the 71 pre-existing failures are unrelated to this change).
- [ ] Regression test against a live SQS with `sonar.core.serverBaseURL` set, per `docs/regression-testing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches issue/hotspot migration flows across multiple pipeline versions and adds an extra SonarQube settings API read (with caching), which could affect sync behavior if URL resolution fails or differs from configured base URLs.
> 
> **Overview**
> Source-link comments added during issue/hotspot migration now use the SonarQube server’s configured `sonar.core.serverBaseURL` (fallback to client `baseURL`) and are rendered as a shorter markdown hyperlink.
> 
> This introduces shared helpers (`resolveSourceBaseURL`, `buildIssueSourceComment`, `buildHotspotSourceComment`), wires `sqClient` through hotspot sync entrypoints to resolve the URL once per run, and updates the parallel issue-sync worker to emit the new comment format using a pre-resolved base URL. Adds unit tests covering URL resolution (fallbacks/caching) and comment building/encoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f8e53ef80163df0b765d4519e19c38fa434d5d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->