### PR TITLE
docs: document IN_SANDBOX → OPEN limitation (Issue #136), README polish, SonarQube/Cloud rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Migrate your data from self-hosted SonarQube Server to SonarQube Cloud — no re
 
 CloudVoyager migrates everything — projects, code issues, security hotspots, quality gates, quality profiles, permissions, and more — directly from SonarQube Server to SonarQube Cloud. It is available as both a CLI tool and a Desktop app with a guided wizard interface.
 
-CloudVoyager is compatible with all SonarQube Server versions starting from 9.9.x, i.e. 9.9.x, 2025.1.x, 2025.4.x, 2026.1.x and the latest version (2026.2 as of April 2026). Intermediate SonarQube version may work but this is not guaranteed.
+CloudVoyager is compatible with all SonarQube Server versions starting from 9.9.x, i.e. 9.9.x, 2025.1.x, 2025.4.x, 2026.1.x and the latest version (2026.2 as of April 2026). Intermediate SonarQube Server version may work but this is not guaranteed.
 
 <!-- Updated: 2026-02-19 -->
 ## ✅ Quick Start (Recommended)
@@ -15,9 +15,9 @@ CloudVoyager is compatible with all SonarQube Server versions starting from 9.9.
 
 | 🤔 Scenario | Click Below ⤵️ |
 |----------|-------|
-| Migrate **one project** from SonarQube to SonarCloud | [Single Project Migration](docs/scenario-single-project.md) |
-| Migrate **everything** from SonarQube to **one** SonarCloud org | [Full Migration — Single Org](docs/scenario-single-org.md) |
-| Migrate **everything** from SonarQube to **multiple** SonarCloud orgs | [Full Migration — Multiple Orgs](docs/scenario-multi-org.md) |
+| Migrate **one project** from SonarQube Server to SonarQube Cloud | [Single Project Migration](docs/scenario-single-project.md) |
+| Migrate **everything** from SonarQube Server to **one** SonarQube Cloud org | [Full Migration — Single Org](docs/scenario-single-org.md) |
+| Migrate **everything** from SonarQube Server to **multiple** SonarQube Cloud orgs | [Full Migration — Multiple Orgs](docs/scenario-multi-org.md) |
 
 ## 🖥️ Desktop App (New!)
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -65,7 +65,7 @@ See the [Desktop App Guide](docs/desktop-app.md) for setup instructions and a wa
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
 1. Download the latest release of CloudVoyager from the [releases page](https://github.com/sonar-solutions/cloudvoyager/releases).
-2. Ensure that you have full admin access API tokens for your SonarQube server and your SonarCloud organization.
+2. Ensure that you have full admin access API tokens for your SonarQube Server and your SonarQube Cloud organization.
 3. Create the `migrate-config.json` file with the required information (see the [full migration docs](docs/scenario-single-org.md) for details).
 4. Run the following command in your terminal:
 ```bash
@@ -95,7 +95,7 @@ A **lock file** prevents concurrent runs against the same project, so you cannot
 # Discard checkpoint and start the migration from scratch
 ./cloudvoyager transfer -c config.json --force-restart
 
-# Re-extract data from SonarQube but keep other cached phases
+# Re-extract data from SonarQube Server but keep other cached phases
 ./cloudvoyager transfer -c config.json --force-fresh-extract
 
 # Clear a stale lock file (e.g. after a hard crash)
@@ -105,19 +105,19 @@ A **lock file** prevents concurrent runs against the same project, so you cannot
 See the [Configuration Reference](docs/configuration.md#checkpoint-settings) for checkpoint options (`transfer.checkpoint`).
 
 <!-- Updated: 2026-03-19 -->
-## 🔄 SonarQube Version Compatibility
+## 🔄 SonarQube Server Version Compatibility
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-CloudVoyager ships **four fully independent pipelines** — one per SonarQube version range. At runtime, `version-router.js` calls `/api/system/status`, detects the server version, and dynamically loads the matching pipeline. No special configuration is needed.
+CloudVoyager ships **four fully independent pipelines** — one per SonarQube Server version range. At runtime, `version-router.js` calls `/api/system/status`, detects the server version, and dynamically loads the matching pipeline. No special configuration is needed.
 
-| SonarQube Version | Pipeline | Issue Search Param | MetricKeys | Clean Code Source | Groups API |
+| SonarQube Server Version | Pipeline | Issue Search Param | MetricKeys | Clean Code Source | Groups API |
 |-------------------|----------|-------------------|------------|-------------------|------------|
 | **9.9 LTS** | `sq-9.9` | `statuses` | Batched (15) | SC enrichment map | Standard |
 | **10.0 – 10.3** | `sq-10.0` | `statuses` | Batched (15) | Native from SQ | Standard |
 | **10.4 – 10.8** | `sq-10.4` | `issueStatuses` | Batched (15) | Native from SQ | Standard |
 | **2025.1+** | `sq-2025` | `issueStatuses` | No batching | Native from SQ | Web API V2 fallback |
 
-Each pipeline folder (`src/pipelines/sq-*`) contains its own SonarQube client, SonarCloud client, protobuf builder, and transfer/migrate logic — no runtime version checks or `if/else` branches.
+Each pipeline folder (`src/pipelines/sq-*`) contains its own SonarQube Server client, SonarQube Cloud client, protobuf builder, and transfer/migrate logic — no runtime version checks or `if/else` branches.
 
 See [Backward Compatibility](docs/backward-compatibility.md) for technical details on how version differences are handled.
 
@@ -154,7 +154,7 @@ Want to build and test CloudVoyager locally? See the [Local Development Guide](d
 | [Technical Details](docs/technical-details.md) | Protobuf encoding, measure types, concurrency model |
 | [Troubleshooting](docs/troubleshooting.md) | Common errors and how to fix them |
 | [Dry-Run CSV Reference](docs/dry-run-csv-reference.md) | CSV schema documentation for the dry-run workflow (including user mapping) |
-| [Backward Compatibility](docs/backward-compatibility.md) | SonarQube version support (9.9 LTS through 2025.1+) |
+| [Backward Compatibility](docs/backward-compatibility.md) | SonarQube Server version support (9.9 LTS through 2025.1+) |
 | [Desktop App Guide](docs/desktop-app.md) | Installation, wizard walkthrough, and building from source |
 | [Verification](docs/verification.md) | Migration verification checks, pass/fail criteria, and report formats |
 | [Pseudocode Explanation](docs/pseudocode-explanation.md) | Every feature documented in pseudocode for technical review |

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # ☁️ 🐋 CloudVoyager
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Migrate your data from self-hosted SonarQube to SonarCloud — no re-scanning needed. This was done by reverse-engineering SonarScanner (scan report protobuf files) & then fully rebuilding everything from the ground up on Node.js.
+Migrate your data from self-hosted SonarQube Server to SonarQube Cloud — no re-scanning needed.
 
-CloudVoyager copies everything — projects, code issues, security hotspots, quality gates, quality profiles, permissions, and more — directly from SonarQube into SonarCloud. It is available as both a CLI tool and a Desktop app with a guided wizard interface.
+CloudVoyager migrates everything — projects, code issues, security hotspots, quality gates, quality profiles, permissions, and more — directly from SonarQube Server to SonarQube Cloud. It is available as both a CLI tool and a Desktop app with a guided wizard interface.
+
+CloudVoyager is compatible with all SonarQube Server versions starting from 9.9.x, i.e. 9.9.x, 2025.1.x, 2025.4.x, 2026.1.x and the latest version (2026.2 as of April 2026). Intermediate SonarQube version may work but this is not guaranteed.
 
 <!-- Updated: 2026-02-19 -->
 ## ✅ Quick Start (Recommended)

--- a/docs/Audit & Error Events Logging Strategy.md
+++ b/docs/Audit & Error Events Logging Strategy.md
@@ -187,7 +187,7 @@ With stack traces appended for errors:
 **Error with stack trace:**
 ```
 2026-05-07 01:15:00 [error]: Project JIRA-456 FAILED
-Error: SonarQube API error
+Error: SonarQube Server API error
     at SonarQubeClient.request (/src/sonarqube/api-client.js:45:12)
     at async migrateOneProjectCore (/src/pipelines/sq-2025/pipeline/project-core-migrator/helpers/migrate-one-project-core.js:67:20)
 ```
@@ -225,8 +225,8 @@ CloudVoyagerError (base)
 ├── ConfigurationError          <- Invalid configuration values
 ├── ValidationError             <- Input validation failures
 ├── StateError                  <- Invalid state transitions
-├── SonarQubeAPIError           <- SonarQube API failures
-├── SonarCloudAPIError           <- SonarCloud API failures
+├── SonarQubeAPIError           <- SonarQube Server API failures
+├── SonarCloudAPIError           <- SonarQube Cloud API failures
 ├── AuthenticationError          <- Auth/credential failures
 ├── ProtobufEncodingError       <- Protobuf serialization errors
 ├── GracefulShutdownError       <- Controlled shutdown signal

--- a/docs/Business Value.md
+++ b/docs/Business Value.md
@@ -2,7 +2,7 @@
 
 <!-- Last updated: 2026-05-07 -->
 
-CloudVoyager delivers a complete SonarQube-to-SonarCloud migration without requiring a single line of code to be re-scanned. By reverse-engineering SonarScanner's internal protobuf report protocol, CloudVoyager extracts all data directly from SonarQube's API and repackages it into the exact binary format that SonarCloud's Compute Engine expects.
+CloudVoyager delivers a complete SonarQube Server-to-SonarQube Cloud migration without requiring a single line of code to be re-scanned. By reverse-engineering SonarScanner's internal protobuf report protocol, CloudVoyager extracts all data directly from SonarQube Server's API and repackages it into the exact binary format that SonarQube Cloud's Compute Engine expects.
 
 ---
 
@@ -19,14 +19,14 @@ Traditional migration approaches require re-running CI/CD scanners against every
 - **Days to weeks of pipeline execution** — Each scan must complete in sequence or with limited parallelism, constrained by CI/CD runner availability
 - **Developer interruption** — Teams must update branch configurations, trigger manual pipelines, and monitor for failures
 - **Locked CI/CD resources** — Build agents are occupied running scans instead of their normal development work
-- **Extended validation cycles** — Each re-scan potentially surfaces new issues that did not exist in the original SonarQube, requiring investigation
+- **Extended validation cycles** — Each re-scan potentially surfaces new issues that did not exist in the original SonarQube Server, requiring investigation
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ### CloudVoyager Eliminates This Entirely
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-CloudVoyager connects directly to your existing SonarQube server via API, extracts all project data, and uploads it to SonarCloud as a legitimate scanner submission — without touching your source code or CI/CD pipelines.
+CloudVoyager connects directly to your existing SonarQube Server via API, extracts all project data, and uploads it to SonarQube Cloud as a legitimate scanner submission — without touching your source code or CI/CD pipelines.
 
 **Real-world example from production use:**
 
@@ -48,7 +48,7 @@ This same migration via re-scanning would have taken days,占用 significant CI/
 - **No CI/CD disruption** — Migration runs in the background while your pipelines continue normal operations
 - **No coordination required** — Individual development teams do not need to take any action
 - **Predictable timeline** — A 50-project portfolio migrates in hours, not weeks
-- **Zero re-scan risk** — Code that passed SonarQube analysis arrives in SonarCloud with the same issue status, not potentially different results from a re-run
+- **Zero re-scan risk** — Code that passed SonarQube Server analysis arrives in SonarQube Cloud with the same issue status, not potentially different results from a re-run
 
 ---
 
@@ -60,7 +60,7 @@ This same migration via re-scanning would have taken days,占用 significant CI/
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-CloudVoyager migrates every category of data that SonarQube tracks:
+CloudVoyager migrates every category of data that SonarQube Server tracks:
 
 | Category | Data Preserved |
 |----------|---------------|
@@ -76,12 +76,12 @@ CloudVoyager migrates every category of data that SonarQube tracks:
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Each issue carries its complete lifecycle history from SonarQube:
+Each issue carries its complete lifecycle history from SonarQube Server:
 
-- **Original creation date** — Preserved via SCM date backdating, so SonarCloud shows the same temporal distribution as SonarQube
+- **Original creation date** — Preserved via SCM date backdating, so SonarQube Cloud shows the same temporal distribution as SonarQube Server
 - **Status transitions** — Confirmed, False Positive, Accepted, Won't Fix, Resolved, Reopened states all synced
-- **Assignments** — Issues assigned to specific users transfer to the corresponding SonarCloud user
-- **Comments** — Full comment history preserved with `[Migrated from SonarQube]` attribution
+- **Assignments** — Issues assigned to specific users transfer to the corresponding SonarQube Cloud user
+- **Comments** — Full comment history preserved with `[Migrated from SonarQube Server]` attribution
 - **Tags** — Custom categorization labels maintained
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -89,7 +89,7 @@ Each issue carries its complete lifecycle history from SonarQube:
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-CloudVoyager preserves each issue's original SonarQube creation date by backdating SCM changeset blame dates in the protobuf report. Issues appear in SonarCloud with the same creation timestamp they had in SonarQube, maintaining the historical distribution in the creation date facet.
+CloudVoyager preserves each issue's original SonarQube Server creation date by backdating SCM changeset blame dates in the protobuf report. Issues appear in SonarQube Cloud with the same creation timestamp they had in SonarQube Server, maintaining the historical distribution in the creation date facet.
 
 For calendar days with more than 5,000 issues, CloudVoyager automatically splits into sub-groups with 1-day-spaced synthetic dates to prevent clustering, ensuring a realistic distribution across the project's history.
 
@@ -108,7 +108,7 @@ For calendar days with more than 5,000 issues, CloudVoyager automatically splits
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Before any data touches SonarCloud, run the migration in dry-run mode:
+Before any data touches SonarQube Cloud, run the migration in dry-run mode:
 
 ```bash
 cloudvoyager migrate -c migrate-config.json --dry-run
@@ -116,9 +116,9 @@ cloudvoyager migrate -c migrate-config.json --dry-run
 
 This extracts all data and generates 9 CSV mapping files for review. You can:
 
-- Verify which projects map to which SonarCloud organizations
+- Verify which projects map to which SonarQube Cloud organizations
 - Exclude specific projects or branches from migration
-- Map SonarQube users to SonarCloud users before migration
+- Map SonarQube Server users to SonarQube Cloud users before migration
 - Review quality gate and profile assignments
 
 Only after reviewing the generated CSVs do you proceed to the actual migration.
@@ -134,20 +134,20 @@ The checkpoint journal tracks:
 - Per-organization completion status
 - Per-project progress across 11 migration phases
 - Upload deduplication via CE task ID verification (prevents re-uploading completed analyses)
-- Session fingerprint validation (warns on SonarQube version changes between runs)
+- Session fingerprint validation (warns on SonarQube Server version changes between runs)
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 #### Layer 3: Post-Migration Verification
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-After migration completes, the verification pipeline runs **58+ automated checks** comparing SonarQube against SonarCloud:
+After migration completes, the verification pipeline runs **58+ automated checks** comparing SonarQube Server against SonarQube Cloud:
 
 | Verification Area | Checks Performed |
 |-------------------|-----------------|
 | **Issues** | Count parity, status matching, status history (changelog sequence), assignments, comments, tags |
 | **Hotspots** | Count parity, status matching (Safe, Acknowledged, Fixed, To Review), comments |
-| **Branches** | All SonarQube branches exist in SonarCloud |
+| **Branches** | All SonarQube Server branches exist in SonarQube Cloud |
 | **Measures** | 18 key metrics compared (ncloc, complexity, coverage, violations, etc.) |
 | **Quality Gates** | Existence, condition definitions, project assignments |
 | **Quality Profiles** | Existence, active rule counts, project assignments |
@@ -230,7 +230,7 @@ This parallelism means CloudVoyager fully utilizes available resources without r
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Moving to SonarCloud should not mean rebuilding your entire quality governance framework from scratch. CloudVoyager migrates every governance artifact:
+Moving to SonarQube Cloud should not mean rebuilding your entire quality governance framework from scratch. CloudVoyager migrates every governance artifact:
 
 | Governance Element | What Gets Migrated |
 |-------------------|-------------------|
@@ -252,29 +252,29 @@ Quality gates are recreated with their exact condition logic:
 - **Metric + operator + threshold** preserved for every condition
 - **Gate permissions** migrated for custom gates
 - **Project assignments** applied per organization mapping
-- Built-in gates (Sonar way) use SonarCloud's default since they are platform-managed
+- Built-in gates (Sonar way) use SonarQube Cloud's default since they are platform-managed
 
-This means your existing quality standards continue uninterrupted — projects that passed SonarQube's gate pass SonarCloud's gate with the same criteria.
+This means your existing quality standards continue uninterrupted — projects that passed SonarQube Server's gate pass SonarQube Cloud's gate with the same criteria.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ### Quality Profile Fidelity
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Quality profiles use SonarQube's native backup/restore XML format, preserving:
+Quality profiles use SonarQube Server's native backup/restore XML format, preserving:
 
 - **All rule activations and deactivations**
 - **Severity overrides** for individual rules
 - **Rule parameter values** (for rules with configurable parameters)
 - **Inheritance chains** — profiles restored in dependency order so parent profiles exist before children
 
-**Built-in profile handling** is handled specially. SonarCloud's built-in profiles cannot be overwritten, so CloudVoyager extracts the built-in profile's rules from SonarQube and creates a custom profile with a `(SonarQube Migrated)` suffix. This ensures the exact same rules are active in SonarCloud as they were in SonarQube.
+**Built-in profile handling** is handled specially. SonarQube Cloud's built-in profiles cannot be overwritten, so CloudVoyager extracts the built-in profile's rules from SonarQube Server and creates a custom profile with a `(SonarQube Server Migrated)` suffix. This ensures the exact same rules are active in SonarQube Cloud as they were in SonarQube Server.
 
 **Quality profile diff reports** are generated after migration, showing:
-- **Missing rules** — Active in SonarQube but not available in SonarCloud
-- **Added rules** — Available in SonarCloud but not in SonarQube
+- **Missing rules** — Active in SonarQube Server but not available in SonarQube Cloud
+- **Added rules** — Available in SonarQube Cloud but not in SonarQube Server
 
-This enables governance teams to review rule parity before cutting over to SonarCloud.
+This enables governance teams to review rule parity before cutting over to SonarQube Cloud.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ### Project Settings and Bindings
@@ -290,7 +290,7 @@ Per-project configuration that transfers includes:
 - **DevOps bindings** (GitHub, GitLab, Azure DevOps, Bitbucket) for pull request decoration and automatic branch analysis
 - **Non-inherited project-level settings**
 
-This ensures each project arrives in SonarCloud fully configured and ready for your development teams to use immediately.
+This ensures each project arrives in SonarQube Cloud fully configured and ready for your development teams to use immediately.
 
 ---
 
@@ -307,7 +307,7 @@ CloudVoyager's business value is straightforward:
 | **Cost Efficiency** | No CI/CD runner consumption, no developer coordination overhead |
 | **Governance Continuity** | Quality gates, profiles, permissions, groups, and templates maintained across the migration |
 
-CloudVoyager is purpose-built for enterprises that need to migrate to SonarCloud without disrupting development teams, sacrificing historical data, or rebuilding governance configuration from scratch.
+CloudVoyager is purpose-built for enterprises that need to migrate to SonarQube Cloud without disrupting development teams, sacrificing historical data, or rebuilding governance configuration from scratch.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 **Root causes identified and fixed:**
 
-1. **POST body format + Content-Type** — Settings were sent as URL query parameters (`/api/settings/set?key=...&values=...`) with a `null` body and `Content-Type: application/json` (from axios defaults). Changed to send parameters as a form-encoded POST body string with an explicit `Content-Type: application/x-www-form-urlencoded` header, which is the correct format for SonarQube/SonarCloud web API POST endpoints. The explicit header is required because the axios client's default `Content-Type: application/json` would not be overridden by auto-detection (axios uses `rewrite=false` for URLSearchParams).
+1. **POST body format + Content-Type** — Settings were sent as URL query parameters (`/api/settings/set?key=...&values=...`) with a `null` body and `Content-Type: application/json` (from axios defaults). Changed to send parameters as a form-encoded POST body string with an explicit `Content-Type: application/x-www-form-urlencoded` header, which is the correct format for SonarQube Server/SonarQube Cloud web API POST endpoints. The explicit header is required because the axios client's default `Content-Type: application/json` would not be overridden by auto-detection (axios uses `rewrite=false` for URLSearchParams).
 
 2. **Truthy check bug in `dispatchSettingToApi`** — Used `if (setting.value)` which is a JavaScript truthy check. This silently skipped settings with empty string values (`value: ""`). Changed to `if (setting.value !== undefined && setting.value !== null)` for correctness.
 
@@ -40,7 +40,7 @@
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> to dramatically reduce wall-clock time for large projects (e.g., Angular Framework with 31,622 issues — from ~90 minutes to ~5-10 minutes).
 
-**Problem:** Issue sync was bottlenecked on SonarCloud API response times. A single Node.js process with `mapConcurrent` at concurrency=20 couldn't push past 20 concurrent HTTP requests, and the single event loop serialized callback processing.
+**Problem:** Issue sync was bottlenecked on SonarQube Cloud API response times. A single Node.js process with `mapConcurrent` at concurrency=20 couldn't push past 20 concurrent HTTP requests, and the single event loop serialized callback processing.
 
 **Solution:** For projects with ≥500 matched pairs, spawn N worker threads (default 20) using `worker_threads` with `eval: true` (SEA-compatible — no file system access needed). Each worker runs self-contained inline code using only Node.js built-in `https`/`http` modules, with an internal concurrency pool of 5 issues each. Total concurrent API calls: 20×5 = 100 (vs 20 previously).
 
@@ -60,7 +60,7 @@
 
 ## Accurate Issue Creation Date Backdating (2026-04-28)
 
-<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> to preserve each issue's original SonarQube creation date in SonarCloud. Verified 99.92% accuracy (26/31,641 mismatches on Angular Framework — all from issues sharing the same startLine).
+<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> to preserve each issue's original SonarQube Server creation date in SonarQube Cloud. Verified 99.92% accuracy (26/31,641 mismatches on Angular Framework — all from issues sharing the same startLine).
 
 **Root cause found:** `resolveLineCount()` defaulted to 1 when the `lines` metric wasn't available, causing `changesetIndexByLine` arrays to be 1 element long. Per-line date indices beyond index 0 were silently dropped, so the CE assigned a single date per file. The fix extends the array to `max(existingLength, maxIssueLine)`.
 
@@ -85,9 +85,9 @@
 
 ## Regression Testing System — Phase 1 (2026-04-25)
 
-<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> for CloudVoyager. 5 bug-fix scenarios tested across all 4 SonarQube versions (9.9, 10.0, 10.4, 2025.1) = 20 matrix jobs.
+<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> for CloudVoyager. 5 bug-fix scenarios tested across all 4 SonarQube Server versions (9.9, 10.0, 10.4, 2025.1) = 20 matrix jobs.
 
-**Architecture:** Each CI job spins up an ephemeral SonarQube Enterprise Docker container with PostgreSQL. Test data is enriched with issue comments, status changes, and hotspot metadata via SQ API. CloudVoyager runs the migration to SonarCloud, then assertion scripts verify each previously-fixed bug hasn't regressed.
+**Architecture:** Each CI job spins up an ephemeral SonarQube Server Enterprise Docker container with PostgreSQL. Test data is enriched with issue comments, status changes, and hotspot metadata via SQ API. CloudVoyager runs the migration to SonarQube Cloud, then assertion scripts verify each previously-fixed bug hasn't regressed.
 
 **Phase 1 scenarios:**
 
@@ -99,7 +99,7 @@
 | `issue-sync-first-migration` | #91 | Issue sync triggers on first migration run |
 | `kill-and-continue` | #15, #57 | SIGTERM + resume produces no duplicates |
 
-**Security:** Sensitive workflows (regression tests + SonarCloud scanning) moved to private repo `sonar-solutions/cloudvoyager-ci`. Public repo has no access to SQ Enterprise license keys or SonarCloud tokens. Private repo syncs from public every 15 minutes.
+**Security:** Sensitive workflows (regression tests + SonarQube Cloud scanning) moved to private repo `sonar-solutions/cloudvoyager-ci`. Public repo has no access to SQ Enterprise license keys or SonarQube Cloud tokens. Private repo syncs from public every 15 minutes.
 
 **Code review:** 5 parallel AI review agents found 10 P1s, 8 P2s, 4 P3s — all fixed before commit.
 
@@ -111,9 +111,9 @@
 
 ## Bug Fix: Issue Migration Data Loss + SCM Date-Bucket Distribution (2026-04-23)
 
-<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> and implemented SCM-based date-bucket distribution to work around SonarCloud's 10K Elasticsearch visualization cap.
+<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> and implemented SCM-based date-bucket distribution to work around SonarQube Cloud's 10K Elasticsearch visualization cap.
 
-**Bug 1 — Batch distributor silently drops issues (critical):** The old batch distributor split large issue sets into separate 5K-batch analyses. SonarCloud's issue tracker treats each analysis as a complete snapshot — issues from prior analyses not in the current one are closed. Only the last batch's issues survived. **Fix:** Disabled multi-analysis batching. All issues now upload in a single analysis.
+**Bug 1 — Batch distributor silently drops issues (critical):** The old batch distributor split large issue sets into separate 5K-batch analyses. SonarQube Cloud's issue tracker treats each analysis as a complete snapshot — issues from prior analyses not in the current one are closed. Only the last batch's issues survived. **Fix:** Disabled multi-analysis batching. All issues now upload in a single analysis.
 
 **Bug 2 — Missing IN_SANDBOX status in SQ 2025 pipeline:** The `issueStatuses` parameter was missing `IN_SANDBOX` (new in SQ 2025) and incorrectly included `CLOSED`. Fixed in both `issue-methods.js` and `issues-hotspots.js`.
 
@@ -143,7 +143,7 @@
 
 ## Design: Matrix-Based Regression Testing (2026-04-22)
 
-<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> for comprehensive regression testing via GitHub Actions matrix strategy. Covers 19 matrix entries mapping to all fixed issues (PRIORITY bugs #53, #56, #70, #88, #89, #91, #94, #98 plus changelog fixes and non-PRIORITY issues). Phased rollout: 5 PRIORITY entries in Phase 1 (2 days), remaining 14 in Phase 2 (3 more days). Tests run against real SonarQube/SonarCloud instances with `max-parallel: 4`. Includes test data health check, cleanup policy, and rate limiting mitigation. Design doc: `~/.gstack/projects/sonar-solutions-cloudvoyager/joshua.quek-main-design-20260422-184500.md`
+<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> for comprehensive regression testing via GitHub Actions matrix strategy. Covers 19 matrix entries mapping to all fixed issues (PRIORITY bugs #53, #56, #70, #88, #89, #91, #94, #98 plus changelog fixes and non-PRIORITY issues). Phased rollout: 5 PRIORITY entries in Phase 1 (2 days), remaining 14 in Phase 2 (3 more days). Tests run against real SonarQube Server/SonarQube Cloud instances with `max-parallel: 4`. Includes test data health check, cleanup policy, and rate limiting mitigation. Design doc: `~/.gstack/projects/sonar-solutions-cloudvoyager/joshua.quek-main-design-20260422-184500.md`
 
 ---
 
@@ -155,7 +155,7 @@
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 
-On resume, the checkpoint extractor restores the cached `scmRevisionId` from the first run. If SonarCloud already processed a newer report (e.g. from a previous partial migration), the CE task fails with "a newer report has already been processed" and the entire project is marked failed. This is incorrect — the project already has analysis data on SonarCloud.
+On resume, the checkpoint extractor restores the cached `scmRevisionId` from the first run. If SonarQube Cloud already processed a newer report (e.g. from a previous partial migration), the CE task fails with "a newer report has already been processed" and the entire project is marked failed. This is incorrect — the project already has analysis data on SonarQube Cloud.
 
 **Fix:** In `waitForAnalysis()`, detect the "a newer report has already been processed" error message and treat it as a success (log a warning instead of throwing). Applied to all 4 pipelines.
 
@@ -189,7 +189,7 @@ Re-ran migration after fixes: **3/3 projects succeeded, 0 failed, 0 errors in er
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 
-`addHotspotComment()` sent `{ hotspot, text }` to `/api/hotspots/add_comment`, but SonarCloud expects the parameter name `comment`, not `text`. Every hotspot comment/source-link/metadata-marker call returned `400: The 'comment' parameter is missing`.
+`addHotspotComment()` sent `{ hotspot, text }` to `/api/hotspots/add_comment`, but SonarQube Cloud expects the parameter name `comment`, not `text`. Every hotspot comment/source-link/metadata-marker call returned `400: The 'comment' parameter is missing`.
 
 **Fix:** Changed `params: { hotspot, text }` to `params: { hotspot, comment: text }` in all 4 pipeline versions.
 
@@ -341,7 +341,7 @@ Previously, a fresh (non-resume) migration would `rm -rf` the entire `migration-
 
 ## Bug Fix: New Code Definitions Migration Fails with 400 Error (2026-04-22)
 
-<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> the "New code definitions" migration step failed with `SonarCloud API error (400): Either 'value', 'values' or 'fieldValues' must be provided`.
+<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> the "New code definitions" migration step failed with `SonarQube Cloud API error (400): Either 'value', 'values' or 'fieldValues' must be provided`.
 
 ### Root Cause
 
@@ -379,7 +379,7 @@ Changed the call to `client.setProjectSetting(setting.key, { value: setting.valu
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ## Issue Batching: Distribute Large Issue Sets Across Multiple Dates (2026-04-20)
 
-<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> per branch now automatically split into multiple scanner reports, each with a distinct `analysis_date`. This prevents SonarCloud's Elasticsearch visualization limit (10K per date bucket) from hiding migrated issues.
+<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> per branch now automatically split into multiple scanner reports, each with a distinct `analysis_date`. This prevents SonarQube Cloud's Elasticsearch visualization limit (10K per date bucket) from hiding migrated issues.
 
 ### New Feature
 
@@ -433,7 +433,7 @@ All changes are in `desktop/src/renderer/js/components/migration-graph*.js`.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 
-- **Root cause:** JavaScript's `Date.toISOString()` produces `2007-09-08T21:21:02.125Z` (includes milliseconds). SonarQube's `createdAfter`/`createdBefore` API parameters reject this format and require `2007-09-08T21:21:02+0000`.
+- **Root cause:** JavaScript's `Date.toISOString()` produces `2007-09-08T21:21:02.125Z` (includes milliseconds). SonarQube Server's `createdAfter`/`createdBefore` API parameters reject this format and require `2007-09-08T21:21:02+0000`.
 - **Fixed:** Added `format-sonarqube-date.js` helper that strips milliseconds and replaces `Z` with `+0000`. All date-window boundaries and midpoints now use this formatter.
 
 ### Bug 3 — Desktop app config validation failure (`/transfer must NOT have additional properties`)
@@ -449,7 +449,7 @@ All changes are in `desktop/src/renderer/js/components/migration-graph*.js`.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> a **Phase 2: Metadata Sync** that runs automatically after the scanner report upload completes.
 
-- **Added:** Issue metadata sync — replays full status history from SQ changelog, copies comments with attribution, adds `metadata-synchronized` tag, syncs assignments, and adds a `[SonarQube Source]` comment linking back to the original SQ issue URL.
+- **Added:** Issue metadata sync — replays full status history from SQ changelog, copies comments with attribution, adds `metadata-synchronized` tag, syncs assignments, and adds a `[SonarQube Server Source]` comment linking back to the original SQ issue URL.
 - **Added:** Hotspot metadata sync — syncs hotspot statuses, comments, and source links.
 - **Added:** `skipIssueMetadataSync` and `skipHotspotMetadataSync` options in transfer config to opt out.
 - **Impact:** All 4 pipeline versions (sq-9.9, sq-10.0, sq-10.4, sq-2025) now include metadata sync. Previously, the `transfer` command only uploaded the scanner report, leaving all issues in default "Open" status with no comments, tags, or assignments.
@@ -458,11 +458,11 @@ All changes are in `desktop/src/renderer/js/components/migration-graph*.js`.
 
 ## External Issue Prefix Fix (2026-03-27)
 
-<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> where **all external linter issues** (Ruff, Pylint, ESLint, Checkstyle, etc.) were silently dropped during migration from SonarQube 2025+.
+<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> where **all external linter issues** (Ruff, Pylint, ESLint, Checkstyle, etc.) were silently dropped during migration from SonarQube Server 2025+.
 
-- **Root cause:** SonarQube 2025+ returns external linter rules with an `external_` prefix (e.g., `external_ruff:D200`). SonarCloud's `/api/rules/repositories` includes `external_ruff` as a known repo, causing `isExternalIssue()` to misclassify these as native issues. SC then dropped them because no native rule `external_ruff:D200` exists.
+- **Root cause:** SonarQube Server 2025+ returns external linter rules with an `external_` prefix (e.g., `external_ruff:D200`). SonarQube Cloud's `/api/rules/repositories` includes `external_ruff` as a known repo, causing `isExternalIssue()` to misclassify these as native issues. SC then dropped them because no native rule `external_ruff:D200` exists.
 - **Fixed:** `isExternalIssue()` now detects the `external_` prefix and always treats such rules as external — across all 4 pipeline versions (sq-9.9, sq-10.0, sq-10.4, sq-2025).
-- **Fixed:** External issue builders now strip the `external_` prefix from the engineId via a new shared `stripExternalPrefix()` utility, preventing a double `external_external_ruff:D200` prefix in SonarCloud.
+- **Fixed:** External issue builders now strip the `external_` prefix from the engineId via a new shared `stripExternalPrefix()` utility, preventing a double `external_external_ruff:D200` prefix in SonarQube Cloud.
 - **Fixed:** sq-2025 issue model now preserves `externalRuleEngine` from SQ API responses.
 - **Impact:** Affected up to 36 external linter types. Tested with `okorach-oss_sonar-tools` project (1,101 Ruff+Pylint issues previously dropped, now migrated correctly).
 
@@ -481,7 +481,7 @@ All changes are in `desktop/src/renderer/js/components/migration-graph*.js`.
 
 ### Separate Unit Tests Workflow
 
-<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> a standalone workflow, decoupled from both SonarCloud scanning and regression tests.
+<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> a standalone workflow, decoupled from both SonarQube Cloud scanning and regression tests.
 
 - **New:** `.github/workflows/unit-tests.yml` — standalone unit test workflow triggered on push to `main`
 - **Changed:** `.github/workflows/sonarcloud.yml` — removed test coverage step; now only runs SAST/SCA scanning
@@ -502,9 +502,9 @@ All changes are in `desktop/src/renderer/js/components/migration-graph*.js`.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> identified 83 issues. The following 10 high/medium severity bugs were fixed across 26 files.
 
-- **Fixed:** Org-level verification was comparing SonarCloud to itself (passing `scClient` as both args to `runOrgChecks`). Now correctly constructs a `SonarQubeClient` for the SQ side.
+- **Fixed:** Org-level verification was comparing SonarQube Cloud to itself (passing `scClient` as both args to `runOrgChecks`). Now correctly constructs a `SonarQubeClient` for the SQ side.
 - **Fixed:** Missing `await` on `syncIssueAssignment()` in sq-10.0 pipeline caused silent error swallowing and stats race conditions.
-- **Fixed:** `ACCEPTED` status mapped to invalid `'accept'` transition in sq-9.9 and sq-10.0 pipelines (SonarCloud only supports `wontfix`). Now matches sq-10.4/sq-2025 correct mapping.
+- **Fixed:** `ACCEPTED` status mapped to invalid `'accept'` transition in sq-9.9 and sq-10.0 pipelines (SonarQube Cloud only supports `wontfix`). Now matches sq-10.4/sq-2025 correct mapping.
 - **Fixed:** `ShutdownCoordinator` created but never passed to `handleMigrateAction` and `handleSyncMetadataAction`, preventing graceful cleanup on SIGINT.
 - **Fixed:** `build-match-key.js` used `||` instead of `??` for line numbers, treating `line: 0` (file-level issues) as falsy. Fixed in sq-9.9, sq-10.4, and sq-2025.
 - **Fixed:** `findDateRange` in search slicer had no null check — empty API results caused `NaN` timestamps and silent data loss.
@@ -523,7 +523,7 @@ All changes are in `desktop/src/renderer/js/components/migration-graph*.js`.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 
-SonarQube's `/api/issues/search` endpoint caps results at 10,000. Projects exceeding this limit now use date-window slicing to retrieve all issues.
+SonarQube Server's `/api/issues/search` endpoint caps results at 10,000. Projects exceeding this limit now use date-window slicing to retrieve all issues.
 
 - **New:** `src/shared/utils/search-slicer/` (5 files) — partitions the creation-date range into narrowing windows until each window returns fewer than 10K results
 - **New:** `probe-total.js` added to each pipeline's `api-client/helpers/` (sq-9.9, sq-10.0, sq-10.4, sq-2025) — probes the total issue count for a query
@@ -533,22 +533,22 @@ SonarQube's `/api/issues/search` endpoint caps results at 10,000. Projects excee
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 
-Fixed silent loss of external (third-party) issues when the SonarCloud rule-repositories API was unreachable.
+Fixed silent loss of external (third-party) issues when the SonarQube Cloud rule-repositories API was unreachable.
 
-- **New:** `src/shared/utils/fallback-repos/index.js` — built-in set of 43 known SonarCloud rule repositories used as a fallback
+- **New:** `src/shared/utils/fallback-repos/index.js` — built-in set of 43 known SonarQube Cloud rule repositories used as a fallback
 - **Fixed:** `isExternalIssue()` falls back to `FALLBACK_SONARCLOUD_REPOS` when the live repo set is empty; handles rules without colons and empty repo prefixes
 - **Fixed:** `getRuleRepositories()` retries the API call up to 3 times with exponential backoff (1 s, 2 s, 3 s) and returns the fallback set if all retries fail
 
 *(See the existing v1.1.9 entry below for per-file details.)*
 
-### SonarCloud Public Scanning (#66)
+### SonarQube Cloud Public Scanning (#66)
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 
-Added automatic SAST/SCA scanning of the CloudVoyager repository via SonarCloud.
+Added automatic SAST/SCA scanning of the CloudVoyager repository via SonarQube Cloud.
 
 - **New:** `.github/workflows/sonarcloud.yml` — triggers on push to `main` and on pull requests
-- **New:** `sonar-project.properties` — SonarCloud project configuration (org, project key, sources, exclusions)
+- **New:** `sonar-project.properties` — SonarQube Cloud project configuration (org, project key, sources, exclusions)
 - **Requires:** `SONAR_TOKEN` secret configured in the GitHub repository
 
 ### Release Milestone References (#75)
@@ -613,7 +613,7 @@ Fixed 134 hook failures and 47 test failures caused by the refactored class wrap
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 
-Fixed a bug where external (third-party) issues were silently dropped during migration when the SonarCloud `/api/rules/repositories` endpoint was unreachable or returned an error.
+Fixed a bug where external (third-party) issues were silently dropped during migration when the SonarQube Cloud `/api/rules/repositories` endpoint was unreachable or returned an error.
 
 #### Root Cause
 
@@ -625,7 +625,7 @@ Fixed a bug where external (third-party) issues were silently dropped during mig
 #### Fix (applied across all 4 pipelines: sq-9.9, sq-10.0, sq-10.4, sq-2025)
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
-- **`isExternalIssue`** — Falls back to `FALLBACK_SONARCLOUD_REPOS` (a built-in set of known SonarCloud rule repos) when the live repo set is empty. Also adds guards for rules without colons and empty repo prefixes.
+- **`isExternalIssue`** — Falls back to `FALLBACK_SONARCLOUD_REPOS` (a built-in set of known SonarQube Cloud rule repos) when the live repo set is empty. Also adds guards for rules without colons and empty repo prefixes.
 - **`buildExternalIssues`** — Removes the early-return that skipped processing; now logs a warning and continues with fallback data.
 - **`getRuleRepositories`** — Retries the API call up to 3 times with exponential backoff (1s, 2s, 3s). If all retries fail, returns `FALLBACK_SONARCLOUD_REPOS` instead of an empty set.
 
@@ -719,11 +719,11 @@ Added a comprehensive GitHub Actions regression testing workflow that runs all C
 
 ## [1.1.5] - 2026-03-25
 
-### Desktop App — SonarCloud Organization Validation
+### Desktop App — SonarQube Cloud Organization Validation
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 
-- **config-form.js** — Added `validateOrgs()` method that enforces at least one SonarCloud organization is present and all required fields (org key, token) are filled before allowing the user to proceed.
+- **config-form.js** — Added `validateOrgs()` method that enforces at least one SonarQube Cloud organization is present and all required fields (org key, token) are filled before allowing the user to proceed.
 - **migrate-config.js** — Org step Next button now calls `ConfigForm.validateOrgs()` before advancing.
 - **sync-metadata-config.js** — Org step Next button now calls `ConfigForm.validateOrgs()` before advancing.
 - **verify-config.js** — Org step Next button now calls `ConfigForm.validateOrgs()` before advancing.
@@ -750,7 +750,7 @@ Refactored project migration into modular components and added new capabilities 
 - **ce-submitter.js** — Extracted CE submission with robust retry mechanism: submit → timeout fallback to `/api/ce/activity` polling (5 checks) → re-submit → poll again → fail with descriptive error.
 
 #### Issue Status Mapping
-- **issue-status-mapper.js** — Extracted issue status transition mapping from changelog diffs. Maps SonarQube status changes (CONFIRMED, REOPENED, RESOLVED, CLOSED, ACCEPTED, FALSE-POSITIVE, WONTFIX) to SonarCloud transitions. Handles SQ 10.4+ where WONTFIX/FALSE-POSITIVE appear as direct status values.
+- **issue-status-mapper.js** — Extracted issue status transition mapping from changelog diffs. Maps SonarQube Server status changes (CONFIRMED, REOPENED, RESOLVED, CLOSED, ACCEPTED, FALSE-POSITIVE, WONTFIX) to SonarQube Cloud transitions. Handles SQ 10.4+ where WONTFIX/FALSE-POSITIVE appear as direct status values.
 
 #### Checkpoint-Aware Extraction
 - **checkpoint-extractor.js** — Extracted checkpoint-aware data extraction with journal + cache support. Implements 13-phase extraction pipeline (project metadata, metrics, components, source files, rules, issues, hotspots, measures, sources, duplications, changesets, symbols, syntax highlighting) with per-phase caching and resume capability. Also supports branch-specific extraction.
@@ -819,12 +819,12 @@ Full codebase review performed across all 322 source files (4 version-specific p
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 
-Refactored the entire codebase from a flat structure with a single `VersionAwareSonarQubeClient` to a **pipeline-per-version** architecture. Each supported SonarQube version range now has its own fully independent pipeline directory containing all version-specific code.
+Refactored the entire codebase from a flat structure with a single `VersionAwareSonarQubeClient` to a **pipeline-per-version** architecture. Each supported SonarQube Server version range now has its own fully independent pipeline directory containing all version-specific code.
 
 #### Architecture Change
 - Moved all version-specific code from flat `src/` directories into `src/pipelines/sq-{version}/` directories (sq-9.9, sq-10.0, sq-10.4, sq-2025)
 - Moved all version-independent shared code into `src/shared/` (config, mapping, reports, state, utils, verification)
-- Added `src/version-router.js` to detect SonarQube version and dynamically load the correct pipeline
+- Added `src/version-router.js` to detect SonarQube Server version and dynamically load the correct pipeline
 - Removed `VersionAwareSonarQubeClient` — each pipeline now has its own `SonarQubeClient` with version-specific behavior hardcoded
 - No runtime version checks exist within any pipeline — all version differences are resolved by the pipeline selection
 
@@ -896,17 +896,17 @@ Refactored the entire codebase from a flat structure with a single `VersionAware
 
 ## [1.1.1] - 2026-03-12
 
-### Bug Fix: SonarCloud Issue Sync Failure (FALSE_POSITIVE Status Parameter)
+### Bug Fix: SonarQube Cloud Issue Sync Failure (FALSE_POSITIVE Status Parameter)
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 
 Projects were being marked as **partial** because the "Sync issues" step failed for every project with:
 > `Value of parameter 'statuses' (FALSE_POSITIVE) must be one of: [OPEN, CONFIRMED, REOPENED, RESOLVED, CLOSED]`
 
-The SonarCloud `/api/issues/search` endpoint was being called with `FALSE_POSITIVE`, `ACCEPTED`, and `FIXED` appended to the `statuses` parameter. SonarCloud does not accept these values — `FALSE_POSITIVE` and `WONTFIX` are *resolutions* in SonarCloud (issues appear as `RESOLVED` with a `resolution` field), while `ACCEPTED` and `FIXED` are SonarQube 10.4+ statuses that SonarCloud's API does not support. The fix restricts the SonarCloud issue search to `OPEN,CONFIRMED,REOPENED,RESOLVED,CLOSED` only, which correctly captures all issues including false positives.
+The SonarQube Cloud `/api/issues/search` endpoint was being called with `FALSE_POSITIVE`, `ACCEPTED`, and `FIXED` appended to the `statuses` parameter. SonarQube Cloud does not accept these values — `FALSE_POSITIVE` and `WONTFIX` are *resolutions* in SonarQube Cloud (issues appear as `RESOLVED` with a `resolution` field), while `ACCEPTED` and `FIXED` are SonarQube Server 10.4+ statuses that SonarQube Cloud's API does not support. The fix restricts the SonarQube Cloud issue search to `OPEN,CONFIRMED,REOPENED,RESOLVED,CLOSED` only, which correctly captures all issues including false positives.
 
 #### Files Modified
-- **Fixed:** `src/sonarcloud/api/issues.js` — removed invalid SonarCloud statuses from `ALL_STATUSES` constant
+- **Fixed:** `src/sonarcloud/api/issues.js` — removed invalid SonarQube Cloud statuses from `ALL_STATUSES` constant
 
 #### Documentation Fixes
 - **Fixed:** `docs/key-capabilities.md` — issue transition mapping had `FALSE-POSITIVE → wontfix` (incorrect); corrected to `FALSE-POSITIVE → falsepositive`; added missing `REOPENED → reopen`, `OPEN → unconfirm`, and `CLOSED → resolve` transitions
@@ -925,7 +925,7 @@ The SonarCloud `/api/issues/search` endpoint was being called with `FALSE_POSITI
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 - Added a **write-ahead checkpoint journal** that tracks phase-by-phase progress for both `transfer` and `migrate` commands, enabling true pause/resume across all migration workflows
 - Interrupted migrations (CTRL+C, crashes, network failures) can now be resumed from the exact point of interruption — no re-processing of completed work
-- The journal stores a session fingerprint (SonarQube version, URL, project key) and validates it on resume, warning on version mismatches
+- The journal stores a session fingerprint (SonarQube Server version, URL, project key) and validates it on resume, warning on version mismatches
 
 #### Graceful Shutdown (SIGINT/SIGTERM)
 
@@ -983,7 +983,7 @@ The SonarCloud `/api/issues/search` endpoint was being called with `FALSE_POSITI
 - `transfer.checkpoint.enabled` — Enable/disable checkpoint journal (default: `true`)
 - `transfer.checkpoint.cacheExtractions` — Enable/disable extraction caching (default: `true`)
 - `transfer.checkpoint.cacheMaxAgeDays` — Max age of cache files in days (default: `7`)
-- `transfer.checkpoint.strictResume` — Fail on SonarQube version mismatch when resuming (default: `false`)
+- `transfer.checkpoint.strictResume` — Fail on SonarQube Server version mismatch when resuming (default: `false`)
 
 #### Enhanced Commands
 
@@ -1020,9 +1020,9 @@ The SonarCloud `/api/issues/search` endpoint was being called with `FALSE_POSITI
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 
 #### New Feature: User Mapping
-- Added `user-mappings.csv` to the dry-run CSV workflow, enabling SonarQube-to-SonarCloud user login mapping
-- During `--dry-run`, CloudVoyager now collects all unique issue assignees across all projects using lightweight facet queries and enriches them with display names and emails from the SonarQube user API
-- Users can fill in the `SonarCloud Login` column to map SQ logins to SC logins, or set `Include=no` to skip assignment for specific users (e.g., service accounts)
+- Added `user-mappings.csv` to the dry-run CSV workflow, enabling SonarQube Server-to-SonarQube Cloud user login mapping
+- During `--dry-run`, CloudVoyager now collects all unique issue assignees across all projects using lightweight facet queries and enriches them with display names and emails from the SonarQube Server user API
+- Users can fill in the `SonarQube Cloud Login` column to map SQ logins to SC logins, or set `Include=no` to skip assignment for specific users (e.g., service accounts)
 - During the actual migration, the user mapping CSV is automatically loaded and applied to issue assignments
 
 #### Issue Assignment Improvements
@@ -1045,18 +1045,18 @@ The SonarCloud `/api/issues/search` endpoint was being called with `FALSE_POSITI
 
 ---
 
-### 2026-03-09 — SonarQube 9.9 & 2025.1 Backward Compatibility
+### 2026-03-09 — SonarQube Server 9.9 & 2025.1 Backward Compatibility
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 
-#### New: Version-Aware SonarQube Client
-- Added `VersionAwareSonarQubeClient` subclass (`src/sonarqube/version-aware-client.js`) that auto-detects the SonarQube server version and adapts API calls accordingly
+#### New: Version-Aware SonarQube Server Client
+- Added `VersionAwareSonarQubeClient` subclass (`src/sonarqube/version-aware-client.js`) that auto-detects the SonarQube Server version and adapts API calls accordingly
 - All backward-compatibility logic is **isolated** in the subclass — the base `SonarQubeClient` and all API modules remain untouched
 - Version is detected once on connection and cached for the lifetime of the client
 
 #### Version-Aware Issue Fetching
-- **SonarQube < 10.4**: Uses legacy `statuses` parameter with combined pre-10.4 and 10.4+ status values
-- **SonarQube >= 10.4 / 2025.1**: Uses modern `issueStatuses` parameter, avoiding deprecation warnings and future breakage
+- **SonarQube Server < 10.4**: Uses legacy `statuses` parameter with combined pre-10.4 and 10.4+ status values
+- **SonarQube Server >= 10.4 / 2025.1**: Uses modern `issueStatuses` parameter, avoiding deprecation warnings and future breakage
 - Falls back to legacy behavior when version is unknown (safe default)
 
 #### Defensive API Wrappers
@@ -1072,7 +1072,7 @@ The SonarCloud `/api/issues/search` endpoint was being called with `FALSE_POSITI
 #### Documentation
 - Created `CONTRIBUTING.md` with comprehensive guide to all codebase patterns and conventions (extractor, API module, migrator, client, isolation, error handling, pagination, concurrency, testing)
 - Updated `docs/backward-compatibility.md` with version-aware client architecture, issue status parameter differences, and expanded version support table
-- Added SonarQube version compatibility section to `README.md` with support matrix
+- Added SonarQube Server version compatibility section to `README.md` with support matrix
 - Added `sonarqubeCompatibility` metadata and version keywords to `package.json`
 - Updated documentation table in `README.md` with backward compatibility and contributing links
 
@@ -1084,11 +1084,11 @@ The SonarCloud `/api/issues/search` endpoint was being called with `FALSE_POSITI
 
 #### Enhancement: `verify` Command
 - Added **status history (changelog) verification** to the issue metadata checker
-- Fetches changelogs from both SonarQube and SonarCloud via `/api/issues/changelog`
+- Fetches changelogs from both SonarQube Server and SonarQube Cloud via `/api/issues/changelog`
 - Extracts status transitions from each changelog and compares them in order
 - Flags issues where SQ transitions are missing from SC as `statusHistoryMismatches`
 - Issues with no status changes (never transitioned) are skipped
-- Added `getIssueChangelog` to the SonarCloud API client
+- Added `getIssueChangelog` to the SonarQube Cloud API client
 - Updated Markdown, PDF, and console reports to include status history mismatch details
 - Updated verification documentation with new check description and pass/fail criteria
 
@@ -1099,8 +1099,8 @@ The SonarCloud `/api/issues/search` endpoint was being called with `FALSE_POSITI
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 
 #### New Feature: `verify` Command
-- Added a `verify` command that exhaustively compares SonarQube and SonarCloud data to confirm migration completeness
-- Performs read-only checks — no data is modified in either SonarQube or SonarCloud
+- Added a `verify` command that exhaustively compares SonarQube Server and SonarQube Cloud data to confirm migration completeness
+- Performs read-only checks — no data is modified in either SonarQube Server or SonarQube Cloud
 - Reuses the existing migration config file (no new config schema needed)
 - Supports the same `--only` component filtering as the `migrate` command
 
@@ -1146,7 +1146,7 @@ The SonarCloud `/api/issues/search` endpoint was being called with `FALSE_POSITI
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 
 #### Enterprise Portfolio API (V2)
-- Migrated portfolio management to SonarCloud's V2 Enterprise API for creating and managing portfolios
+- Migrated portfolio management to SonarQube Cloud's V2 Enterprise API for creating and managing portfolios
 - Added `src/sonarcloud/enterprise-client.js` for V2 API interactions
 
 #### Configuration
@@ -1179,7 +1179,7 @@ The SonarCloud `/api/issues/search` endpoint was being called with `FALSE_POSITI
 - Enhanced documentation and reports for migration process, including new transfer scenarios and improved output paths
 
 #### Testing
-- Added unit tests for SonarQube models, state management, transfer pipeline, concurrency utilities, error handling, and logging
+- Added unit tests for SonarQube Server models, state management, transfer pipeline, concurrency utilities, error handling, and logging
 
 #### Documentation
 - Added local development guide for building and running CloudVoyager from source with step-by-step instructions
@@ -1196,12 +1196,12 @@ The SonarCloud `/api/issues/search` endpoint was being called with `FALSE_POSITI
 - Enables stakeholders to review migration outcomes at a glance
 
 #### Quality Profile Diff Reports
-- Added side-by-side comparison of active rules per language between SonarQube and SonarCloud
+- Added side-by-side comparison of active rules per language between SonarQube Server and SonarQube Cloud
 - Identifies rule discrepancies after profile migration, so teams can verify policy parity before go-live
 
 #### New Code Period Migration
-- Migrates "new code" period definitions (used for quality gate evaluations) to SonarCloud via the settings API
-- Supports all SonarQube new code period types with automatic mapping to SonarCloud equivalents
+- Migrates "new code" period definitions (used for quality gate evaluations) to SonarQube Cloud via the settings API
+- Supports all SonarQube Server new code period types with automatic mapping to SonarQube Cloud equivalents
 
 #### Auto-Tune Performance
 - Added `--auto-tune` flag that detects available CPU cores and RAM to automatically configure concurrency and memory limits
@@ -1209,10 +1209,10 @@ The SonarCloud `/api/issues/search` endpoint was being called with `FALSE_POSITI
 - Automatic process respawn with increased heap size when memory limits are configured
 
 #### CLI Enhancements
-- Added `--wait` flag to block until SonarCloud finishes analyzing the uploaded report, useful for CI/CD pipelines
-- Branch name is now resolved from SonarCloud (not SonarQube) to avoid mismatches in multi-branch setups
+- Added `--wait` flag to block until SonarQube Cloud finishes analyzing the uploaded report, useful for CI/CD pipelines
+- Branch name is now resolved from SonarQube Cloud (not SonarQube Server) to avoid mismatches in multi-branch setups
 
-#### SonarCloud Integration Improvements
+#### SonarQube Cloud Integration Improvements
 - Added project key availability check to detect naming conflicts before migration begins
 - Improved duplicate report prevention via SCM revision tracking
 
@@ -1237,10 +1237,10 @@ The SonarCloud `/api/issues/search` endpoint was being called with `FALSE_POSITI
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 
 #### Full Migration Pipeline (`migrate` command)
-- **Issue metadata sync** — migrates issue statuses, assignments, comments, and tags from SonarQube to SonarCloud
+- **Issue metadata sync** — migrates issue statuses, assignments, comments, and tags from SonarQube Server to SonarQube Cloud
 - **Hotspot metadata sync** — migrates security hotspot statuses and review comments
 - **Permissions migration** — transfers global permissions, project-level permissions, and permission templates
-- **Portfolio migration** — recreates portfolios in SonarCloud while preserving project associations
+- **Portfolio migration** — recreates portfolios in SonarQube Cloud while preserving project associations
 - **Project settings migration** — migrates tags, links, DevOps bindings, and project-level configuration
 - **Quality gates migration** — transfers gate definitions, conditions, project assignments, and access permissions
 - **Quality profiles migration** — uses backup/restore to transfer profiles via XML; built-in profiles are migrated as custom copies with inheritance chains and permissions preserved
@@ -1252,7 +1252,7 @@ The SonarCloud `/api/issues/search` endpoint was being called with `FALSE_POSITI
 - Generates detailed migration reports with per-organization and per-project summaries
 
 #### Rate Limiting
-- Added configurable rate limiting for SonarCloud API write requests with exponential backoff on 503/429 responses
+- Added configurable rate limiting for SonarQube Cloud API write requests with exponential backoff on 503/429 responses
 - Prevents API throttling during large-scale migrations
 
 #### Concurrency and Performance Tuning
@@ -1266,7 +1266,7 @@ The SonarCloud `/api/issues/search` endpoint was being called with `FALSE_POSITI
 - Added LICENSE file for open-source compliance
 - Created scenario-based migration guides:
   - **Single project** — migrate one specific project
-  - **Single organization** — migrate all projects to one SonarCloud organization
+  - **Single organization** — migrate all projects to one SonarQube Cloud organization
 - Removed outdated usage guide (content consolidated into scenario documents)
 
 ---
@@ -1276,7 +1276,7 @@ The SonarCloud `/api/issues/search` endpoint was being called with `FALSE_POSITI
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 
 #### Data Extraction Engine
-- Built the core extraction engine that pulls all relevant data from SonarQube via its REST API:
+- Built the core extraction engine that pulls all relevant data from SonarQube Server via its REST API:
   - Project metadata, branches, and quality gate associations
   - Issues with full pagination support and incremental sync capability
   - Measures and metrics at both project and component level
@@ -1288,7 +1288,7 @@ The SonarCloud `/api/issues/search` endpoint was being called with `FALSE_POSITI
 
 #### CLI Interface
 - Commander-based CLI with four core commands:
-  - `transfer` — extract from SonarQube, build protobuf report, upload to SonarCloud
+  - `transfer` — extract from SonarQube Server, build protobuf report, upload to SonarQube Cloud
   - `validate` — validate configuration file before running
   - `status` — view current sync state and transfer history
   - `reset` — clear sync state to force a full re-transfer
@@ -1296,13 +1296,13 @@ The SonarCloud `/api/issues/search` endpoint was being called with `FALSE_POSITI
 - Tokens can be provided via environment variables (`SONARQUBE_TOKEN`, `SONARCLOUD_TOKEN`) to avoid storing secrets in config files
 
 #### Protobuf Report Builder
-- Transforms extracted SonarQube data into protobuf-encoded scanner reports matching SonarCloud's internal Compute Engine format
+- Transforms extracted SonarQube Server data into protobuf-encoded scanner reports matching SonarQube Cloud's internal Compute Engine format
 - Uses a flat component structure (no directory hierarchy) with line counts derived from source files
 - Maintains component reference mapping to preserve relationships between files, issues, and measures
 
 #### Configuration System
 - JSON-based configuration with schema validation
-- Supports SonarQube source settings, SonarCloud target settings, and transfer options (mode, batch size, state file)
+- Supports SonarQube Server source settings, SonarQube Cloud target settings, and transfer options (mode, batch size, state file)
 - Environment variable overrides for sensitive tokens
 
 #### State Management

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,17 +8,17 @@ This guide documents the architectural patterns and conventions of the CloudVoya
 ## Golden Rule: Pipeline Isolation
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Each supported SonarQube version range gets its own **complete, independent pipeline directory** under `src/pipelines/`. There are no runtime version checks within any pipeline -- each pipeline has its behavior hardcoded for its target version range.
+Each supported SonarQube Server version range gets its own **complete, independent pipeline directory** under `src/pipelines/`. There are no runtime version checks within any pipeline -- each pipeline has its behavior hardcoded for its target version range.
 
 ```
 src/pipelines/
-├── sq-9.9/     # SonarQube 9.9 LTS
-├── sq-10.0/    # SonarQube 10.0–10.3
-├── sq-10.4/    # SonarQube 10.4–10.8
-└── sq-2025/    # SonarQube 2025.1+
+├── sq-9.9/     # SonarQube Server 9.9 LTS
+├── sq-10.0/    # SonarQube Server 10.0–10.3
+├── sq-10.4/    # SonarQube Server 10.4–10.8
+└── sq-2025/    # SonarQube Server 2025.1+
 ```
 
-The **version router** (`src/version-router.js`) detects the SonarQube server version at runtime and dynamically imports the correct pipeline. This means:
+The **version router** (`src/version-router.js`) detects the SonarQube Server version at runtime and dynamically imports the correct pipeline. This means:
 
 - **Never add version-conditional logic inside a pipeline.** If behavior differs between versions, it belongs in a separate pipeline directory.
 - **Never import across pipeline boundaries.** Each pipeline is self-contained.
@@ -35,10 +35,10 @@ src/
 ├── version-router.js           # Detects SQ version, loads correct pipeline
 ├── commands/                   # CLI command handlers (transfer, migrate, sync-metadata, verify)
 ├── pipelines/                  # Version-specific pipeline implementations
-│   ├── sq-9.9/                 # SonarQube 9.9 LTS
-│   ├── sq-10.0/                # SonarQube 10.0–10.3
-│   ├── sq-10.4/                # SonarQube 10.4–10.8
-│   └── sq-2025/                # SonarQube 2025.1+
+│   ├── sq-9.9/                 # SonarQube Server 9.9 LTS
+│   ├── sq-10.0/                # SonarQube Server 10.0–10.3
+│   ├── sq-10.4/                # SonarQube Server 10.4–10.8
+│   └── sq-2025/                # SonarQube Server 2025.1+
 └── shared/                     # Version-independent shared code
     ├── config/                 # Configuration loading and validation (Ajv-based)
     ├── mapping/                # Organization mapping and CSV tools
@@ -54,7 +54,7 @@ Each pipeline directory (`src/pipelines/sq-{version}/`) contains a complete, sel
 sq-{version}/
 ├── transfer-pipeline.js           # Single-project transfer orchestrator
 ├── migrate-pipeline.js            # Full multi-org migration orchestrator
-├── sonarqube/                     # SonarQube integration
+├── sonarqube/                     # SonarQube Server integration
 │   ├── api-client.js               # HTTP client with pagination, auth, SCM revision
 │   ├── models.js                   # Data models and factory functions
 │   ├── api/                        # API method modules
@@ -79,8 +79,8 @@ sq-{version}/
 │   └── schema/                      # .proto definitions
 │       ├── constants.proto
 │       └── scanner-report.proto
-├── sonarcloud/                    # SonarCloud integration
-│   ├── api-client.js               # SonarCloud HTTP client (retry, throttle)
+├── sonarcloud/                    # SonarQube Cloud integration
+│   ├── api-client.js               # SonarQube Cloud HTTP client (retry, throttle)
 │   ├── uploader.js                 # Report packaging and CE submission
 │   ├── enterprise-client.js        # Enterprise API client
 │   ├── rule-enrichment.js          # Rule enrichment for Clean Code attributes
@@ -158,7 +158,7 @@ export async function getXxx(client, param) {
 ### 3. Migrator Pattern (`src/pipelines/sq-{version}/sonarcloud/migrators/`)
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Transform extracted SonarQube data and apply it to SonarCloud:
+Transform extracted SonarQube Server data and apply it to SonarQube Cloud:
 
 ```js
 export async function migrateXxx(extractedData, scClient, options) {
@@ -191,8 +191,8 @@ Each pipeline has its own `SonarQubeClient` tailored to its version range:
 | Error Class | When to Use |
 |-------------|-------------|
 | `ConfigurationError` | Invalid config file or missing required fields |
-| `SonarQubeAPIError` | SonarQube API failures (include endpoint in constructor) |
-| `SonarCloudAPIError` | SonarCloud API failures (include endpoint in constructor) |
+| `SonarQubeAPIError` | SonarQube Server API failures (include endpoint in constructor) |
+| `SonarCloudAPIError` | SonarQube Cloud API failures (include endpoint in constructor) |
 | `AuthenticationError` | 401/403 responses (include service name) |
 | `ProtobufEncodingError` | Protobuf encoding failures |
 | `StateError` | State file I/O failures |
@@ -205,7 +205,7 @@ Each pipeline has its own `SonarQubeClient` tailored to its version range:
 ### 6. Pagination
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-All paginated SonarQube APIs use `getPaginated()`:
+All paginated SonarQube Server APIs use `getPaginated()`:
 
 ```js
 return await this.getPaginated('/api/xxx/search', { ps: 500 }, 'items');
@@ -213,7 +213,7 @@ return await this.getPaginated('/api/xxx/search', { ps: 500 }, 'items');
 
 **Rules:**
 - Default page size: 500
-- Override to `ps: 100` for permission-related APIs (SonarQube limitation)
+- Override to `ps: 100` for permission-related APIs (SonarQube Server limitation)
 - Handles both `data.paging.total` (10.x+) and `data.total` (9.x) response formats
 - Never implement manual pagination -- always use `getPaginated()`
 
@@ -251,7 +251,7 @@ sqIssues (100K) → fetchSqChangelogs() → hasManualChanges() filter → ~1-2K 
 
 An issue is considered to have **manual changes** if any of:
 1. Its changelog has at least one entry with a non-empty `user` field (human actor, not system)
-2. It has comments not prefixed with `[Migrated from SonarQube]` (manual, not auto-generated)
+2. It has comments not prefixed with `[Migrated from SonarQube Server]` (manual, not auto-generated)
 3. It has custom tags (`tags` array is non-empty)
 
 **Shared utilities:**
@@ -352,10 +352,10 @@ npm run lint      # ESLint
 
 ---
 
-## Adding New SonarQube Version Support
+## Adding New SonarQube Server Version Support
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-When a new SonarQube version introduces API changes:
+When a new SonarQube Server version introduces API changes:
 
 1. **Research** the API differences (check release notes, deprecation logs)
 2. **Create a new pipeline directory** under `src/pipelines/sq-{version}/` by copying the closest existing pipeline as a starting point

--- a/docs/Core Technologies.md
+++ b/docs/Core Technologies.md
@@ -2,7 +2,7 @@
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-CloudVoyager is built on a carefully selected stack of battle-tested open-source technologies. Each technology was chosen to address specific requirements of the SonarQube-to-SonarCloud migration workflow.
+CloudVoyager is built on a carefully selected stack of battle-tested open-source technologies. Each technology was chosen to address specific requirements of the SonarQube Server-to-SonarQube Cloud migration workflow.
 
 ## 1. Node.js
 
@@ -49,12 +49,12 @@ This approach produces a distributable binary that does not require the end user
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-SonarCloud accepts scanner reports only in Protocol Buffer format. Protobuf was chosen because:
+SonarQube Cloud accepts scanner reports only in Protocol Buffer format. Protobuf was chosen because:
 
-- **SonarCloud API requirement** — The scanner report upload endpoint expects a binary-encoded Protobuf payload, not JSON
+- **SonarQube Cloud API requirement** — The scanner report upload endpoint expects a binary-encoded Protobuf payload, not JSON
 - **Compact binary encoding** — Protobuf messages are significantly smaller than equivalent JSON, reducing upload time for large codebases
 - **Strict schema enforcement** — The `.proto` schema definitions (`scanner-report.proto`) catch structural errors at build time rather than at upload time
-- **Language neutrality** — The same schema is used across all supported SonarQube versions (9.9, 10.0, 10.4, 2025.1)
+- **Language neutrality** — The same schema is used across all supported SonarQube Server versions (9.9, 10.0, 10.4, 2025.1)
 
 ### Protobuf Schema
 
@@ -151,7 +151,7 @@ src/commands/
   reset.js            — Reset migration state
   status.js           — Show migration status
   validate.js         — Validate configuration
-  test-connection.js — Test SonarQube/SonarCloud connectivity
+  test-connection.js — Test SonarQube Server/SonarQube Cloud connectivity
 ```
 
 ## 5. Ajv
@@ -249,7 +249,7 @@ npm run build:linux-arm64 # Linux ARM64
 CI/CD is implemented entirely in GitHub Actions because:
 
 - **Native to the repository** — No external CI service configuration required
-- **Matrix builds** — Test across Node.js versions, platforms, and SonarQube versions in parallel
+- **Matrix builds** — Test across Node.js versions, platforms, and SonarQube Server versions in parallel
 - **Artifact sharing** — `actions/cache` (not `actions/upload-artifact`) passes build artifacts between jobs
 - **Workflow composition** — Reusable workflows (`workflow_call`) allow `build.yml` to be composed into release pipelines
 - **Secrets management** — `SONARCLOUD_TOKEN` and `SONARQUBE_TOKEN` stored as repository secrets
@@ -263,7 +263,7 @@ CI/CD is implemented entirely in GitHub Actions because:
 | `unit-tests.yml` | Run AVA unit tests on every push |
 | `build.yml` | Build SEA binaries for all 6 platforms |
 | `build-desktop.yml` | Build Electron desktop app for all platforms |
-| `regression.yml` | End-to-end regression tests with real SonarQube/SonarCloud |
+| `regression.yml` | End-to-end regression tests with real SonarQube Server/SonarQube Cloud |
 | `release.yml` | Create GitHub releases with attached binaries |
 | `gh-release.yml` | Draft GitHub release notes |
 | `version-bump.yml` | Automated version bumping on main branch |
@@ -287,4 +287,4 @@ Each platform is built in a dedicated job:
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Regression workflows spin up real SonarQube and SonarCloud instances and run actual migration commands. The workflows use `actions/cache` to share state between jobs rather than artifact uploads, following the project's CI best practice of using cache for inter-job data transfer.
+Regression workflows spin up real SonarQube Server and SonarQube Cloud instances and run actual migration commands. The workflows use `actions/cache` to share state between jobs rather than artifact uploads, following the project's CI best practice of using cache for inter-job data transfer.

--- a/docs/Easy Local Development Guide.md
+++ b/docs/Easy Local Development Guide.md
@@ -2,7 +2,7 @@
 
 <!-- <subsection-updated last-updated="2026-05-07T01:15:00Z" updated-by="Claude" /> -->
 
-Welcome to CloudVoyager! This guide walks you through setting up and running CloudVoyager on your local machine. No prior experience with SonarQube or SonarCloud is required — just follow the steps below.
+Welcome to CloudVoyager! This guide walks you through setting up and running CloudVoyager on your local machine. No prior experience with SonarQube Server or SonarQube Cloud is required — just follow the steps below.
 
 ---
 
@@ -10,7 +10,7 @@ Welcome to CloudVoyager! This guide walks you through setting up and running Clo
 
 <!-- <subsection-updated last-updated="2026-05-07T01:15:00Z" updated-by="Claude" /> -->
 
-CloudVoyager is a command-line tool that migrates projects from **SonarQube** (self-hosted) to **SonarCloud** (cloud-hosted). It transfers source code, quality gates, quality profiles, permissions, and more.
+CloudVoyager is a command-line tool that migrates projects from **SonarQube Server** (self-hosted) to **SonarQube Cloud** (cloud-hosted). It transfers source code, quality gates, quality profiles, permissions, and more.
 
 **In plain English:** It copies your code analysis data from your own server to the cloud, saving you from doing it manually.
 
@@ -155,8 +155,8 @@ CloudVoyager v1.x.x
 <!-- <subsection-updated last-updated="2026-05-07T01:15:00Z" updated-by="Claude" /> -->
 
 CloudVoyager needs a JSON configuration file that tells it:
-- How to connect to your SonarQube server (source)
-- How to connect to your SonarCloud organization (destination)
+- How to connect to your SonarQube Server (source)
+- How to connect to your SonarQube Cloud organization (destination)
 - Which projects to migrate
 
 Create a file called `config.json` at the project root:
@@ -187,8 +187,8 @@ Create a file called `config.json` at the project root:
 ```
 
 **Where to find your tokens:**
-- **SonarQube token:** Log in to SonarQube → My Account → Security → Generate Tokens
-- **SonarCloud token:** Log in to SonarCloud → Account → Security → Generate Tokens
+- **SonarQube Server token:** Log in to SonarQube Server → My Account → Security → Generate Tokens
+- **SonarQube Cloud token:** Log in to SonarQube Cloud → Account → Security → Generate Tokens
 
 ---
 
@@ -220,7 +220,7 @@ ERROR: Missing required field 'source.sonarQube.url'
 
 <!-- <subsection-updated last-updated="2026-05-07T01:15:00Z" updated-by="Claude" /> -->
 
-Test that CloudVoyager can connect to both SonarQube and SonarCloud:
+Test that CloudVoyager can connect to both SonarQube Server and SonarQube Cloud:
 
 ```bash
 ./dist/bin/cloudvoyager-macos-arm64 test -c config.json --verbose
@@ -229,8 +229,8 @@ Test that CloudVoyager can connect to both SonarQube and SonarCloud:
 **Expected output (success):**
 ```
 Testing connections...
-Source (SonarQube): Connected successfully
-Target (SonarCloud): Connected successfully
+Source (SonarQube Server): Connected successfully
+Target (SonarQube Cloud): Connected successfully
 All connections verified.
 ```
 
@@ -356,7 +356,7 @@ npm run package
 ### "Connection refused" when testing
 
 Check that:
-1. Your SonarQube/SonarCloud URLs are accessible from your network
+1. Your SonarQube Server/SonarQube Cloud URLs are accessible from your network
 2. Your tokens are valid and not expired
 3. Your firewall allows outbound HTTPS (port 443)
 
@@ -382,10 +382,10 @@ You can override config values using environment variables:
 |----------|-------------|
 | `LOG_LEVEL` | Set logging level: `debug`, `info`, `warn`, `error` |
 | `LOG_FILE` | Path to log file (logs to console by default) |
-| `SONARQUBE_TOKEN` | Override SonarQube token |
-| `SONARCLOUD_TOKEN` | Override SonarCloud token |
-| `SONARQUBE_URL` | Override SonarQube URL |
-| `SONARCLOUD_URL` | Override SonarCloud URL |
+| `SONARQUBE_TOKEN` | Override SonarQube Server token |
+| `SONARCLOUD_TOKEN` | Override SonarQube Cloud token |
+| `SONARQUBE_URL` | Override SonarQube Server URL |
+| `SONARCLOUD_URL` | Override SonarQube Cloud URL |
 
 **Example:**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@
 ## 📁 Project Structure
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-CloudVoyager uses a **pipeline-per-version** architecture. Each supported SonarQube version range has its own self-contained pipeline, while shared (version-independent) code lives in `src/shared/`.
+CloudVoyager uses a **pipeline-per-version** architecture. Each supported SonarQube Server version range has its own self-contained pipeline, while shared (version-independent) code lives in `src/shared/`.
 
 ```
 src/
@@ -19,10 +19,10 @@ src/
 │   ├── sync-metadata.js               # Standalone metadata sync command
 │   └── verify.js                      # Migration verification command
 ├── pipelines/                        # Version-specific pipeline implementations
-│   ├── sq-9.9/                        # SonarQube 9.9 LTS
-│   ├── sq-10.0/                       # SonarQube 10.0–10.3
-│   ├── sq-10.4/                       # SonarQube 10.4–10.8
-│   └── sq-2025/                       # SonarQube 2025.1+
+│   ├── sq-9.9/                        # SonarQube Server 9.9 LTS
+│   ├── sq-10.0/                       # SonarQube Server 10.0–10.3
+│   ├── sq-10.4/                       # SonarQube Server 10.4–10.8
+│   └── sq-2025/                       # SonarQube Server 2025.1+
 └── shared/                           # Version-independent shared code
     ├── config/                        # Configuration loading and validation
     │   ├── loader.js                   # Config loading (Ajv + ajv-formats) for transfer commands
@@ -67,7 +67,7 @@ src/
     │   ├── shutdown.js                 # Graceful SIGINT/SIGTERM shutdown coordinator
     │   ├── progress.js                 # Checkpoint progress display and ETA
     │   ├── prompt.js                   # Interactive user prompts (confirmation dialogs)
-    │   ├── version.js                  # SonarQube version parsing and comparison
+    │   ├── version.js                  # SonarQube Server version parsing and comparison
     │   ├── portfolio-skip.js           # handleMissingEnterpriseKey — graceful portfolio skip when enterprise key absent
     │   ├── search-slicer/             # Date-window slicing for 10K+ issue retrieval (SQ & SC)
     │   │   ├── index.js                # fetchWithSlicing orchestrator
@@ -90,7 +90,7 @@ src/
     │   │   ├── apply-pre-filter.js     # Applies hasManualChanges pre-filter; sets stats.filtered
     │   │   └── wait-for-sc-indexing.js # Retries SC fetch until analysis is indexed (Issue #91)
     │   └── fallback-repos/
-    │       └── index.js                # 44 known SonarCloud rule repositories (fallback set)
+    │       └── index.js                # 44 known SonarQube Cloud rule repositories (fallback set)
     └── verification/                  # Migration verification
         ├── verify-pipeline.js          # Verification orchestrator (read-only comparison)
         ├── checkers/                   # Per-check verification modules
@@ -141,7 +141,7 @@ sq-{version}/
 │   ├── index.js                       # Full multi-org migration orchestrator
 │   └── helpers/                       # 10 helper files
 │
-├── sonarqube/                        # SonarQube integration
+├── sonarqube/                        # SonarQube Server integration
 │   ├── api-client.js                  # Re-export → api-client/index.js
 │   ├── api-client/
 │   │   ├── index.js                    # HTTP client (factory function: createSonarQubeClient)
@@ -194,7 +194,7 @@ sq-{version}/
 │       ├── scanner-report.proto
 │       └── constants.proto
 │
-├── sonarcloud/                       # SonarCloud integration
+├── sonarcloud/                       # SonarQube Cloud integration
 │   ├── api-client.js                  # Re-export → api-client/index.js (factory: createSonarCloudClient)
 │   ├── api-client/
 │   │   ├── index.js
@@ -207,7 +207,7 @@ sq-{version}/
 │   ├── enterprise-client/
 │   │   ├── index.js
 │   │   └── helpers/                    # 4 helper files
-│   ├── rule-enrichment.js             # Rule enrichment from SonarCloud (sq-9.9 uses this)
+│   ├── rule-enrichment.js             # Rule enrichment from SonarQube Cloud (sq-9.9 uses this)
 │   ├── api/
 │   │   ├── hotspots.js                 # Hotspot API methods (<50 lines)
 │   │   ├── issues.js                   # Re-export → issues/helpers/ (3 helpers)
@@ -256,7 +256,7 @@ sq-{version}/
 ### Shared Utilities — SCM Date Backdating
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-The **batch-distributor** (`src/shared/utils/batch-distributor/`) preserves each issue's original SonarQube creation date in SonarCloud by rewriting SCM changeset blame dates in the protobuf report.
+The **batch-distributor** (`src/shared/utils/batch-distributor/`) preserves each issue's original SonarQube Server creation date in SonarQube Cloud by rewriting SCM changeset blame dates in the protobuf report.
 
 The primary function is `backdateChangesets(extractedData)`, which:
 
@@ -277,18 +277,18 @@ Legacy helpers (`computeBatchPlan`, `computeBatchDate`, `createBatchExtractedDat
 ## 🔄 Version Routing
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-`version-router.js` detects the SonarQube server version and dynamically imports the correct pipeline:
+`version-router.js` detects the SonarQube Server version and dynamically imports the correct pipeline:
 
 1. Makes a lightweight `GET /api/system/status` call to get the server version
 2. Maps the version to a pipeline: `sq-9.9`, `sq-10.0`, `sq-10.4`, or `sq-2025`
 3. Dynamically imports `transfer-pipeline.js` and `migrate-pipeline.js` from the selected pipeline
 4. Returns the pipeline functions to the calling command
 
-No runtime version checks exist within any pipeline — each pipeline has its behavior hardcoded for its target SonarQube version range.
+No runtime version checks exist within any pipeline — each pipeline has its behavior hardcoded for its target SonarQube Server version range.
 
 | SQ Version | Pipeline | Key Differences |
 |------------|----------|-----------------|
-| 9.9 LTS | sq-9.9 | Legacy `statuses` param, Clean Code enriched from SonarCloud |
+| 9.9 LTS | sq-9.9 | Legacy `statuses` param, Clean Code enriched from SonarQube Cloud |
 | 10.0–10.3 | sq-10.0 | Legacy `statuses` param, native Clean Code |
 | 10.4–10.8 | sq-10.4 | Modern `issueStatuses` param |
 | 2025.1+ | sq-2025 | Modern `issueStatuses` param, Web API V2 with fallbacks |
@@ -318,12 +318,12 @@ Uses `pipelines/sq-{version}/transfer-pipeline.js` (selected by version-router):
 2. **Initialize state** — load previous state for incremental transfers
 3. **Acquire lock file** — prevent concurrent runs on the same project
 4. **Initialize checkpoint journal** — load or create checkpoint for pause/resume
-5. **Test connections** — verify SonarQube and SonarCloud connectivity
-6. **Extract data** — extract project data from SonarQube (issues, sources, measures, rules, hotspots, etc.) — 10+ extraction phases
+5. **Test connections** — verify SonarQube Server and SonarQube Cloud connectivity
+6. **Extract data** — extract project data from SonarQube Server (issues, sources, measures, rules, hotspots, etc.) — 10+ extraction phases
 7. **Build messages** — transform extracted data into protobuf message structures (including external issues + ad-hoc rules for unsupported plugins)
 8. **Encode** — encode messages to binary protobuf format
 9. **Package** — create ZIP archive (metadata.pb, component-N.pb, issues-N.pb, externalissues-N.pb, adhocrules.pb, measures-N.pb, duplications-N.pb, source-N.txt, activerules.pb, changesets-N.pb)
-10. **Upload** — submit scanner report ZIP to SonarCloud CE endpoint
+10. **Upload** — submit scanner report ZIP to SonarQube Cloud CE endpoint
 11. **Metadata sync** — sync issue statuses, comments, assignments, and tags from SQ to SC; sync hotspot statuses, comments, and source links (skippable via `skipIssueMetadataSync` / `skipHotspotMetadataSync`)
 12. **Release lock** — release the advisory lock file
 13. **Update state** — record successful transfer in state file
@@ -348,7 +348,7 @@ Uses `pipelines/sq-{version}/migrate-pipeline.js` (selected by version-router):
    - Compare quality profiles and write diff report (`quality-profiles/quality-profile-diff.json`)
    - Create permission templates
    - For each project (11 steps):
-     - Resolve project key (use original SonarQube key; fall back to `{org}_{key}` if taken globally)
+     - Resolve project key (use original SonarQube Server key; fall back to `{org}_{key}` if taken globally)
      - Upload scanner report (via transfer pipeline)
      - Sync issue statuses, assignments, comments, tags
      - Sync hotspot statuses and comments
@@ -368,8 +368,8 @@ On resume, completed organizations and projects are skipped based on the migrati
 
 Uses `shared/verification/verify-pipeline.js`:
 
-1. **Connect to SonarQube** — verify connectivity
-2. **Fetch project list** — get all projects from SonarQube
+1. **Connect to SonarQube Server** — verify connectivity
+2. **Fetch project list** — get all projects from SonarQube Server
 3. **Build org mappings** — map projects to target orgs (same logic as `migrate`)
 4. **For each target organization:**
    - Verify quality gates (existence + conditions)
@@ -378,7 +378,7 @@ Uses `shared/verification/verify-pipeline.js`:
    - Verify global permissions
    - Verify permission templates
    - For each project:
-     - Verify project exists in SonarCloud
+     - Verify project exists in SonarQube Cloud
      - Verify branches (SQ vs SC)
      - Verify issues (matched by rule+file+line; compare statuses, status history via changelog, assignments, comments, tags)
      - Verify hotspots (matched by rule+file+line; compare statuses, comments)
@@ -386,7 +386,7 @@ Uses `shared/verification/verify-pipeline.js`:
      - Verify quality gate and profile assignments
      - Verify project settings, tags, links, new code periods, DevOps bindings
      - Verify project permissions
-5. **Portfolio check** — reference-only verification (always skipped; requires Enterprise API access that is not available). SonarQube portfolios are listed in the report for manual reference but no SonarCloud comparison is performed.
+5. **Portfolio check** — reference-only verification (always skipped; requires Enterprise API access that is not available). SonarQube Server portfolios are listed in the report for manual reference but no SonarQube Cloud comparison is performed.
 6. **Generate reports** — JSON, Markdown, PDF, and console summary
 
 <!-- Updated: Mar 25, 2026 -->
@@ -394,7 +394,7 @@ Uses `shared/verification/verify-pipeline.js`:
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
 - **Extractor Pattern** — specialized modules for each data type with consistent interface
-- **Migrator Pattern** — specialized modules for each SonarCloud migration target
+- **Migrator Pattern** — specialized modules for each SonarQube Cloud migration target
 - **Client-Service Pattern** — API clients handle HTTP, services handle business logic
 - **Builder Pattern** — ProtobufBuilder constructs complex message structures
 - **State Pattern** — StateTracker manages transfer state for incremental sync
@@ -408,7 +408,7 @@ Uses `shared/verification/verify-pipeline.js`:
   - Server-wide extraction steps run via `Promise.all` (quality gates, profiles, groups, permissions, templates, portfolios, server info, webhooks)
   - Org-wide resource migration uses two-batch parallelism: batch 1 (independent: groups, gates, profiles, templates) then batch 2 (dependent: global permissions, profile comparison)
   - Project-level steps run in parallel where possible (issue + hotspot sync concurrent, config steps concurrent, gate/profile/permission assignment concurrent)
-- **Shared Throttler Pattern** — SonarCloud API clients within an org share a single POST throttler (`sharedThrottler`) to enforce `minRequestInterval` across all concurrent project migrations, preventing rate limit violations
+- **Shared Throttler Pattern** — SonarQube Cloud API clients within an org share a single POST throttler (`sharedThrottler`) to enforce `minRequestInterval` across all concurrent project migrations, preventing rate limit violations
 
 <!-- Updated: Mar 25, 2026 -->
 ## ⚡ Concurrency and Performance
@@ -502,10 +502,10 @@ setup ────────┤                     ├─ sync-metadata (4 pa
 - **Integration Tests:** 30 parallel jobs testing every CLI flag combination via matrix strategy (`fail-fast: false`). Config files generated at runtime from GitHub Secrets.
 - **Summary:** Gate job that only passes when all 30 integration tests pass
 
-### SonarCloud Analysis
+### SonarQube Cloud Analysis
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-A standalone `SonarCloud Analysis` workflow (`sonarcloud.yml`) runs SAST and SCA scanning on every push to `main`. It does **not** run unit tests or ingest coverage — those are handled by the separate Unit Tests workflow.
+A standalone `SonarQube Cloud Analysis` workflow (`sonarcloud.yml`) runs SAST and SCA scanning on every push to `main`. It does **not** run unit tests or ingest coverage — those are handled by the separate Unit Tests workflow.
 
 ### Auto Version Bump
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -531,7 +531,7 @@ The `Build and Release` workflow (`release.yml`) builds binaries for 6 platforms
 | File | Purpose |
 |---|---|
 | `unit-tests.yml` | Standalone unit tests (push to main only) |
-| `sonarcloud.yml` | SAST/SCA scanning via SonarCloud |
+| `sonarcloud.yml` | SAST/SCA scanning via SonarQube Cloud |
 | `version-bump.yml` | Auto-bump version from PR milestone on merge |
 | `release.yml` | Orchestrator — install, build, desktop build, release |
 | `regression.yml` | Regression orchestrator — triggers, stage sequencing |

--- a/docs/backward-compatibility.md
+++ b/docs/backward-compatibility.md
@@ -1,45 +1,45 @@
-# Backward Compatibility: SonarQube Version Support
+# Backward Compatibility: SonarQube Server Version Support
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-CloudVoyager supports migrating from **SonarQube 9.9 LTS** through **SonarQube 2025.1** (and newer) to SonarCloud. This document explains how the tool handles the differences between SonarQube versions.
+CloudVoyager supports migrating from **SonarQube Server 9.9 LTS** through **SonarQube Server 2025.1** (and newer) to SonarQube Cloud. This document explains how the tool handles the differences between SonarQube Server versions.
 
 ## Background
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Different SonarQube versions introduced significant API and taxonomy changes:
+Different SonarQube Server versions introduced significant API and taxonomy changes:
 
-**SonarQube 10.0** introduced the **Clean Code taxonomy**:
+**SonarQube Server 10.0** introduced the **Clean Code taxonomy**:
 - **Clean Code Attributes** (e.g., `CONVENTIONAL`, `LOGICAL`, `TRUSTWORTHY`) — classify *why* code is problematic
 - **Software Qualities** (`MAINTAINABILITY`, `RELIABILITY`, `SECURITY`) — classify *what* is affected
 - **Impact Severities** (`LOW`, `MEDIUM`, `HIGH`, `BLOCKER`) — classify *how severe* the impact is
 
-**SonarQube 10.4** introduced a **new issue lifecycle**:
+**SonarQube Server 10.4** introduced a **new issue lifecycle**:
 - Replaced the `statuses` API parameter with `issueStatuses`
 - Removed `REOPENED`, `RESOLVED`, and `CLOSED` statuses
 - Added `ACCEPTED` (replacing "Won't Fix") and `FIXED` statuses
 
-**SonarQube 2025.1** removed web services deprecated in 8.x/9.x, and continues the migration to Web API V2.
+**SonarQube Server 2025.1** removed web services deprecated in 8.x/9.x, and continues the migration to Web API V2.
 
-**SonarQube 9.9 LTS** uses the older taxonomy:
+**SonarQube Server 9.9 LTS** uses the older taxonomy:
 - **Issue Types** (`CODE_SMELL`, `BUG`, `VULNERABILITY`, `SECURITY_HOTSPOT`)
 - **Severities** (`INFO`, `MINOR`, `MAJOR`, `CRITICAL`, `BLOCKER`)
 - Legacy `statuses` parameter with `OPEN`, `CONFIRMED`, `REOPENED`, `RESOLVED`, `CLOSED`
 
-SonarCloud (always the latest version) uses the new Clean Code taxonomy. CloudVoyager bridges these gaps automatically.
+SonarQube Cloud (always the latest version) uses the new Clean Code taxonomy. CloudVoyager bridges these gaps automatically.
 
 ## Architecture: Pipeline-Per-Version
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Instead of a single codebase with runtime version checks, CloudVoyager uses a **pipeline-per-version** architecture. Each supported SonarQube version range has its own self-contained pipeline under `src/pipelines/`:
+Instead of a single codebase with runtime version checks, CloudVoyager uses a **pipeline-per-version** architecture. Each supported SonarQube Server version range has its own self-contained pipeline under `src/pipelines/`:
 
 ```
 src/
 ├── version-router.js              # Detects SQ version, loads correct pipeline
 ├── pipelines/
-│   ├── sq-9.9/                    # SonarQube 9.9 LTS
-│   ├── sq-10.0/                   # SonarQube 10.0–10.3
-│   ├── sq-10.4/                   # SonarQube 10.4–10.8
-│   └── sq-2025/                   # SonarQube 2025.1+
+│   ├── sq-9.9/                    # SonarQube Server 9.9 LTS
+│   ├── sq-10.0/                   # SonarQube Server 10.0–10.3
+│   ├── sq-10.4/                   # SonarQube Server 10.4–10.8
+│   └── sq-2025/                   # SonarQube Server 2025.1+
 └── shared/                        # Version-independent code (utils, state, config, etc.)
 ```
 
@@ -49,7 +49,7 @@ Each pipeline directory contains a complete set of modules (60–66 JS files eac
 sq-{version}/
 ├── transfer-pipeline.js           # Single-project transfer orchestrator
 ├── migrate-pipeline.js            # Full multi-org migration orchestrator
-├── sonarqube/                     # SonarQube API client, models, extractors
+├── sonarqube/                     # SonarQube Server API client, models, extractors
 │   ├── api-client.js
 │   ├── models.js
 │   ├── api/                       # API method modules
@@ -59,7 +59,7 @@ sq-{version}/
 │   ├── encoder.js
 │   ├── build-*.js
 │   └── schema/                    # .proto definitions
-├── sonarcloud/                    # SonarCloud API client, uploader, migrators
+├── sonarcloud/                    # SonarQube Cloud API client, uploader, migrators
 │   ├── api-client.js
 │   ├── uploader.js
 │   ├── rule-enrichment.js
@@ -72,12 +72,12 @@ sq-{version}/
     └── results.js
 ```
 
-**No runtime version checks exist within any pipeline.** Each pipeline has its behavior hardcoded for its target SonarQube version range. This eliminates branching logic and makes each pipeline easier to understand and maintain.
+**No runtime version checks exist within any pipeline.** Each pipeline has its behavior hardcoded for its target SonarQube Server version range. This eliminates branching logic and makes each pipeline easier to understand and maintain.
 
 ## How Version Routing Works
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-1. `version-router.js` makes a lightweight `GET /api/system/status` call to detect the SonarQube server version
+1. `version-router.js` makes a lightweight `GET /api/system/status` call to detect the SonarQube Server version
 2. `resolvePipelineId()` maps the parsed version to a pipeline folder:
    - `major >= 2025` → `sq-2025`
    - `(major === 10 && minor >= 4) || (major > 10 && major < 2025)` → `sq-10.4` (covers 10.4–10.8 and any hypothetical 11.x–2024.x versions)
@@ -98,14 +98,14 @@ If version detection fails (e.g., network error), the router falls back to the `
 |----------|--------|---------|---------|---------|
 | Issue search param | `statuses` (legacy) | `statuses` (legacy) | `issueStatuses` (modern) | `issueStatuses` (modern) |
 | metricKeys limit | Batch at 15 | Batch at 15 | Batch at 15 | No batching |
-| Clean Code source | SonarCloud enrichment map | Native from SQ | Native from SQ | Native from SQ |
+| Clean Code source | SonarQube Cloud enrichment map | Native from SQ | Native from SQ | Native from SQ |
 | Rule enrichment | Always called | Not needed | Not needed | Not needed |
 | Groups API | `/api/user_groups/search` | Same | Same | Standard (with V2 API fallback) |
 
 ### Issue Lifecycle Differences
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-The issue search API changed significantly across SonarQube versions:
+The issue search API changed significantly across SonarQube Server versions:
 
 | Pipeline | API Parameter | Valid Status Values |
 |----------|--------------|---------------------|
@@ -124,32 +124,32 @@ Each pipeline uses the correct parameter directly — no conditional logic requi
 ### Metric Keys Batching
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-SonarQube 9.9 through 10.8 enforces a limit of **15 metric keys per request** to the measures API. Pipelines `sq-9.9`, `sq-10.0`, and `sq-10.4` batch metric key requests accordingly.
+SonarQube Server 9.9 through 10.8 enforces a limit of **15 metric keys per request** to the measures API. Pipelines `sq-9.9`, `sq-10.0`, and `sq-10.4` batch metric key requests accordingly.
 
-SonarQube 2025.1+ removed this limit, so the `sq-2025` pipeline sends all metric keys in a single request.
+SonarQube Server 2025.1+ removed this limit, so the `sq-2025` pipeline sends all metric keys in a single request.
 
 ### Clean Code Taxonomy Enrichment
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-The `sq-9.9` pipeline fetches the Clean Code taxonomy from SonarCloud because SonarQube 9.9 does not provide it:
+The `sq-9.9` pipeline fetches the Clean Code taxonomy from SonarQube Cloud because SonarQube Server 9.9 does not provide it:
 
 ```
-SonarQube 9.9.0.65466 does not support Clean Code taxonomy (requires 10.0+). Fetching enrichment from SonarCloud...
+SonarQube Server 9.9.0.65466 does not support Clean Code taxonomy (requires 10.0+). Fetching enrichment from SonarQube Cloud...
 Rule enrichment map built: 1,247 rules with Clean Code data
 ```
 
-The `sq-10.0`, `sq-10.4`, and `sq-2025` pipelines read Clean Code data natively from SonarQube — no enrichment fetch needed.
+The `sq-10.0`, `sq-10.4`, and `sq-2025` pipelines read Clean Code data natively from SonarQube Server — no enrichment fetch needed.
 
-### Rule Enrichment from SonarCloud (sq-9.9 only)
+### Rule Enrichment from SonarQube Cloud (sq-9.9 only)
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-For SonarQube 9.9, the `rule-enrichment.js` module in the `sq-9.9` pipeline:
+For SonarQube Server 9.9, the `rule-enrichment.js` module in the `sq-9.9` pipeline:
 
-1. For each SonarCloud quality profile, queries `/api/rules/search` with `f=cleanCodeAttribute,impacts`
+1. For each SonarQube Cloud quality profile, queries `/api/rules/search` with `f=cleanCodeAttribute,impacts`
 2. Builds a **rule enrichment map** — a lookup table mapping rule keys (e.g., `javascript:S1234`) to their Clean Code attributes and impacts
-3. When building the scanner report, rules and issues are enriched with the correct Clean Code data from SonarCloud
+3. When building the scanner report, rules and issues are enriched with the correct Clean Code data from SonarQube Cloud
 
-This means the migrated data in SonarCloud will have the **exact same** Clean Code classification as if it had been scanned natively.
+This means the migrated data in SonarQube Cloud will have the **exact same** Clean Code classification as if it had been scanned natively.
 
 ### Fallback Chain (sq-9.9 only)
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -158,7 +158,7 @@ The enrichment follows a two-level fallback:
 
 | Priority | Source | When Used |
 |----------|--------|-----------|
-| 1 | SonarCloud rule enrichment | Rule exists in SC quality profiles |
+| 1 | SonarQube Cloud rule enrichment | Rule exists in SC quality profiles |
 | 2 | Type-based inference | Rule not in SC (external rules) |
 
 **Type-based inference** (last resort) maps the old taxonomy as follows:
@@ -188,13 +188,13 @@ The enrichment follows a two-level fallback:
 | sq-10.4 | `/api/user_groups/search` (standard) |
 | sq-2025 | `/api/user_groups/search` (standard, with Web API V2 fallback) |
 
-SonarQube 2025.1+ began deprecating some legacy Web API endpoints. The `sq-2025` pipeline uses the standard groups API but includes fallback to the V2 API (`/api/v2/authorizations/groups`) if the legacy endpoint is unavailable.
+SonarQube Server 2025.1+ began deprecating some legacy Web API endpoints. The `sq-2025` pipeline uses the standard groups API but includes fallback to the V2 API (`/api/v2/authorizations/groups`) if the legacy endpoint is unavailable.
 
 ### Performance Optimization
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
 - **Transfer pipeline** (`transfer` command): Enrichment map is built once per project transfer (sq-9.9 only)
-- **Migrate pipeline** (`migrate` command): Enrichment map is built **once per SonarCloud organization** and reused across all projects in that org (sq-9.9 only)
+- **Migrate pipeline** (`migrate` command): Enrichment map is built **once per SonarQube Cloud organization** and reused across all projects in that org (sq-9.9 only)
 - **sq-10.0, sq-10.4, sq-2025**: Enrichment fetch is skipped entirely (no extra API calls)
 
 ## Common API Constraints (All Versions)
@@ -220,11 +220,11 @@ These constraints apply across all four pipelines:
 
 All four pipelines support automatic detection and migration of external/plugin issues (e.g., MuleSoft, Checkstyle, PMD):
 
-1. **Auto-detection**: Compares SonarQube rule repositories (`getRuleRepositories()`) against SonarCloud available repositories
-2. **External encoding**: Rules not available in SonarCloud are encoded as `ExternalIssue` + `AdHocRule` protobuf messages in the scanner report
-3. **Display in SonarCloud**: External rules appear as `external_{engineId}:{ruleId}` (e.g., `external_mulesoft:MS058`). Ad-hoc rules do not appear in SC rules search (expected behavior per SC docs).
+1. **Auto-detection**: Compares SonarQube Server rule repositories (`getRuleRepositories()`) against SonarQube Cloud available repositories
+2. **External encoding**: Rules not available in SonarQube Cloud are encoded as `ExternalIssue` + `AdHocRule` protobuf messages in the scanner report
+3. **Display in SonarQube Cloud**: External rules appear as `external_{engineId}:{ruleId}` (e.g., `external_mulesoft:MS058`). Ad-hoc rules do not appear in SC rules search (expected behavior per SC docs).
 
-**Critical implementation detail**: The `cleanCodeAttribute` field in `AdHocRule` must be encoded as a **protobuf enum (varint)**, NOT a string. Despite the GitHub proto definition showing `optional string`, the real SonarCloud scanner uses enum encoding. SonarCloud's Compute Engine silently ignores external issues if `cleanCodeAttribute` is string-encoded.
+**Critical implementation detail**: The `cleanCodeAttribute` field in `AdHocRule` must be encoded as a **protobuf enum (varint)**, NOT a string. Despite the GitHub proto definition showing `optional string`, the real SonarQube Cloud scanner uses enum encoding. SonarQube Cloud's Compute Engine silently ignores external issues if `cleanCodeAttribute` is string-encoded.
 
 Clean Code attribute enum values:
 
@@ -245,7 +245,7 @@ Clean Code attribute enum values:
 | `RESPECTFUL` | 13 |
 | `TRUSTWORTHY` | 14 |
 
-The `impacts` and `defaultImpacts` (Impact message) fields are also required for external issues to be accepted by SonarCloud.
+The `impacts` and `defaultImpacts` (Impact message) fields are also required for external issues to be accepted by SonarQube Cloud.
 
 ## Feature Support Matrix
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -277,7 +277,7 @@ All features are supported across all four pipelines:
 Two resilience features apply identically across all four pipelines:
 
 - **Search slicing for 10K+ issues** — Each pipeline's `issues-hotspots.js` calls `fetchWithSlicing` from the shared `src/shared/utils/search-slicer/` utility. A `probe-total.js` helper in each pipeline's `api-client/helpers/` probes the total count with `ps=1`. If the total exceeds 10,000, the date-window bisection algorithm activates automatically.
-- **Fallback rule repositories** — Each pipeline's `getRuleRepositories()` retries 3 times with exponential backoff and falls back to the shared `src/shared/utils/fallback-repos/index.js` (43 known SonarCloud repositories). The `isExternalIssue()` guard in each pipeline uses the fallback set when the live set is empty.
+- **Fallback rule repositories** — Each pipeline's `getRuleRepositories()` retries 3 times with exponential backoff and falls back to the shared `src/shared/utils/fallback-repos/index.js` (43 known SonarQube Cloud repositories). The `isExternalIssue()` guard in each pipeline uses the fallback set when the live set is empty.
 
 ## What Works Identically Across Pipelines
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -303,7 +303,7 @@ These components are shared across all version-specific pipelines (via `src/shar
 ## Usage
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-No special configuration is needed. CloudVoyager detects the SonarQube version automatically and loads the correct pipeline:
+No special configuration is needed. CloudVoyager detects the SonarQube Server version automatically and loads the correct pipeline:
 
 ```bash
 # Works with SQ 9.9, 10.x, 2025.1, or any supported version
@@ -314,7 +314,7 @@ node src/index.js migrate -c config.json
 Use `--verbose` to see detailed logs about version detection and pipeline selection:
 
 ```
-SonarQube server version: 9.9.0.65466 → using pipeline: sq-9.9
+SonarQube Server version: 9.9.0.65466 → using pipeline: sq-9.9
 ```
 
 Use the `test` command to verify connectivity and see which pipeline is selected:
@@ -323,12 +323,12 @@ Use the `test` command to verify connectivity and see which pipeline is selected
 node src/index.js test -c config.json
 ```
 
-## Supported SonarQube Versions
+## Supported SonarQube Server Versions
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
 | Version | Pipeline | Support Level | Notes |
 |---------|----------|--------------|-------|
-| 9.9 LTS | sq-9.9 | Full | Clean Code enriched from SonarCloud; legacy `statuses` param |
+| 9.9 LTS | sq-9.9 | Full | Clean Code enriched from SonarQube Cloud; legacy `statuses` param |
 | 10.0 - 10.3 | sq-10.0 | Full | Native Clean Code taxonomy; legacy `statuses` param with extended values |
 | 10.4 - 10.8 | sq-10.4 | Full | Modern `issueStatuses` param; metric batching at 15 |
 | 2025.1+ | sq-2025 | Full | Modern `issueStatuses` param; no metric batching; V2 API fallbacks |
@@ -337,40 +337,40 @@ node src/index.js test -c config.json
 ## Troubleshooting
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-### "Failed to detect SonarQube version"
+### "Failed to detect SonarQube Server version"
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
 If version detection fails, CloudVoyager falls back to the `sq-9.9` pipeline. This is non-fatal — the migration will proceed. Check:
 
-- SonarQube URL is correct and reachable
-- SonarQube token has sufficient permissions
-- Network connectivity to the SonarQube server
+- SonarQube Server URL is correct and reachable
+- SonarQube Server token has sufficient permissions
+- Network connectivity to the SonarQube Server
 
 ### "Failed to build rule enrichment map"
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
 If the enrichment fetch fails (sq-9.9 pipeline), CloudVoyager falls back to type-based inference. This is non-fatal — the migration will proceed, but Clean Code attributes may be less precise for active rules. Check:
 
-- SonarCloud token has sufficient permissions
-- Network connectivity to SonarCloud
-- Quality profiles exist in SonarCloud for the relevant languages
+- SonarQube Cloud token has sufficient permissions
+- Network connectivity to SonarQube Cloud
+- Quality profiles exist in SonarQube Cloud for the relevant languages
 
 ### Issues appear with generic Clean Code attributes
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
 If migrated issues show `CONVENTIONAL` instead of more specific attributes (like `LOGICAL` or `TRUSTWORTHY`), it means:
 
-1. The rule wasn't found in the SonarCloud enrichment map
+1. The rule wasn't found in the SonarQube Cloud enrichment map
 2. Type-based inference was used as fallback
 
-This is expected for external/plugin rules that don't exist in SonarCloud. For native rules, verify that SonarCloud quality profiles are properly configured for the relevant languages.
+This is expected for external/plugin rules that don't exist in SonarQube Cloud. For native rules, verify that SonarQube Cloud quality profiles are properly configured for the relevant languages.
 
-### External issues not appearing in SonarCloud
+### External issues not appearing in SonarQube Cloud
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
 If external issues are missing after migration:
 
 1. Verify that `cleanCodeAttribute` is encoded as a protobuf enum (varint), not a string
 2. Verify that `impacts` and `defaultImpacts` fields are populated in `AdHocRule` messages
-3. Check SonarCloud CE task logs for silent rejection of malformed external issue messages
-4. Ad-hoc rules will not appear in the SonarCloud rules search — this is expected behavior
+3. Check SonarQube Cloud CE task logs for silent rejection of malformed external issue messages
+4. Ad-hoc rules will not appear in the SonarQube Cloud rules search — this is expected behavior

--- a/docs/bespoke-algorithms.md
+++ b/docs/bespoke-algorithms.md
@@ -20,7 +20,7 @@ This document describes custom, non-trivial algorithms implemented from scratch 
 
 <!-- <section-updated last-updated="2026-01-01T00:00:00Z" updated-by="Claude" /> -->
 
-SonarQube's `/api/issues/search` endpoint caps results at 10,000 items per query. Projects with large issue counts require the response window to be sliced by creation date and results stitched together.
+SonarQube Server's `/api/issues/search` endpoint caps results at 10,000 items per query. Projects with large issue counts require the response window to be sliced by creation date and results stitched together.
 
 ### Algorithm
 
@@ -197,7 +197,7 @@ CloudVoyager checkpoints migration progress so a run can be resumed after any in
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> Each file's changeset protobuf has `changesets[]` (array of `{revision, author, date}`) and `changesetIndexByLine[]` (maps each line to a changeset index). The CE takes **MAX(date)** across an issue's `textRange.startLine..endLine` to determine its creation date.
 
-Without backdating, all issues in a migrated project would get the same creation date (the extraction timestamp). The goal is **1:1 accuracy** — each issue's creation date in SonarCloud should match its original `creationDate` from SonarQube. A 5K-per-day safety split handles rare cases where a single calendar day has >5K issues (SonarCloud's ES visualization cap is 10K per date bucket).
+Without backdating, all issues in a migrated project would get the same creation date (the extraction timestamp). The goal is **1:1 accuracy** — each issue's creation date in SonarQube Cloud should match its original `creationDate` from SonarQube Server. A 5K-per-day safety split handles rare cases where a single calendar day has >5K issues (SonarQube Cloud's ES visualization cap is 10K per date bucket).
 
 ### Algorithm
 
@@ -280,7 +280,7 @@ Legacy files (unchanged, no longer used by backdateChangesets):
 
 <!-- <section-updated last-updated="2026-01-01T00:00:00Z" updated-by="Claude" /> -->
 
-SonarCloud's Compute Engine accepts analysis reports encoded as protobuf-over-zip, matching the format produced by SonarScanner. CloudVoyager reconstructs this format without running an actual scan.
+SonarQube Cloud's Compute Engine accepts analysis reports encoded as protobuf-over-zip, matching the format produced by SonarScanner. CloudVoyager reconstructs this format without running an actual scan.
 
 ### Encoding Pipeline
 
@@ -297,4 +297,4 @@ The protobuf schemas were reverse-engineered from the SonarScanner source and ar
 ### Implementation
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
-`src/pipelines/<version>/sonarcloud/api/` — SonarCloud upload client
+`src/pipelines/<version>/sonarcloud/api/` — SonarQube Cloud upload client

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,7 +56,7 @@ See `examples/config.example.json` for a complete example.
 
 Used by: `migrate`, `sync-metadata`, `verify`
 
-Performs a full migration from a SonarQube server to one or more SonarCloud organizations, including projects, quality gates, quality profiles, groups, permissions, portfolios, and more. The `sync-metadata` command uses the same config to sync only issue and hotspot metadata for already-migrated projects. The `verify` command uses the same config to compare SonarQube and SonarCloud data and confirm migration completeness.
+Performs a full migration from a SonarQube Server to one or more SonarQube Cloud organizations, including projects, quality gates, quality profiles, groups, permissions, portfolios, and more. The `sync-metadata` command uses the same config to sync only issue and hotspot metadata for already-migrated projects. The `verify` command uses the same config to compare SonarQube Server and SonarQube Cloud data and confirm migration completeness.
 
 ```json
 {
@@ -119,37 +119,37 @@ See `examples/migrate-config.example.json` for a complete example.
 ## 🔧 Configuration Options
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
-### SonarQube Settings
+### SonarQube Server Settings
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `url` | Yes | SonarQube server URL |
-| `token` | Yes | SonarQube API token (or set via `SONARQUBE_TOKEN` env var) |
+| `url` | Yes | SonarQube Server URL |
+| `token` | Yes | SonarQube Server API token (or set via `SONARQUBE_TOKEN` env var) |
 | `projectKey` | For `transfer` only | Project key to export (not needed for `migrate`) |
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
-### SonarCloud Settings (Single Org)
+### SonarQube Cloud Settings (Single Org)
 
 Used by `transfer`, `test`, `validate`, `status`, `reset`.
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `url` | No | SonarCloud server URL (default: `https://sonarcloud.io`) |
-| `token` | Yes | SonarCloud API token (or set via `SONARCLOUD_TOKEN` env var) |
-| `organization` | Yes | SonarCloud organization key |
-| `projectKey` | For `transfer` only | Destination project key. The display name is automatically carried over from SonarQube |
+| `url` | No | SonarQube Cloud server URL (default: `https://sonarcloud.io`) |
+| `token` | Yes | SonarQube Cloud API token (or set via `SONARCLOUD_TOKEN` env var) |
+| `organization` | Yes | SonarQube Cloud organization key |
+| `projectKey` | For `transfer` only | Destination project key. The display name is automatically carried over from SonarQube Server |
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
-### SonarCloud Settings (Multi-Org)
+### SonarQube Cloud Settings (Multi-Org)
 
 Used by `migrate`, `sync-metadata`. Instead of a single org, you provide an array of target organizations.
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `organizations[].key` | Yes | SonarCloud organization key |
-| `organizations[].token` | Yes | SonarCloud API token for this org |
-| `organizations[].url` | No | SonarCloud server URL. Use `https://sonarcloud.io` (EU, default) or `https://sonarqube.us` (US). In the Desktop app an EU/US radio button sets this automatically. |
-| `enterprise.key` | Optional | SonarCloud enterprise key. Required only for portfolio migration via V2 API. If absent, portfolio migration is gracefully skipped and the migration continues normally. |
+| `organizations[].key` | Yes | SonarQube Cloud organization key |
+| `organizations[].token` | Yes | SonarQube Cloud API token for this org |
+| `organizations[].url` | No | SonarQube Cloud server URL. Use `https://sonarcloud.io` (EU, default) or `https://sonarqube.us` (US). In the Desktop app an EU/US radio button sets this automatically. |
+| `enterprise.key` | Optional | SonarQube Cloud enterprise key. Required only for portfolio migration via V2 API. If absent, portfolio migration is gracefully skipped and the migration continues normally. |
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ### Transfer Settings
@@ -172,7 +172,7 @@ The `transfer.checkpoint` block controls the pause/resume behavior. All settings
 | `enabled` | `true` | Enable checkpoint journal for pause/resume support |
 | `cacheExtractions` | `true` | Cache extraction results to disk for faster resume |
 | `cacheMaxAgeDays` | `7` | Maximum age of extraction cache files in days before auto-purge |
-| `strictResume` | `false` | Fail on SonarQube version mismatch when resuming (default: warn only) |
+| `strictResume` | `false` | Fail on SonarQube Server version mismatch when resuming (default: warn only) |
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ### Migrate Settings
@@ -182,15 +182,15 @@ The `transfer.checkpoint` block controls the pause/resume behavior. All settings
 | `outputDir` | `./migration-output` | Directory for mapping CSVs and server info output |
 | `skipIssueMetadataSync` | `false` | Skip syncing issue metadata (statuses, assignments, comments, tags) |
 | `skipHotspotMetadataSync` | `false` | Skip syncing hotspot metadata (statuses, comments) |
-| `skipQualityProfileSync` | `false` | Skip syncing quality profiles (projects use default SonarCloud profiles) |
+| `skipQualityProfileSync` | `false` | Skip syncing quality profiles (projects use default SonarQube Cloud profiles) |
 | `dryRun` | `false` | Extract and generate mappings without migrating |
 
-> **Project key behavior (migrate command):** By default, the `migrate` command uses the original SonarQube project key on SonarCloud. If the key is already taken by another SonarCloud organization, the tool falls back to a prefixed key (`{org}_{key}`) and logs a warning. Key conflicts are listed in the migration report.
+> **Project key behavior (migrate command):** By default, the `migrate` command uses the original SonarQube Server project key on SonarQube Cloud. If the key is already taken by another SonarQube Cloud organization, the tool falls back to a prefixed key (`{org}_{key}`) and logs a warning. Key conflicts are listed in the migration report.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ### Rate Limit Settings
 
-Controls retry and throttling behavior for SonarCloud API requests. By default, retries are enabled (`maxRetries: 3`) but request throttling is off (`minRequestInterval: 0`). Add a `rateLimit` section to any config file to customize.
+Controls retry and throttling behavior for SonarQube Cloud API requests. By default, retries are enabled (`maxRetries: 3`) but request throttling is off (`minRequestInterval: 0`). Add a `rateLimit` section to any config file to customize.
 
 ```json
 {
@@ -204,7 +204,7 @@ Controls retry and throttling behavior for SonarCloud API requests. By default, 
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `maxRetries` | `3` | Max retry attempts when SonarCloud returns 503 or 429. Set to `0` to disable retries. Retries use exponential backoff (delay doubles each attempt). |
+| `maxRetries` | `3` | Max retry attempts when SonarQube Cloud returns 503 or 429. Set to `0` to disable retries. Retries use exponential backoff (delay doubles each attempt). |
 | `baseDelay` | `1000` | Initial delay in ms before the first retry. Doubles each retry: 1000ms → 2000ms → 4000ms → etc. Only applies when `maxRetries` > 0. |
 | `minRequestInterval` | `0` | Minimum ms to wait between POST (write) requests. Set to `0` to disable throttling. Values like `100`–`200` help avoid triggering rate limits during high-volume operations. |
 
@@ -245,10 +245,10 @@ Controls CPU, memory, and concurrency tuning. Add a `performance` section to any
 | `autoTune` | `false` | Auto-detect CPU and RAM and set optimal values. When enabled, uses 75% of total RAM (max 16GB) and scales concurrency based on CPU cores. Explicit settings override auto-tuned values. |
 | `maxConcurrency` | `64` | General concurrency limit for parallel I/O operations (1–64) |
 | `maxMemoryMB` | `8192` | Max heap size in MB. Set to `0` for Node.js default. The tool auto-restarts with the increased heap size when needed. |
-| `sourceExtraction.concurrency` | `50` | Max concurrent source file fetches from SonarQube (1–50) |
-| `hotspotExtraction.concurrency` | `50` | Max concurrent hotspot detail fetches from SonarQube (1–50) |
-| `issueSync.concurrency` | `20` | Max concurrent issue metadata sync operations to SonarCloud (1–20) |
-| `hotspotSync.concurrency` | `20` | Max concurrent hotspot sync operations to SonarCloud (1–20) |
+| `sourceExtraction.concurrency` | `50` | Max concurrent source file fetches from SonarQube Server (1–50) |
+| `hotspotExtraction.concurrency` | `50` | Max concurrent hotspot detail fetches from SonarQube Server (1–50) |
+| `issueSync.concurrency` | `20` | Max concurrent issue metadata sync operations to SonarQube Cloud (1–20) |
+| `hotspotSync.concurrency` | `20` | Max concurrent hotspot sync operations to SonarQube Cloud (1–20) |
 | `projectMigration.concurrency` | `8` | Max concurrent project migrations (1–8) |
 
 **Auto-tune defaults:** When `autoTune` is enabled (or `--auto-tune` CLI flag is used), the following values are calculated based on your hardware:
@@ -286,7 +286,7 @@ Explicit config values or CLI flags override auto-tuned values.
 | `--dry-run` | Extract data and generate mapping CSVs without migrating | `migrate` |
 | `--skip-issue-metadata-sync` | Skip syncing issue metadata (statuses, assignments, comments, tags) | `migrate`, `sync-metadata` |
 | `--skip-hotspot-metadata-sync` | Skip syncing hotspot metadata (statuses, comments) | `migrate`, `sync-metadata` |
-| `--skip-quality-profile-sync` | Skip syncing quality profiles (projects use default SonarCloud profiles) | `migrate`, `sync-metadata` |
+| `--skip-quality-profile-sync` | Skip syncing quality profiles (projects use default SonarQube Cloud profiles) | `migrate`, `sync-metadata` |
 
 **Selective migration flag:**
 
@@ -335,14 +335,14 @@ Multiple components can be combined: `--only scan-data,quality-gates,permissions
 
 | Variable | Description |
 |----------|-------------|
-| `SONARQUBE_TOKEN` | Override SonarQube token from config |
-| `SONARCLOUD_TOKEN` | Override SonarCloud token from config |
-| `SONARQUBE_URL` | Override SonarQube URL from config |
-| `SONARCLOUD_URL` | Override SonarCloud URL from config |
+| `SONARQUBE_TOKEN` | Override SonarQube Server token from config |
+| `SONARCLOUD_TOKEN` | Override SonarQube Cloud token from config |
+| `SONARQUBE_URL` | Override SonarQube Server URL from config |
+| `SONARCLOUD_URL` | Override SonarQube Cloud URL from config |
 | `LOG_LEVEL` | Set logging level (`debug`, `info`, `warn`, `error`) |
 | `LOG_FILE` | Path to log file (optional) |
 | `MAX_SOURCE_FILES` | Limit number of source files to extract (0 = all) |
-| `SONAR_TOKEN` | SonarCloud token used by the `sonarcloud.yml` GitHub Actions workflow for SAST/SCA scanning of the CloudVoyager repository itself (not used by the CLI) |
+| `SONAR_TOKEN` | SonarQube Cloud token used by the `sonarcloud.yml` GitHub Actions workflow for SAST/SCA scanning of the CloudVoyager repository itself (not used by the CLI) |
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 📜 npm Scripts vs Binary Commands
@@ -411,7 +411,7 @@ For multi-project migrations (`migrate` command), we recommend the following 3-s
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ### Step 1: Dry run — verify everything
 
-Run a dry run first to extract all data, generate mapping CSVs, and validate your config without touching SonarCloud:
+Run a dry run first to extract all data, generate mapping CSVs, and validate your config without touching SonarQube Cloud:
 
 ```bash
 # npm
@@ -436,7 +436,7 @@ npm run migrate:skip-all-metadata:auto-tune
 ./cloudvoyager migrate -c migrate-config.json --verbose --skip-issue-metadata-sync --skip-hotspot-metadata-sync --auto-tune
 ```
 
-Skipping metadata during the main migration avoids SonarCloud rate limiting (503 errors) that can occur during high-volume issue/hotspot sync.
+Skipping metadata during the main migration avoids SonarQube Cloud rate limiting (503 errors) that can occur during high-volume issue/hotspot sync.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ### Step 3: Sync metadata separately
@@ -484,7 +484,7 @@ The journal records:
 - Which extraction phases have completed (metrics, issues, sources, etc.)
 - Per-branch transfer status (completed, in-progress, pending)
 - Upload deduplication data (prevents duplicate CE tasks after crashes)
-- Session fingerprint (SonarQube version, URL, project key) for resume validation
+- Session fingerprint (SonarQube Server version, URL, project key) for resume validation
 
 **Key behaviors:**
 - **Automatic resume**: Running the same `transfer` command after an interruption automatically resumes from the last checkpoint
@@ -529,5 +529,5 @@ Additional files created during transfer:
 | 2026-02-19 | npm Scripts | Expanded script table with all commands |
 | 2026-02-18 | Performance Settings | Auto-tune feature added |
 | 2026-02-17 | Transfer-All, Migrate, Rate Limit, Workflow | Migration engine config options |
-| 2026-02-16 | Single Project, SonarQube, Env Vars, State | Core configuration system |
+| 2026-02-16 | Single Project, SonarQube Server, Env Vars, State | Core configuration system |
 -->

--- a/docs/design-review-regression-testing.md
+++ b/docs/design-review-regression-testing.md
@@ -51,5 +51,5 @@ PASS -- no YAGNI violations.
 
 | ID | Issue | Suggested Fix |
 |----|-------|---------------|
-| 5.1 | `cv-test-malformed` requires Unicode keys and empty names that SonarQube API rejects | Specify DB-level seeding or descope to API-achievable scenarios only |
+| 5.1 | `cv-test-malformed` requires Unicode keys and empty names that SonarQube Server API rejects | Specify DB-level seeding or descope to API-achievable scenarios only |
 | 5.2 | `max-parallel: 8` may still exceed SQC rate limits with no cross-job throttling | Lower to 4, add staggered startup delays, or use separate SQC orgs |

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -33,7 +33,7 @@ Download the latest release from the [GitHub Releases](https://github.com/your-o
 
 On launch, the Welcome screen presents the available workflows:
 
-- **Transfer One Project** — Migrate a single project from SonarQube to SonarCloud
+- **Transfer One Project** — Migrate a single project from SonarQube Server to SonarQube Cloud
 - **Move All Projects & Settings** — Full organization migration (projects, quality gates, profiles, permissions, etc.)
 - **Verify Migration Results** — Compare data between source and destination after migration
 - **Sync Settings & Policies** — Update coding rules, policies, and permissions without re-migrating code data
@@ -45,7 +45,7 @@ On launch, the Welcome screen presents the available workflows:
 
 Each workflow guides you through a series of screens:
 
-1. **Connection setup** — Enter SonarQube and SonarCloud URLs and tokens
+1. **Connection setup** — Enter SonarQube Server and SonarQube Cloud URLs and tokens
 2. **Options** — Configure transfer mode, branch selection, and other settings
 3. **Review** — Confirm all settings before starting
 4. **Start** — Kick off the migration and watch live logs
@@ -60,8 +60,8 @@ The live log viewer shows migration progress in real-time with a timer, cancel b
 
 | Step | Description |
 |------|-------------|
-| 1. SonarQube Connection | Enter URL and token for the source SonarQube instance |
-| 2. SonarCloud Connection | Enter URL, token, organization, and project key for the target. An **EU / US radio button** selects the SonarQube Cloud instance (`sonarcloud.io` vs `sonarqube.us`) |
+| 1. SonarQube Server Connection | Enter URL and token for the source SonarQube Server instance |
+| 2. SonarQube Cloud Connection | Enter URL, token, organization, and project key for the target. An **EU / US radio button** selects the SonarQube Cloud instance (`sonarcloud.io` vs `sonarqube.us`) |
 | 3. Transfer Settings | Choose transfer mode (full/incremental), batch size, branch options. The "More Settings (Advanced)" section is collapsed by default (click the gear icon to expand) |
 | 4. Review & Start | Review all settings and begin the transfer |
 
@@ -70,8 +70,8 @@ The live log viewer shows migration progress in real-time with a timer, cancel b
 
 | Step | Description |
 |------|-------------|
-| 1. SonarQube Connection | Enter URL and admin token for the source SonarQube instance |
-| 2. SonarCloud Organizations | Add or remove target SonarCloud organizations with their tokens. Each organization entry includes an **EU / US radio button** to select the SonarQube Cloud instance (`sonarcloud.io` vs `sonarqube.us`) |
+| 1. SonarQube Server Connection | Enter URL and admin token for the source SonarQube Server instance |
+| 2. SonarQube Cloud Organizations | Add or remove target SonarQube Cloud organizations with their tokens. Each organization entry includes an **EU / US radio button** to select the SonarQube Cloud instance (`sonarcloud.io` vs `sonarqube.us`) |
 | 3. Migration Settings | Configure output directory, dry run, included/excluded projects. The "Choose What to Migrate" and "More Settings (Advanced)" sections are collapsed by default to reduce clutter (click the shield or gear icon to expand) |
 | 4. Review & Start | Review all settings and begin the full migration |
 
@@ -82,8 +82,8 @@ The live log viewer shows migration progress in real-time with a timer, cancel b
 
 | Step | Description |
 |------|-------------|
-| 1. SonarQube Connection | Enter URL and token for the source SonarQube instance |
-| 2. SonarCloud Organizations | Add target SonarCloud organizations to verify against |
+| 1. SonarQube Server Connection | Enter URL and token for the source SonarQube Server instance |
+| 2. SonarQube Cloud Organizations | Add target SonarQube Cloud organizations to verify against |
 | 3. Review & Start | Review settings and begin verification |
 
 ### Sync Metadata Config (3 steps)
@@ -91,14 +91,14 @@ The live log viewer shows migration progress in real-time with a timer, cancel b
 
 | Step | Description |
 |------|-------------|
-| 1. SonarQube Connection | Enter URL and token for the source SonarQube instance |
-| 2. SonarCloud Organizations | Add target SonarCloud organizations for metadata sync |
+| 1. SonarQube Server Connection | Enter URL and token for the source SonarQube Server instance |
+| 2. SonarQube Cloud Organizations | Add target SonarQube Cloud organizations for metadata sync |
 | 3. Review & Start | Review settings and begin metadata synchronization |
 
 ### Other Screens
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-- **Connection Test** — Runs the `test` command to verify connectivity to both SonarQube and SonarCloud
+- **Connection Test** — Runs the `test` command to verify connectivity to both SonarQube Server and SonarQube Cloud
 - **Execution** — Live log viewer with elapsed timer, cancel button, and status badge (running/success/failed)
 
 ![Live Migration Progress](screenshots/migrate_progress.png)

--- a/docs/dry-run-csv-reference.md
+++ b/docs/dry-run-csv-reference.md
@@ -13,16 +13,16 @@ The `--dry-run` flag generates 9 exhaustive CSV files in `migration-output/mappi
 
 ```
 1. cloudvoyager migrate -c config.json --dry-run
-   -> Extracts all data from SonarQube
+   -> Extracts all data from SonarQube Server
    -> Generates exhaustive CSVs in migration-output/mappings/
    -> Prints summary + instructions
-   -> Stops (no SonarCloud changes)
+   -> Stops (no SonarQube Cloud changes)
 
 2. Review and edit CSVs (set Include=no to exclude resources)
 
 3. cloudvoyager migrate -c config.json
    -> Detects existing CSVs, reads them into memory BEFORE wiping output dir
-   -> Re-extracts from SonarQube, applies CSV overrides
+   -> Re-extracts from SonarQube Server, applies CSV overrides
    -> Migrates using filtered data
 
 4. If interrupted, re-run the same command to resume from the last checkpoint.
@@ -53,7 +53,7 @@ Every CSV has an `Include` column as the first field. Values are case-insensitiv
 | 6 | `portfolio-mappings.csv` | Portfolios and member projects (parent/child) | Include |
 | 7 | `template-mappings.csv` | Permission templates and assignments (parent/child) | Include |
 | 8 | `global-permissions.csv` | Group-level permission assignments | Include |
-| 9 | `user-mappings.csv` | SonarQube-to-SonarCloud user login mapping | Include, SonarCloud Login |
+| 9 | `user-mappings.csv` | SonarQube Server-to-SonarQube Cloud user login mapping | Include, SonarQube Cloud Login |
 
 ---
 
@@ -65,10 +65,10 @@ One row per branch per project. The main branch is listed first for each project
 | Column | Editable | Description |
 |--------|----------|-------------|
 | Include | Yes | Set to `no` to exclude this branch. Setting `no` on the main branch excludes the **entire project** |
-| Project Key | Read-only | SonarQube project key |
+| Project Key | Read-only | SonarQube Server project key |
 | Project Name | Read-only | Project display name |
 | Branch | Read-only | Branch name (main branch listed first) |
-| Target Organization | Read-only | SonarCloud organization key |
+| Target Organization | Read-only | SonarQube Cloud organization key |
 | ALM Platform | Read-only | DevOps binding (github, gitlab, etc.) |
 | Repository | Read-only | Repository identifier |
 | Monorepo | Read-only | Whether project is part of a monorepo |
@@ -95,7 +95,7 @@ One row per organization binding group.
 | Column | Editable | Description |
 |--------|----------|-------------|
 | Include | Yes | Set to `no` to exclude |
-| Target Organization | Read-only | SonarCloud organization key |
+| Target Organization | Read-only | SonarQube Cloud organization key |
 | Binding Group | Read-only | DevOps binding group identifier |
 | ALM Platform | Read-only | DevOps platform |
 | Projects Count | Read-only | Number of projects in this group |
@@ -112,7 +112,7 @@ One row per group.
 | Description | Read-only | Group description |
 | Members Count | Read-only | Number of members |
 | Is Default | Read-only | Whether this is a default group |
-| Target Organization | Read-only | Target SonarCloud organization |
+| Target Organization | Read-only | Target SonarQube Cloud organization |
 
 ### profile-mappings.csv
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -128,12 +128,12 @@ One row per quality profile.
 | Is Built-In | Read-only | Whether this is a built-in profile |
 | Parent | Read-only | Parent profile name (if inherited) |
 | Active Rules | Read-only | Number of active rules |
-| Target Organization | Read-only | Target SonarCloud organization |
+| Target Organization | Read-only | Target SonarQube Cloud organization |
 
 ### gate-mappings.csv
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-One row per quality gate. Conditions are always migrated as-is from SonarQube — they cannot be modified via the CSV.
+One row per quality gate. Conditions are always migrated as-is from SonarQube Server — they cannot be modified via the CSV.
 
 | Column | Editable | Description |
 |--------|----------|-------------|
@@ -142,7 +142,7 @@ One row per quality gate. Conditions are always migrated as-is from SonarQube �
 | Is Default | Read-only | Whether this is the default gate |
 | Is Built-In | Read-only | Whether this is a built-in gate |
 | Conditions Count | Read-only | Number of conditions on this gate |
-| Target Organization | Read-only | Target SonarCloud organization |
+| Target Organization | Read-only | Target SonarQube Cloud organization |
 
 **Example:**
 ```csv
@@ -168,7 +168,7 @@ Uses a **parent/child row pattern**. Portfolio header rows have empty member fie
 | Visibility | Read-only | *(header row only)* Portfolio visibility |
 | Member Project Key | Read-only | *(member row)* Project key |
 | Member Project Name | Read-only | *(member row)* Project name |
-| Target Organization | Read-only | Target SonarCloud organization |
+| Target Organization | Read-only | Target SonarQube Cloud organization |
 
 ### template-mappings.csv (Parent/Child Pattern)
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -183,7 +183,7 @@ Uses a **parent/child row pattern**. Template header rows have empty permission 
 | Key Pattern | Read-only | *(header row only)* Project key pattern regex |
 | Permission Key | Read-only | *(permission row)* Permission key (e.g., `admin`, `codeviewer`) |
 | Group Name | Read-only | *(permission row)* Group that has this permission |
-| Target Organization | Read-only | Target SonarCloud organization |
+| Target Organization | Read-only | Target SonarQube Cloud organization |
 
 ### global-permissions.csv
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -199,20 +199,20 @@ One row per group+permission combination.
 ### user-mappings.csv
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-One row per unique SonarQube issue assignee, sorted by issue count (descending). This CSV enables mapping SonarQube usernames to SonarCloud logins, which typically differ because SonarCloud uses SSO/GitHub authentication.
+One row per unique SonarQube Server issue assignee, sorted by issue count (descending). This CSV enables mapping SonarQube Server usernames to SonarQube Cloud logins, which typically differ because SonarQube Cloud uses SSO/GitHub authentication.
 
 | Column | Editable | Description |
 |--------|----------|-------------|
 | Include | Yes | Set to `no` to skip assignment for this user entirely |
-| SonarQube Login | Read-only | Username/login from SonarQube |
-| SonarCloud Login | **Yes** | Fill in the corresponding SonarCloud login for this user |
-| Display Name | Read-only | User's display name from SonarQube (for identification) |
-| Email | Read-only | User's email from SonarQube (for identification) |
+| SonarQube Server Login | Read-only | Username/login from SonarQube Server |
+| SonarQube Cloud Login | **Yes** | Fill in the corresponding SonarQube Cloud login for this user |
+| Display Name | Read-only | User's display name from SonarQube Server (for identification) |
+| Email | Read-only | User's email from SonarQube Server (for identification) |
 | Issue Count | Read-only | Total number of issues assigned to this user across all projects |
 
 **Example:**
 ```csv
-Include,SonarQube Login,SonarCloud Login,Display Name,Email,Issue Count
+Include,SonarQube Server Login,SonarQube Cloud Login,Display Name,Email,Issue Count
 yes,john.doe,john-doe-github,John Doe,john@example.com,42
 yes,jane.smith,jsmith,Jane Smith,jane@example.com,15
 no,service-account,,Service Account,,3
@@ -220,10 +220,10 @@ yes,dev.user,,Dev User,dev@example.com,1
 ```
 
 In this example:
-- `john.doe` will be mapped to `john-doe-github` in SonarCloud
-- `jane.smith` will be mapped to `jsmith` in SonarCloud
+- `john.doe` will be mapped to `john-doe-github` in SonarQube Cloud
+- `jane.smith` will be mapped to `jsmith` in SonarQube Cloud
 - `service-account` is excluded — its issues will not be assigned to anyone
-- `dev.user` has no SonarCloud Login filled in — assignment will be attempted with the original SQ login `dev.user` (current default behavior)
+- `dev.user` has no SonarQube Cloud Login filled in — assignment will be attempted with the original SQ login `dev.user` (current default behavior)
 
 **Note:** The Display Name and Email columns are provided to help identify users — they are not used during migration.
 
@@ -252,9 +252,9 @@ In `group-mappings.csv`, set `Include` to `no` for the group row.
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 In `template-mappings.csv`, set `Include` to `no` on the specific permission row (not the template header).
 
-### Map a SonarQube user to a SonarCloud user
+### Map a SonarQube Server user to a SonarQube Cloud user
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
-In `user-mappings.csv`, fill in the `SonarCloud Login` column with the user's SonarCloud login (e.g., their GitHub username).
+In `user-mappings.csv`, fill in the `SonarQube Cloud Login` column with the user's SonarQube Cloud login (e.g., their GitHub username).
 
 ### Skip assignment for a service account
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -274,7 +274,7 @@ The shared `csv-entity-filters.js` module (`src/shared/mapping/csv-entity-filter
 
 - CSVs are RFC 4180 compliant. Fields containing commas, quotes, or newlines are properly quoted.
 - Running `--dry-run` again will regenerate fresh CSVs, overwriting any edits.
-- If CSV references entities that no longer exist in SonarQube (e.g., a project was deleted between dry-run and full run), a warning is logged and the reference is skipped.
+- If CSV references entities that no longer exist in SonarQube Server (e.g., a project was deleted between dry-run and full run), a warning is logged and the reference is skipped.
 - Gate names, project keys, and group names are matched **case-sensitively**.
 - If a migration is interrupted mid-run, re-running the same command resumes from the last checkpoint. Already-migrated projects and resources are skipped.
 

--- a/docs/key-capabilities.md
+++ b/docs/key-capabilities.md
@@ -326,6 +326,7 @@ For each issue in SonarQube, the sync engine:
    - `ACCEPTED` → `accept`
    - `FALSE-POSITIVE` → `falsepositive`
    - `WONTFIX` → `wontfix`
+   - `IN_SANDBOX` (SonarQube 2025+) → no transition; the issue stays `OPEN` on SonarCloud because there is no equivalent state. See [Troubleshooting](./troubleshooting.md) for details.
 3. **Assigns** the issue to the corresponding user, using the `user-mappings.csv` when available:
    - If a SonarCloud Login is mapped in the CSV, uses the mapped login
    - If the user is excluded (`Include=no`), skips assignment

--- a/docs/key-capabilities.md
+++ b/docs/key-capabilities.md
@@ -9,9 +9,9 @@
 
 1. [Executive Summary](#1-executive-summary)
 2. [The Core Innovation: Reverse-Engineered Scanner Protocol](#2-the-core-innovation-reverse-engineered-scanner-protocol)
-3. [Exhaustive SonarQube Data Extraction](#3-exhaustive-sonarqube-data-extraction)
+3. [Exhaustive SonarQube Server Data Extraction](#3-exhaustive-sonarqube-data-extraction)
 4. [Protobuf Report Encoding Engine](#4-protobuf-report-encoding-engine)
-5. [SonarCloud Integration and Upload](#5-sonarcloud-integration-and-upload)
+5. [SonarQube Cloud Integration and Upload](#5-sonarcloud-integration-and-upload)
 6. [Full Organization Migration Pipeline](#6-full-organization-migration-pipeline)
 7. [Issue and Hotspot Metadata Synchronization](#7-issue-and-hotspot-metadata-synchronization)
 8. [Quality Profile and Quality Gate Migration](#8-quality-profile-and-quality-gate-migration)
@@ -40,9 +40,9 @@
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ## 1. Executive Summary
 
-CloudVoyager is a CLI tool that migrates complete SonarQube installations to SonarCloud **without requiring a single line of code to be re-scanned**. It achieves this by reverse-engineering SonarScanner's internal protobuf report protocol and rebuilding the entire data pipeline from the ground up in Node.js.
+CloudVoyager is a CLI tool that migrates complete SonarQube Server installations to SonarQube Cloud **without requiring a single line of code to be re-scanned**. It achieves this by reverse-engineering SonarScanner's internal protobuf report protocol and rebuilding the entire data pipeline from the ground up in Node.js.
 
-Where existing migration approaches require re-running CI/CD scanners against every project (a process that can take days or weeks across large portfolios), CloudVoyager extracts all data directly from SonarQube's API and repackages it into the exact binary format that SonarCloud's Compute Engine expects. The result is a migration that preserves code issues, security hotspots, measures, quality gates, quality profiles, permissions, and project metadata — all in a fraction of the time.
+Where existing migration approaches require re-running CI/CD scanners against every project (a process that can take days or weeks across large portfolios), CloudVoyager extracts all data directly from SonarQube Server's API and repackages it into the exact binary format that SonarQube Cloud's Compute Engine expects. The result is a migration that preserves code issues, security hotspots, measures, quality gates, quality profiles, permissions, and project metadata — all in a fraction of the time.
 
 **Key metrics from production use:**
 - 29 out of 29 projects migrated successfully in a single run (~16 minutes)
@@ -58,7 +58,7 @@ Where existing migration approaches require re-running CI/CD scanners against ev
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### The Problem
 
-SonarCloud's ingestion pipeline is not designed for external data import. It accepts data exclusively through a proprietary protobuf-based scanner report format, submitted to an internal Compute Engine (CE) endpoint. This format is undocumented for external consumers. There is no official migration path from SonarQube to SonarCloud that preserves historical data without re-scanning.
+SonarQube Cloud's ingestion pipeline is not designed for external data import. It accepts data exclusively through a proprietary protobuf-based scanner report format, submitted to an internal Compute Engine (CE) endpoint. This format is undocumented for external consumers. There is no official migration path from SonarQube Server to SonarQube Cloud that preserves historical data without re-scanning.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### The Approach
@@ -70,20 +70,20 @@ CloudVoyager reverse-engineered the scanner report protocol by:
 3. **Identifying encoding conventions** — Discovering that the report uses two distinct encoding styles:
    - **Single-message encoding** for metadata, components, and changesets (one protobuf message per file)
    - **Length-delimited streaming** for issues, measures, and active rules (multiple messages concatenated with varint length prefixes)
-4. **Mapping the ZIP archive structure** — Reconstructing the exact file naming conventions (`metadata.pb`, `component-{ref}.pb`, `issues-{ref}.pb`, `measures-{ref}.pb`, `source-{ref}.txt`, `activerules.pb`, `changesets-{ref}.pb`, `context-props.pb`) expected by SonarCloud's CE endpoint.
+4. **Mapping the ZIP archive structure** — Reconstructing the exact file naming conventions (`metadata.pb`, `component-{ref}.pb`, `issues-{ref}.pb`, `measures-{ref}.pb`, `source-{ref}.txt`, `activerules.pb`, `changesets-{ref}.pb`, `context-props.pb`) expected by SonarQube Cloud's CE endpoint.
 5. **Rebuilding the pipeline in Node.js** — Implementing the entire encode-and-submit pipeline using `protobufjs`, with the proto schemas inlined directly into the bundle so no external schema files are needed at runtime.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Why This Matters
 
-This is a novel capability. No other tool reconstructs SonarScanner's internal binary protocol to inject data into SonarCloud. The approach bypasses the need for source code access entirely — CloudVoyager needs only API-level access to SonarQube to produce a report that SonarCloud treats as a legitimate scanner submission.
+This is a novel capability. No other tool reconstructs SonarScanner's internal binary protocol to inject data into SonarQube Cloud. The approach bypasses the need for source code access entirely — CloudVoyager needs only API-level access to SonarQube Server to produce a report that SonarQube Cloud treats as a legitimate scanner submission.
 
 ---
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
-## 3. Exhaustive SonarQube Data Extraction
+## 3. Exhaustive SonarQube Server Data Extraction
 
-CloudVoyager includes **24 specialized extractor modules** covering every category of data available through SonarQube's REST API. The extraction system is designed to be both exhaustive and resilient — server-wide extraction continues even if individual items fail.
+CloudVoyager includes **24 specialized extractor modules** covering every category of data available through SonarQube Server's REST API. The extraction system is designed to be both exhaustive and resilient — server-wide extraction continues even if individual items fail.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Code and Analysis Data
@@ -129,7 +129,7 @@ CloudVoyager includes **24 specialized extractor modules** covering every catego
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Pagination Handling
 
-The SonarQube API client handles pagination transparently via a `getPaginated` method that auto-fetches all pages and concatenates results. Different endpoints enforce different page size limits (some cap at 100 instead of 500), and each extractor handles this automatically.
+The SonarQube Server API client handles pagination transparently via a `getPaginated` method that auto-fetches all pages and concatenates results. Different endpoints enforce different page size limits (some cap at 100 instead of 500), and each extractor handles this automatically.
 
 ---
 
@@ -141,7 +141,7 @@ The SonarQube API client handles pagination transparently via a `getPaginated` m
 
 CloudVoyager uses a **builder-encoder** architecture that separates message construction from binary serialization:
 
-1. **Builder phase** (`builder.js`, `build-components.js`, `build-issues.js`, `build-measures.js`) — Transforms extracted SonarQube data into structured JavaScript objects matching the protobuf schema. Manages component reference mapping (sequential integer IDs) to maintain relationships between files, issues, and measures.
+1. **Builder phase** (`builder.js`, `build-components.js`, `build-issues.js`, `build-measures.js`) — Transforms extracted SonarQube Server data into structured JavaScript objects matching the protobuf schema. Manages component reference mapping (sequential integer IDs) to maintain relationships between files, issues, and measures.
 
 2. **Encoder phase** (`encoder.js`) — Takes the built messages and serializes them to binary protobuf format using `protobufjs`. Handles both single-message and length-delimited encoding styles.
 
@@ -165,7 +165,7 @@ The `.proto` schema files are loaded as inline text at build time (via esbuild's
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Flat Component Model
 
-Components use a flat structure where all files are direct children of the project root (no intermediate directory components). Line counts are derived from actual source file content rather than SonarQube's measures API, ensuring accuracy.
+Components use a flat structure where all files are direct children of the project root (no intermediate directory components). Line counts are derived from actual source file content rather than SonarQube Server's measures API, ensuring accuracy.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Measure Type Intelligence
@@ -183,7 +183,7 @@ Active rules are filtered to only include languages actually used in the project
 ---
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
-## 5. SonarCloud Integration and Upload
+## 5. SonarQube Cloud Integration and Upload
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Report Packaging
@@ -205,7 +205,7 @@ scanner-report.zip
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Compute Engine Submission
 
-The report is submitted to SonarCloud's CE endpoint as a multipart form upload with:
+The report is submitted to SonarQube Cloud's CE endpoint as a multipart form upload with:
 - The ZIP archive as the report payload
 - Project key and organization context
 - Optional analysis parameters
@@ -213,20 +213,20 @@ The report is submitted to SonarCloud's CE endpoint as a multipart form upload w
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Duplicate Detection via SCM Revision
 
-Each report includes an `scm_revision_id` (git commit hash) in its metadata. SonarCloud uses this to detect and reject duplicate submissions, preventing accidental data duplication across multiple migration runs.
+Each report includes an `scm_revision_id` (git commit hash) in its metadata. SonarQube Cloud uses this to detect and reject duplicate submissions, preventing accidental data duplication across multiple migration runs.
 
 ### Accurate Issue Creation Date Preservation
 
-<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> in SonarCloud. `backdateChangesets()` reads each issue's `creationDate` and maps it to per-line SCM blame dates in the changeset protobuf. The CE takes MAX(date) across an issue's `textRange` lines, so "oldest wins" for overlapping lines ensures accurate creation dates. A safety split handles calendar days with >5K issues (sub-groups with 1-day-spaced synthetic dates, no file splitting). This produces a realistic historical distribution in SonarCloud's creation date facet matching the original SonarQube project history, instead of arbitrary batch-spaced clusters.
+<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> in SonarQube Cloud. `backdateChangesets()` reads each issue's `creationDate` and maps it to per-line SCM blame dates in the changeset protobuf. The CE takes MAX(date) across an issue's `textRange` lines, so "oldest wins" for overlapping lines ensures accurate creation dates. A safety split handles calendar days with >5K issues (sub-groups with 1-day-spaced synthetic dates, no file splitting). This produces a realistic historical distribution in SonarQube Cloud's creation date facet matching the original SonarQube Server project history, instead of arbitrary batch-spaced clusters.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Branch Name Resolution
 
-The tool resolves the main branch name from SonarCloud (not SonarQube) to avoid mismatches where SonarQube uses "main" but SonarCloud expects "master" or vice versa.
+The tool resolves the main branch name from SonarQube Cloud (not SonarQube Server) to avoid mismatches where SonarQube Server uses "main" but SonarQube Cloud expects "master" or vice versa.
 
 ### Multi-Branch Support
 
-<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> by default (`syncAllBranches: true`), with the main branch always transferred first (SonarCloud's CE requires the main branch report before non-main branches can be submitted). Branch selection can be controlled through:
+<!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> by default (`syncAllBranches: true`), with the main branch always transferred first (SonarQube Cloud's CE requires the main branch report before non-main branches can be submitted). Branch selection can be controlled through:
 
 - **Exclude list** (`excludeBranches` in config) — skip specific branches by name
 - **Include list** (`includeBranches` in config) — only transfer listed branches
@@ -238,14 +238,14 @@ Completed branches are tracked in the state file, so interrupted transfers skip 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Analysis Wait Mode
 
-The `--wait` flag causes the tool to poll SonarCloud's CE task queue until the uploaded report has been fully analyzed. This is useful for CI/CD integration or sequential migration workflows where downstream steps depend on analysis completion.
+The `--wait` flag causes the tool to poll SonarQube Cloud's CE task queue until the uploaded report has been fully analyzed. This is useful for CI/CD integration or sequential migration workflows where downstream steps depend on analysis completion.
 
 ---
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ## 6. Full Organization Migration Pipeline
 
-The `migrate` command orchestrates a comprehensive, multi-stage pipeline that transfers an entire SonarQube installation — not just code, but all organizational configuration.
+The `migrate` command orchestrates a comprehensive, multi-stage pipeline that transfers an entire SonarQube Server installation — not just code, but all organizational configuration.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Pipeline Stages
@@ -255,7 +255,7 @@ The `migrate` command orchestrates a comprehensive, multi-stage pipeline that tr
    ↓
 2. Output Directory Initialization
    ↓
-3. SonarQube Connection Verification
+3. SonarQube Server Connection Verification
    ↓
 4. Full Project Discovery
    ↓
@@ -299,10 +299,10 @@ Server-wide extraction wraps each item in a non-fatal handler. If extracting qua
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Dry-Run Mode
 
-The `--dry-run` flag executes all extraction and mapping steps but stops before making any changes to SonarCloud. This allows teams to:
+The `--dry-run` flag executes all extraction and mapping steps but stops before making any changes to SonarQube Cloud. This allows teams to:
 - Review the generated organization mapping CSVs
-- Map SonarQube users to SonarCloud users via `user-mappings.csv` (since logins typically differ between SQ and SC)
-- Validate that all SonarQube data is accessible
+- Map SonarQube Server users to SonarQube Cloud users via `user-mappings.csv` (since logins typically differ between SQ and SC)
+- Validate that all SonarQube Server data is accessible
 - Verify project key resolution without side effects
 
 ---
@@ -310,15 +310,15 @@ The `--dry-run` flag executes all extraction and mapping steps but stops before 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ## 7. Issue and Hotspot Metadata Synchronization
 
-After uploading the scanner report (which creates issues in SonarCloud with default "Open" status), CloudVoyager synchronizes the full lifecycle metadata from SonarQube.
+After uploading the scanner report (which creates issues in SonarQube Cloud with default "Open" status), CloudVoyager synchronizes the full lifecycle metadata from SonarQube Server.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Issue Sync
 
-For each issue in SonarQube, the sync engine:
+For each issue in SonarQube Server, the sync engine:
 
-1. **Matches** the corresponding SonarCloud issue by composite key: `rule + component + line number`
-2. **Transitions** the status using SonarCloud's workflow API:
+1. **Matches** the corresponding SonarQube Cloud issue by composite key: `rule + component + line number`
+2. **Transitions** the status using SonarQube Cloud's workflow API:
    - `CONFIRMED` → `confirm`
    - `REOPENED` → `reopen`
    - `OPEN` → `unconfirm`
@@ -326,15 +326,15 @@ For each issue in SonarQube, the sync engine:
    - `ACCEPTED` → `accept`
    - `FALSE-POSITIVE` → `falsepositive`
    - `WONTFIX` → `wontfix`
-   - `IN_SANDBOX` (SonarQube 2025+) → no transition; the issue stays `OPEN` on SonarCloud because there is no equivalent state. See [Troubleshooting](./troubleshooting.md) for details.
+   - `IN_SANDBOX` (SonarQube Server 2025+) → no transition; the issue stays `OPEN` on SonarQube Cloud because there is no equivalent state. See [Troubleshooting](./troubleshooting.md) for details.
 3. **Assigns** the issue to the corresponding user, using the `user-mappings.csv` when available:
-   - If a SonarCloud Login is mapped in the CSV, uses the mapped login
+   - If a SonarQube Cloud Login is mapped in the CSV, uses the mapped login
    - If the user is excluded (`Include=no`), skips assignment
-   - Otherwise, falls back to the original SonarQube login
-4. **Copies comments** from SonarQube to SonarCloud
-5. **Sets tags** to match the SonarQube tags
+   - Otherwise, falls back to the original SonarQube Server login
+4. **Copies comments** from SonarQube Server to SonarQube Cloud
+5. **Sets tags** to match the SonarQube Server tags
 
-When multiple SonarCloud issues match the same composite key, the engine uses a first-unmatched-candidate strategy to avoid double-assignment.
+When multiple SonarQube Cloud issues match the same composite key, the engine uses a first-unmatched-candidate strategy to avoid double-assignment.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Hotspot Sync
@@ -363,18 +363,18 @@ The operation is **idempotent** — running it multiple times will not duplicate
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Quality Profile Migration
 
-Quality profiles are migrated using SonarQube's **backup/restore XML format**, which preserves:
+Quality profiles are migrated using SonarQube Server's **backup/restore XML format**, which preserves:
 - All rule activations and deactivations
 - Severity overrides
 - Rule parameter values
 - Language-specific configurations
 
-**Built-in profile handling** is a noteworthy engineering detail. SonarCloud's built-in profiles (e.g., "Sonar way") cannot be overwritten. CloudVoyager handles this by:
-1. Extracting the built-in profile's backup XML from SonarQube
-2. Restoring it as a **custom profile** with a `(SonarQube Migrated)` suffix
+**Built-in profile handling** is a noteworthy engineering detail. SonarQube Cloud's built-in profiles (e.g., "Sonar way") cannot be overwritten. CloudVoyager handles this by:
+1. Extracting the built-in profile's backup XML from SonarQube Server
+2. Restoring it as a **custom profile** with a `(SonarQube Server Migrated)` suffix
 3. Automatically assigning the migrated custom profile to each project
 
-This ensures that the exact same rules are active in SonarCloud as they were in SonarQube, even when the built-in profiles have diverged between versions.
+This ensures that the exact same rules are active in SonarQube Cloud as they were in SonarQube Server, even when the built-in profiles have diverged between versions.
 
 **Inheritance chains** are preserved by restoring profiles in dependency order — parent profiles are restored before their children.
 
@@ -382,15 +382,15 @@ This ensures that the exact same rules are active in SonarCloud as they were in 
 ### Quality Profile Diff Reports
 
 After migration, a side-by-side comparison report is generated per language:
-- **Missing rules**: Active in SonarQube but not available in SonarCloud (may cause fewer issues to be detected)
-- **Added rules**: Available in SonarCloud but not in SonarQube (may create new issues)
+- **Missing rules**: Active in SonarQube Server but not available in SonarQube Cloud (may cause fewer issues to be detected)
+- **Added rules**: Available in SonarQube Cloud but not in SonarQube Server (may create new issues)
 
 This enables teams to review rule parity before going live.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Quality Gate Migration
 
-Quality gates are created with their full condition definitions (metric, operator, error threshold). Gate permissions are migrated for custom gates, and project assignments are applied per the organization mapping. Built-in gates are skipped since SonarCloud provides its own defaults.
+Quality gates are created with their full condition definitions (metric, operator, error threshold). Gate permissions are migrated for custom gates, and project assignments are applied per the organization mapping. Built-in gates are skipped since SonarQube Cloud provides its own defaults.
 
 ---
 
@@ -400,7 +400,7 @@ Quality gates are created with their full condition definitions (metric, operato
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Group Migration
 
-User groups are extracted from SonarQube and recreated in each target SonarCloud organization with matching names and descriptions.
+User groups are extracted from SonarQube Server and recreated in each target SonarQube Cloud organization with matching names and descriptions.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Permission Migration
@@ -414,7 +414,7 @@ Three levels of permissions are migrated:
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Portfolio Migration
 
-Portfolios are recreated in SonarCloud with their project associations preserved, maintaining the organizational hierarchy for executive-level views.
+Portfolios are recreated in SonarQube Cloud with their project associations preserved, maintaining the organizational hierarchy for executive-level views.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Project Configuration Migration
@@ -434,19 +434,19 @@ Per-project settings that are migrated include:
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Intelligent Project-to-Organization Mapping
 
-For enterprises migrating to multiple SonarCloud organizations, CloudVoyager automatically maps projects to target organizations based on their **DevOps platform bindings**:
+For enterprises migrating to multiple SonarQube Cloud organizations, CloudVoyager automatically maps projects to target organizations based on their **DevOps platform bindings**:
 
 1. Projects are grouped by their ALM binding (e.g., GitHub organization, GitLab group, Azure DevOps team)
-2. Each binding group is matched to the corresponding target SonarCloud organization
+2. Each binding group is matched to the corresponding target SonarQube Cloud organization
 3. Unbound projects fall back to the first configured organization
 4. The mapping is exported as CSV for human review before execution
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Project Key Resolution
 
-SonarCloud requires globally unique project keys across all organizations. CloudVoyager handles this with a smart fallback strategy:
+SonarQube Cloud requires globally unique project keys across all organizations. CloudVoyager handles this with a smart fallback strategy:
 
-1. Attempt to use the original SonarQube project key
+1. Attempt to use the original SonarQube Server project key
 2. If the key is already taken by another organization, fall back to `{org}_{key}`
 3. If the key is already owned by the target organization (from a previous run), reuse it
 4. All key conflicts are logged and reported in the migration summary
@@ -466,7 +466,7 @@ The mapping module generates **9 structured CSV files** for human review and edi
 | `portfolio-mappings.csv` | Portfolio definitions and project associations |
 | `template-mappings.csv` | Permission template definitions and group assignments |
 | `global-permissions.csv` | Organization-wide permission assignments |
-| `user-mappings.csv` | SonarQube-to-SonarCloud user login mapping |
+| `user-mappings.csv` | SonarQube Server-to-SonarQube Cloud user login mapping |
 
 Each CSV includes an `Include` column — setting it to `no` excludes that item from migration. Users edit these CSVs between a `--dry-run` and the actual migration run.
 
@@ -496,7 +496,7 @@ Different operations have different optimal concurrency levels, reflecting API r
 | Source file extraction | 10 | I/O-bound, benefits from parallelism |
 | Hotspot detail fetching | 10 | Many small requests |
 | Issue metadata sync | 5 | Write operations, moderate rate limits |
-| Hotspot metadata sync | 3 | Aggressive SonarCloud rate limiting |
+| Hotspot metadata sync | 3 | Aggressive SonarQube Cloud rate limiting |
 | Project migration | 1 | Heavy per-project workload |
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
@@ -660,7 +660,7 @@ An earlier architecture used **worker threads** for protobuf encoding. This was 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Two-Layer Rate Limiting Strategy
 
-The SonarCloud API client implements a configurable two-layer approach:
+The SonarQube Cloud API client implements a configurable two-layer approach:
 
 **Layer 1: Exponential Backoff Retry**
 - Triggers on HTTP 503 (Service Unavailable) and 429 (Too Many Requests) responses
@@ -777,7 +777,7 @@ CloudVoyager's checkpoint system enables true pause/resume for all migration com
 - **Concurrent run prevention**: Lock file with PID and hostname prevents two instances from corrupting state
 - **Stale lock detection**: Dead-process locks are auto-released; cross-machine locks require `--force-unlock`
 - **Upload deduplication**: Before re-uploading after a crash, checks CE activity to prevent duplicate tasks
-- **Session fingerprint validation**: Warns (or blocks with `strictResume`) on SonarQube version changes between runs
+- **Session fingerprint validation**: Warns (or blocks with `strictResume`) on SonarQube Server version changes between runs
 - **Atomic state writes**: Write-to-temp + fsync + rename prevents corruption from mid-write crashes
 
 ### CLI Flags
@@ -829,9 +829,9 @@ Reports include:
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Quality Profile Diff Report
 
-A specialized JSON report (`quality-profile-diff.json`) compares active rules per language between SonarQube source profiles and SonarCloud target profiles, identifying:
-- **Missing rules**: Rules active in SonarQube but not available on SonarCloud
-- **Added rules**: Rules on SonarCloud not present in SonarQube
+A specialized JSON report (`quality-profile-diff.json`) compares active rules per language between SonarQube Server source profiles and SonarQube Cloud target profiles, identifying:
+- **Missing rules**: Rules active in SonarQube Server but not available on SonarQube Cloud
+- **Added rules**: Rules on SonarQube Cloud not present in SonarQube Server
 
 ---
 
@@ -891,8 +891,8 @@ Performance and rate-limit schemas are shared across all configuration types, en
 ### Operational Safeguards
 
 - **`validate`** — Always run before migration to catch config issues early
-- **`test`** — Verify connectivity to both SonarQube and SonarCloud before committing to a long migration
-- **`--dry-run`** — Execute extraction and mapping without writing to SonarCloud
+- **`test`** — Verify connectivity to both SonarQube Server and SonarQube Cloud before committing to a long migration
+- **`--dry-run`** — Execute extraction and mapping without writing to SonarQube Cloud
 - **`--verbose`** — Debug-level logging for troubleshooting
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
@@ -953,14 +953,14 @@ API client errors include specific diagnostics based on the underlying network e
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ## 22. Migration Verification Pipeline
 
-After migration, CloudVoyager can **verify** that all data was transferred correctly by exhaustively comparing SonarQube and SonarCloud. The `verify` command performs read-only checks and generates a detailed pass/fail report.
+After migration, CloudVoyager can **verify** that all data was transferred correctly by exhaustively comparing SonarQube Server and SonarQube Cloud. The `verify` command performs read-only checks and generates a detailed pass/fail report.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### What Gets Verified
 
 | Category | Checks |
 |----------|--------|
-| **Issues** | Count parity, status matching (False Positive, Accepted, Won't Fix, Confirmed, Resolved, Reopened, Open), status history (changelog transition sequence verification), assignments, comments (`[Migrated from SonarQube]` prefix detection), custom tags |
+| **Issues** | Count parity, status matching (False Positive, Accepted, Won't Fix, Confirmed, Resolved, Reopened, Open), status history (changelog transition sequence verification), assignments, comments (`[Migrated from SonarQube Server]` prefix detection), custom tags |
 | **Hotspots** | Count parity, status matching (Safe, Acknowledged, Fixed, To Review), comments |
 | **Branches** | All SQ branches exist in SC |
 | **Measures** | 18 key metrics (ncloc, complexity, violations, coverage, etc.) |
@@ -1014,8 +1014,8 @@ This ensures the verification is comparing exactly the same pairs that were sync
 | Total source lines | ~40,000+ (CLI) + ~2,000 (Desktop) |
 | Source files | 322 JS files (CLI) + 24 files (Desktop) |
 | Version-specific pipelines | 4 (sq-9.9, sq-10.0, sq-10.4, sq-2025) — 66 JS files each |
-| SonarQube extractor modules | 24 |
-| SonarCloud migrator modules | 9 |
+| SonarQube Server extractor modules | 24 |
+| SonarQube Cloud migrator modules | 9 |
 | CLI commands | 9 |
 | Report output formats | 6 (JSON, MD, TXT, PDF x3 types) |
 | Supported binary platforms | 6 (all via Node.js SEA) |
@@ -1033,7 +1033,7 @@ This ensures the verification is comparing exactly the same pairs that were sync
 | Zero-dependency concurrency | Avoid bloat; the custom implementation is ~80 lines and covers all use cases |
 | Dual packaging backends (SEA + Bun) | Node.js SEA for stability (default), Bun compile as experimental alternative for faster builds |
 | Inline proto schemas | Eliminate runtime file I/O dependencies for standalone binary compatibility |
-| Issue batching (5K per date bucket) | Splits large issue sets across multiple scanner reports with backdated `analysis_date` values to stay under SonarCloud's ES 10K visualization limit |
+| Issue batching (5K per date bucket) | Splits large issue sets across multiple scanner reports with backdated `analysis_date` values to stay under SonarQube Cloud's ES 10K visualization limit |
 | Builder-encoder separation | Clean architecture; business logic in builders, serialization in encoder |
 | Non-fatal extraction | Maximize migration completeness even when individual items fail |
 | Settled-mode concurrency | Partial success is better than total failure for large-scale operations |
@@ -1046,8 +1046,8 @@ This ensures the verification is comparing exactly the same pairs that were sync
 1. **No existing tool does this.** CloudVoyager is the first to reverse-engineer SonarScanner's protobuf protocol and reconstruct it programmatically.
 2. **Zero source code access required.** The migration operates entirely at the API level — no repository cloning, no build systems, no CI/CD integration needed.
 3. **Complete fidelity.** Issues, hotspots, measures, quality gates, quality profiles, permissions, groups, templates, portfolios, settings, tags, links, bindings, and new code periods are all preserved.
-4. **Handles projects with 10,000+ issues.** SonarQube caps `/api/issues/search` at 10K results; CloudVoyager automatically detects this and uses date-window bisection (search slicing) to retrieve every issue without data loss. On the upload side, issues are batched into groups of 5,000 with distinct `analysis_date` values to stay under SonarCloud's Elasticsearch visualization limit.
-5. **Robust external issue detection.** Third-party plugin issues are reliably detected even when the SonarCloud rule-repository API is unreachable, using a built-in fallback set of 43 known repositories with retry and exponential backoff.
+4. **Handles projects with 10,000+ issues.** SonarQube Server caps `/api/issues/search` at 10K results; CloudVoyager automatically detects this and uses date-window bisection (search slicing) to retrieve every issue without data loss. On the upload side, issues are batched into groups of 5,000 with distinct `analysis_date` values to stay under SonarQube Cloud's Elasticsearch visualization limit.
+5. **Robust external issue detection.** Third-party plugin issues are reliably detected even when the SonarQube Cloud rule-repository API is unreachable, using a built-in fallback set of 43 known repositories with retry and exponential backoff.
 6. **Production-proven at scale.** Successfully migrated 29 projects with 16,000+ issues in a single automated run.
 7. **Single binary, zero dependencies.** Distributed as a standalone executable — no runtime, no package manager, no setup.
 8. **Fast.** 29 projects, 53 quality profiles, and all organizational configuration migrated in under 16 minutes.
@@ -1094,7 +1094,7 @@ Phase 1 returns a context object consumed by Phase 2, enabling clean separation 
 | `transfer-branch.js` | Single-branch build→encode→upload pipeline (protobuf build, encode, upload via CE submitter) |
 | `ce-submitter.js` | CE submission with retry (submit → timeout → activity polling → re-submit → fail) |
 | `report-packager.js` | Scanner report ZIP creation (all protobuf file types + source text + context-props) |
-| `issue-status-mapper.js` | SonarQube→SonarCloud issue status transition mapping with changelog replay and fallback modes |
+| `issue-status-mapper.js` | SonarQube Server→SonarQube Cloud issue status transition mapping with changelog replay and fallback modes |
 | `checkpoint-extractor.js` | 13-phase checkpoint-aware extraction with journal/cache (project metadata through syntax highlighting) |
 
 ### CSV Entity Filtering
@@ -1138,7 +1138,7 @@ Features: monotonic progress (never goes backward), ETA calculation from recent 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### The Problem
 
-SonarCloud's Elasticsearch-backed UI has a visualization limit that hides issues when more than 10,000 exist in a single date bucket. For large projects migrated in a single scanner report, this means a significant portion of issues become invisible in the SonarCloud interface despite being successfully ingested.
+SonarQube Cloud's Elasticsearch-backed UI has a visualization limit that hides issues when more than 10,000 exist in a single date bucket. For large projects migrated in a single scanner report, this means a significant portion of issues become invisible in the SonarQube Cloud interface despite being successfully ingested.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### The Solution
@@ -1182,12 +1182,12 @@ Components and active rules are retained in all batches so that issues can be re
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Deduplication Prevention
 
-Each batch receives a unique `scmRevisionId` generated via `randomBytes(20).toString('hex')`. This prevents SonarCloud's Compute Engine from rejecting batches as duplicate submissions, since CE uses the SCM revision to detect re-uploads.
+Each batch receives a unique `scmRevisionId` generated via `randomBytes(20).toString('hex')`. This prevents SonarQube Cloud's Compute Engine from rejecting batches as duplicate submissions, since CE uses the SCM revision to detect re-uploads.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" />
 ### Submission Order
 
-Batches are submitted oldest-first (lowest `batchIndex` first). Each batch waits for its CE task to complete before the next batch is submitted, ensuring SonarCloud processes them in chronological order. The batching is transparent to the caller — `transferBranch` automatically detects when batching is needed and routes accordingly.
+Batches are submitted oldest-first (lowest `batchIndex` first). Each batch waits for its CE task to complete before the next batch is submitted, ensuring SonarQube Cloud processes them in chronological order. The batching is transparent to the caller — `transferBranch` automatically detects when batching is needed and routes accordingly.
 
 ---
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,6 +1,6 @@
 # 🛠️ Local Development
 
-<!-- Last updated: Apr 21, 2026 — updated build pipeline, testing, CI/CD details, SonarCloud scanning -->
+<!-- Last updated: Apr 21, 2026 — updated build pipeline, testing, CI/CD details, SonarQube Cloud scanning -->
 
 Use this guide to build and run CloudVoyager locally. All developers should **build the binary and run that** — do not run directly from source. This ensures consistent behavior across environments and eliminates "works on my machine" issues.
 
@@ -183,7 +183,7 @@ chmod +x dist/bin/cloudvoyager-macos-arm64
 # Validate a config file
 ./cloudvoyager validate -c config.json
 
-# Test connections to SonarQube and SonarCloud
+# Test connections to SonarQube Server and SonarQube Cloud
 ./cloudvoyager test -c config.json
 
 # Transfer a single project
@@ -256,7 +256,7 @@ This section documents every command and flag available in CloudVoyager. The exa
 ---
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
-### `test` — Test connections to SonarQube and SonarCloud
+### `test` — Test connections to SonarQube Server and SonarQube Cloud
 
 | Flag | Short | Required | Argument | Description |
 |------|-------|----------|----------|-------------|
@@ -318,19 +318,19 @@ This section documents every command and flag available in CloudVoyager. The exa
 ---
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
-### `transfer` — Transfer a single project from SonarQube to SonarCloud
+### `transfer` — Transfer a single project from SonarQube Server to SonarQube Cloud
 
 | Flag | Short | Required | Argument | Description |
 |------|-------|----------|----------|-------------|
 | `--config <path>` | `-c` | Yes | File path | Path to the configuration file |
 | `--verbose` | `-v` | No | — | Enable debug-level logging for detailed output |
-| `--wait` | — | No | — | Wait for the SonarCloud analysis to complete before returning (blocks until the Compute Engine task finishes) |
+| `--wait` | — | No | — | Wait for the SonarQube Cloud analysis to complete before returning (blocks until the Compute Engine task finishes) |
 | `--concurrency <n>` | — | No | Integer | Override the maximum concurrency for I/O operations (source file extraction, hotspot extraction, etc.) |
 | `--max-memory <mb>` | — | No | Integer | Set the max heap size in MB; auto-restarts the process with increased heap if the current heap is too small |
 | `--auto-tune` | — | No | — | Auto-detect hardware (CPU cores, available memory) and set optimal concurrency and memory values |
 | `--skip-all-branch-sync` | — | No | — | Only sync the main branch (skip non-main branches). Equivalent to setting `transfer.syncAllBranches: false` in config |
 | `--force-restart` | — | No | — | Discard checkpoint journal and start a fresh transfer from scratch |
-| `--force-fresh-extract` | — | No | — | Discard extraction caches and re-extract all data from SonarQube |
+| `--force-fresh-extract` | — | No | — | Discard extraction caches and re-extract all data from SonarQube Server |
 | `--force-unlock` | — | No | — | Force release a stale lock file from a previous run |
 | `--show-progress` | — | No | — | Display checkpoint progress status table and exit |
 
@@ -347,7 +347,7 @@ This section documents every command and flag available in CloudVoyager. The exa
 # Transfer with verbose logging (short flag)
 ./cloudvoyager transfer -c config.json -v
 
-# Transfer and wait for SonarCloud analysis to finish
+# Transfer and wait for SonarQube Cloud analysis to finish
 ./cloudvoyager transfer -c config.json --wait
 
 # Transfer with verbose logging and wait for analysis
@@ -410,17 +410,17 @@ This section documents every command and flag available in CloudVoyager. The exa
 ---
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
-### `migrate` — Full migration from SonarQube to one or more SonarCloud organizations
+### `migrate` — Full migration from SonarQube Server to one or more SonarQube Cloud organizations
 
 | Flag | Short | Required | Argument | Description |
 |------|-------|----------|----------|-------------|
 | `--config <path>` | `-c` | Yes | File path | Path to the migration configuration file |
 | `--verbose` | `-v` | No | — | Enable debug-level logging for detailed output |
-| `--wait` | — | No | — | Wait for each SonarCloud analysis to complete before proceeding |
+| `--wait` | — | No | — | Wait for each SonarQube Cloud analysis to complete before proceeding |
 | `--dry-run` | — | No | — | Extract data and generate project/key mappings without actually migrating any data |
 | `--skip-issue-metadata-sync` | — | No | — | Skip syncing issue metadata (statuses, assignments, comments, tags) after transfer |
 | `--skip-hotspot-metadata-sync` | — | No | — | Skip syncing hotspot metadata (statuses, comments) after transfer |
-| `--skip-quality-profile-sync` | — | No | — | Skip syncing quality profiles (projects use default SonarCloud profiles) |
+| `--skip-quality-profile-sync` | — | No | — | Skip syncing quality profiles (projects use default SonarQube Cloud profiles) |
 | `--concurrency <n>` | — | No | Integer | Override the maximum concurrency for I/O operations (applies to source extraction, hotspot extraction, issue sync, and hotspot sync) |
 | `--max-memory <mb>` | — | No | Integer | Set the max heap size in MB; auto-restarts with increased heap if needed |
 | `--project-concurrency <n>` | — | No | Integer | Maximum number of projects to migrate concurrently |
@@ -527,7 +527,7 @@ This section documents every command and flag available in CloudVoyager. The exa
 # Migration with auto-tune, wait, and skip both metadata syncs
 ./cloudvoyager migrate -c migrate-config.json --verbose --wait --auto-tune --skip-issue-metadata-sync --skip-hotspot-metadata-sync
 
-# Migration skipping quality profile sync (use default SonarCloud profiles)
+# Migration skipping quality profile sync (use default SonarQube Cloud profiles)
 ./cloudvoyager migrate -c migrate-config.json --verbose --skip-quality-profile-sync
 
 # Migration skipping quality profile sync with auto-tune
@@ -588,7 +588,7 @@ This section documents every command and flag available in CloudVoyager. The exa
 ---
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
-### `verify` — Verify migration completeness by comparing SonarQube and SonarCloud data
+### `verify` — Verify migration completeness by comparing SonarQube Server and SonarQube Cloud data
 
 | Flag | Short | Required | Argument | Description |
 |------|-------|----------|----------|-------------|
@@ -658,7 +658,7 @@ This section documents every command and flag available in CloudVoyager. The exa
 | `--verbose` | `-v` | No | — | Enable debug-level logging for detailed output |
 | `--skip-issue-metadata-sync` | — | No | — | Skip syncing issue metadata (statuses, assignments, comments, tags); only sync hotspot metadata |
 | `--skip-hotspot-metadata-sync` | — | No | — | Skip syncing hotspot metadata (statuses, comments); only sync issue metadata |
-| `--skip-quality-profile-sync` | — | No | — | Skip syncing quality profiles (projects use default SonarCloud profiles) |
+| `--skip-quality-profile-sync` | — | No | — | Skip syncing quality profiles (projects use default SonarQube Cloud profiles) |
 | `--concurrency <n>` | — | No | Integer | Override the maximum concurrency for I/O operations (issue sync, hotspot sync, hotspot extraction) |
 | `--max-memory <mb>` | — | No | Integer | Set the max heap size in MB; auto-restarts with increased heap if needed |
 | `--auto-tune` | — | No | — | Auto-detect hardware and set optimal concurrency and memory values |
@@ -782,13 +782,13 @@ The project uses a multi-stage GitHub Actions pipeline:
 | `build.yml` | Build CLI binaries | 6 platform builds in parallel using Node.js 20 |
 | `build-desktop.yml` | Build Electron desktop apps | 6 Electron builds (depends on CLI build artifacts) |
 | `release.yml` | Orchestrator | Chains: install → build → build-desktop → release |
-| `sonarcloud.yml` | SonarCloud SAST/SCA | Automatic scanning on push to `main` and on PRs. Requires `SONAR_TOKEN` secret |
+| `sonarcloud.yml` | SonarQube Cloud SAST/SCA | Automatic scanning on push to `main` and on PRs. Requires `SONAR_TOKEN` secret |
 | `gh-release.yml` | GitHub Releases | Creates releases with milestone links derived from version tags |
 
-### SonarCloud Scanning
+### SonarQube Cloud Scanning
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-The repository includes a `sonarcloud.yml` workflow and a `sonar-project.properties` file at the project root for automatic SAST/SCA scanning via SonarCloud. The workflow runs on every push to `main` and on pull requests. It requires a `SONAR_TOKEN` secret configured in the GitHub repository settings.
+The repository includes a `sonarcloud.yml` workflow and a `sonar-project.properties` file at the project root for automatic SAST/SCA scanning via SonarQube Cloud. The workflow runs on every push to `main` and on pull requests. It requires a `SONAR_TOKEN` secret configured in the GitHub repository settings.
 
 ### Platform Build Matrix (6 targets)
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -811,10 +811,10 @@ The repository includes a `sonarcloud.yml` workflow and a `sonar-project.propert
 |----------|-------------|
 | `LOG_LEVEL` | Set logging level: `debug`, `info`, `warn`, `error` |
 | `LOG_FILE` | Path to log file (optional, logs to console by default) |
-| `SONARQUBE_TOKEN` | Override SonarQube token from config |
-| `SONARCLOUD_TOKEN` | Override SonarCloud token from config |
-| `SONARQUBE_URL` | Override SonarQube URL from config |
-| `SONARCLOUD_URL` | Override SonarCloud URL from config |
+| `SONARQUBE_TOKEN` | Override SonarQube Server token from config |
+| `SONARCLOUD_TOKEN` | Override SonarQube Cloud token from config |
+| `SONARQUBE_URL` | Override SonarQube Server URL from config |
+| `SONARCLOUD_URL` | Override SonarQube Cloud URL from config |
 | `MAX_SOURCE_FILES` | Limit number of source files to extract (`0` = all) |
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -909,7 +909,7 @@ The `.debugging/` folder contains convenience scripts for local testing:
 | `test-verify.sh` | Run `verify` command with `migrate-config.json` |
 | `build-desktop.sh` | Build the Electron desktop app |
 | `run-desktop.sh` | Launch the desktop app in dev mode |
-| `delete-all-sonarcloud-projects.sh` | Delete all projects from a SonarCloud org (for cleanup) |
+| `delete-all-sonarcloud-projects.sh` | Delete all projects from a SonarQube Cloud org (for cleanup) |
 
 These scripts expect the binary at `./dist/bin/cloudvoyager-macos-arm64` and config files at the repo root. Both `migrate-config.json` and `transfer-config.json` are gitignored since they contain credentials.
 
@@ -931,7 +931,7 @@ These scripts expect the binary at `./dist/bin/cloudvoyager-macos-arm64` and con
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🧪 Regression Testing
 
-The regression testing system validates that bug fixes and behavioral changes in CloudVoyager remain correct across SonarQube versions.
+The regression testing system validates that bug fixes and behavioral changes in CloudVoyager remain correct across SonarQube Server versions.
 
 ### Where the Code Lives
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -944,16 +944,16 @@ The regression testing system validates that bug fixes and behavioral changes in
 
 Full regression tests require an environment that mirrors CI:
 
-1. **Docker** — ephemeral SonarQube containers are spun up per test scenario.
-2. **SonarQube Enterprise license key** — the containers need a valid Enterprise Edition license.
-3. **SonarCloud organization access** — tests migrate data into SonarCloud and verify the results.
+1. **Docker** — ephemeral SonarQube Server containers are spun up per test scenario.
+2. **SonarQube Server Enterprise license key** — the containers need a valid Enterprise Edition license.
+3. **SonarQube Cloud organization access** — tests migrate data into SonarQube Cloud and verify the results.
 
 > **Note:** These prerequisites make local runs heavyweight. Most day-to-day development does not require running the full regression suite locally — CI handles it on every PR.
 
 ### Meta-Tests (No Docker Required)
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-The helper utilities in `test/regression/helpers/` have their own unit tests (`test/regression/helpers/*.test.js`). These **meta-tests** run with the regular test command and do not require Docker or a running SonarQube instance:
+The helper utilities in `test/regression/helpers/` have their own unit tests (`test/regression/helpers/*.test.js`). These **meta-tests** run with the regular test command and do not require Docker or a running SonarQube Server instance:
 
 ```bash
 npm test
@@ -963,7 +963,7 @@ npm test
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
 1. **Create an assertion script:** Add `test/regression/assert-{scenario-name}.js` in this repository. Follow the conventions of existing assertion scripts in the same directory.
-2. **Add a matrix entry:** In the private repo `sonar-solutions/cloudvoyager-ci`, add a new entry to the matrix in `regression-bug-fixes.yml` that references your assertion script and the SonarQube version(s) it should run against.
+2. **Add a matrix entry:** In the private repo `sonar-solutions/cloudvoyager-ci`, add a new entry to the matrix in `regression-bug-fixes.yml` that references your assertion script and the SonarQube Server version(s) it should run against.
 
 <!--
 ## Change Log

--- a/docs/milestone-1.2-verification-report.md
+++ b/docs/milestone-1.2-verification-report.md
@@ -14,7 +14,7 @@
 |-------|-------|--------|
 | [#53](https://github.com/sonar-solutions/cloudvoyager/issues/53) | CloudVoyager can't handle projects with more than 10K issues | RESOLVED |
 | [#56](https://github.com/sonar-solutions/cloudvoyager/issues/56) | Third party issues not consistently migrated | RESOLVED |
-| [#66](https://github.com/sonar-solutions/cloudvoyager/issues/66) | Add SonarCloud public scanning | RESOLVED |
+| [#66](https://github.com/sonar-solutions/cloudvoyager/issues/66) | Add SonarQube Cloud public scanning | RESOLVED |
 | [#75](https://github.com/sonar-solutions/cloudvoyager/issues/75) | Modify GitHub workflow YAML to reference milestones | RESOLVED |
 
 ---
@@ -22,7 +22,7 @@
 ## Issue #53 — 10K+ Issues Search Slicing
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-**Problem:** SonarQube's `/api/issues/search` endpoint has a hard 10,000-result limit. Projects exceeding this silently lost data during migration.
+**Problem:** SonarQube Server's `/api/issues/search` endpoint has a hard 10,000-result limit. Projects exceeding this silently lost data during migration.
 
 **Solution:** Implemented a date-window search-slicing algorithm that automatically activates when results hit the 10K limit.
 
@@ -68,16 +68,16 @@
 ## Issue #56 — Third-Party Issue Migration Bug
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-**Problem:** When `getRuleRepositories()` failed to fetch the SonarCloud rules API, it returned an empty Set. This caused `isExternalIssue()` to return `false` for ALL issues, silently dropping third-party analyzer issues (ruff, pylint, Trivy, etc.) during migration.
+**Problem:** When `getRuleRepositories()` failed to fetch the SonarQube Cloud rules API, it returned an empty Set. This caused `isExternalIssue()` to return `false` for ALL issues, silently dropping third-party analyzer issues (ruff, pylint, Trivy, etc.) during migration.
 
-**Solution:** Added a fallback set of 43 known SonarCloud rule repositories, retry logic with exponential backoff on `getRuleRepositories()`, and edge-case guards in `isExternalIssue()`.
+**Solution:** Added a fallback set of 43 known SonarQube Cloud rule repositories, retry logic with exponential backoff on `getRuleRepositories()`, and edge-case guards in `isExternalIssue()`.
 
 ### Files Created
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
 | File | Purpose |
 |------|---------|
-| `src/shared/utils/fallback-repos/index.js` | Exports `FALLBACK_SONARCLOUD_REPOS` — Set of 43 known built-in SonarCloud rule repository keys |
+| `src/shared/utils/fallback-repos/index.js` | Exports `FALLBACK_SONARCLOUD_REPOS` — Set of 43 known built-in SonarQube Cloud rule repository keys |
 
 ### Files Modified
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -111,20 +111,20 @@
 
 ---
 
-## Issue #66 — SonarCloud Public Scanning
+## Issue #66 — SonarQube Cloud Public Scanning
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
 **Problem:** No automated SAST, unit test coverage, or SCA scanning was configured for the repository.
 
-**Solution:** Added a standalone GitHub Actions workflow that runs SonarCloud analysis on every push to `main` and on pull requests.
+**Solution:** Added a standalone GitHub Actions workflow that runs SonarQube Cloud analysis on every push to `main` and on pull requests.
 
 ### Files Created
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
 | File | Purpose |
 |------|---------|
-| `.github/workflows/sonarcloud.yml` | Fully automatic SonarCloud scanning workflow |
-| `sonar-project.properties` | SonarCloud project configuration |
+| `.github/workflows/sonarcloud.yml` | Fully automatic SonarQube Cloud scanning workflow |
+| `sonar-project.properties` | SonarQube Cloud project configuration |
 
 ### Verification
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -193,6 +193,6 @@ Requires the `SONAR_TOKEN` secret to be configured in the GitHub repository sett
 |-------|--------|--------|--------|
 | #53 — 10K+ Search Slicing | 7 | 7 | 0 |
 | #56 — Third-Party Issue Fix | 9 | 9 | 0 |
-| #66 — SonarCloud Scanning | 15 | 15 | 0 |
+| #66 — SonarQube Cloud Scanning | 15 | 15 | 0 |
 | #75 — Release Milestones | 8 | 8 | 0 |
 | **Total** | **39** | **39** | **0** |

--- a/docs/pseudocode-explanation.md
+++ b/docs/pseudocode-explanation.md
@@ -14,7 +14,7 @@ This document describes each feature of the CloudVoyager migration tool in pseud
 5. [Verification Pipeline](#5-verification-pipeline)
 6. [Data Extraction](#6-data-extraction)
 7. [Protobuf Building & Encoding](#7-protobuf-building--encoding)
-8. [Report Upload to SonarCloud](#8-report-upload-to-sonarcloud)
+8. [Report Upload to SonarQube Cloud](#8-report-upload-to-sonarcloud)
 9. [External Issues & Plugin Migration](#9-external-issues--plugin-migration)
 10. [Issue & Hotspot Metadata Sync](#10-issue--hotspot-metadata-sync)
 11. [Quality Gates Migration](#11-quality-gates-migration)
@@ -45,11 +45,11 @@ COMMAND: test
   INPUT: --config <path>, [--verbose]
   STEPS:
     1. Load config
-    2. Detect SonarQube version via version-router (GET /api/system/status)
+    2. Detect SonarQube Server version via version-router (GET /api/system/status)
     3. Load the correct pipeline for the detected version (sq-9.9, sq-10.0, sq-10.4, or sq-2025)
     4. Create SonarQubeClient from the selected pipeline
-    5. Create SonarCloud client
-    6. Test SonarCloud connection (GET /api/organizations/search)
+    5. Create SonarQube Cloud client
+    6. Test SonarQube Cloud connection (GET /api/organizations/search)
     7. Report success or failure for each
 
 COMMAND: status
@@ -90,7 +90,7 @@ COMMAND: verify
 ## 2. Transfer Pipeline
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Transfers a single SonarQube project to SonarCloud.
+Transfers a single SonarQube Server project to SonarQube Cloud.
 
 ```
 FUNCTION transferProject(sonarqubeConfig, sonarcloudConfig, transferConfig, performanceConfig, wait):
@@ -168,7 +168,7 @@ FUNCTION transferBranch(extractedData, branch, scConfig, scProfiles, scRepos, ..
   encoder.loadSchemas()
   encodedReport = encoder.encodeAll(messages)
 
-  // Step 3: Upload to SonarCloud
+  // Step 3: Upload to SonarQube Cloud
   uploader = new ReportUploader(scClient)
   ceTask = uploader.upload(encodedReport, metadata)
 
@@ -198,7 +198,7 @@ FUNCTION transferBranchBatched(extractedData, branch, scConfig, ...):
 ## 3. Migration Pipeline
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Migrates all projects across multiple SonarCloud organizations.
+Migrates all projects across multiple SonarQube Cloud organizations.
 
 ```
 FUNCTION migrateAll(sonarqubeConfig, sonarcloudOrgs, migrateConfig, transferConfig, ...):
@@ -335,7 +335,7 @@ COMMAND sync-metadata:
 ## 5. Verification Pipeline
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Compares SonarQube and SonarCloud data to verify migration completeness.
+Compares SonarQube Server and SonarQube Cloud data to verify migration completeness.
 
 ```
 FUNCTION verifyAll(sonarqubeConfig, sonarcloudOrgs, outputDir, onlyComponents, ...):
@@ -398,7 +398,7 @@ FUNCTION verifyAll(sonarqubeConfig, sonarcloudOrgs, outputDir, onlyComponents, .
 ## 6. Data Extraction
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Extracts all data from SonarQube for a single project.
+Extracts all data from SonarQube Server for a single project.
 
 ```
 FUNCTION DataExtractor.extractAll():
@@ -476,7 +476,7 @@ FUNCTION DataExtractor.extractBranch(branchName, mainData):
 ## 7. Protobuf Building & Encoding
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Transforms extracted data into SonarCloud's scanner report protobuf format.
+Transforms extracted data into SonarQube Cloud's scanner report protobuf format.
 
 ```
 CLASS ProtobufBuilder:
@@ -621,10 +621,10 @@ CLASS ProtobufEncoder:
 
 ---
 
-## 8. Report Upload to SonarCloud
+## 8. Report Upload to SonarQube Cloud
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Packages the encoded protobuf report and submits it to SonarCloud's Compute Engine.
+Packages the encoded protobuf report and submits it to SonarQube Cloud's Compute Engine.
 
 ```
 CLASS ReportUploader:
@@ -716,7 +716,7 @@ FUNCTION buildExternalIssues():
 
     // --- Resolve Clean Code Attribute ---
     //   CRITICAL: Must be a protobuf enum (varint int), NOT a string!
-    //   SonarCloud CE silently ignores external issues if string-encoded.
+    //   SonarQube Cloud CE silently ignores external issues if string-encoded.
     IF issue.cleanCodeAttribute:
       cleanCodeAttr = mapCleanCodeAttribute(issue.cleanCodeAttribute)
       // Maps: "CONVENTIONAL"->1, "FORMATTED"->2, ... "TRUSTWORTHY"->14
@@ -765,7 +765,7 @@ FUNCTION buildExternalIssues():
 
 
 FUNCTION buildRuleEnrichmentMap(scClient, scProfiles):
-  // For SQ < 10.0: fetch Clean Code taxonomy from SonarCloud
+  // For SQ < 10.0: fetch Clean Code taxonomy from SonarQube Cloud
   enrichmentMap = new Map()
 
   FOR EACH profile IN scProfiles:
@@ -784,7 +784,7 @@ FUNCTION buildRuleEnrichmentMap(scClient, scProfiles):
 ## 10. Issue & Hotspot Metadata Sync
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Syncs issue/hotspot statuses, assignments, comments, and tags from SonarQube to SonarCloud after scanner report upload.
+Syncs issue/hotspot statuses, assignments, comments, and tags from SonarQube Server to SonarQube Cloud after scanner report upload.
 
 ```
 FUNCTION syncIssues(projectKey, sqIssues, scClient, options):
@@ -834,8 +834,8 @@ FUNCTION syncIssues(projectKey, sqIssues, scClient, options):
     // 4e. Mark as metadata-synchronized
     scClient.setIssueTags(sc.key, [...existing, "metadata-synchronized"])
 
-    // 4f. Add source link back to SonarQube
-    scClient.addIssueComment(sc.key, "SonarQube Source: {sonarqubeUrl}/issues?id=...")
+    // 4f. Add source link back to SonarQube Server
+    scClient.addIssueComment(sc.key, "SonarQube Server Source: {sonarqubeUrl}/issues?id=...")
 
   RETURN { matched, transitioned, assigned, commented, tagged, failed }
 
@@ -860,7 +860,7 @@ FUNCTION syncHotspots(projectKey, sqHotspots, scClient, options):
       scClient.addHotspotComment(sc.key, formatComment(comment))
 
     // Source link
-    scClient.addHotspotComment(sc.key, "SonarQube Source: {url}")
+    scClient.addHotspotComment(sc.key, "SonarQube Server Source: {url}")
 
   RETURN { matched, statusChanged, commentAdded, failed }
 ```
@@ -931,10 +931,10 @@ FUNCTION migrateQualityProfiles(extractedProfiles, scClient):
   // --- Restore built-in profiles as custom (with renamed suffix) ---
   FOR EACH profile IN builtInProfiles:
     renamedXml = modifyBackupXml(profile.backupXml, {
-      name: profile.name + " (SonarQube Migrated)"
+      name: profile.name + " (SonarQube Server Migrated)"
     })
     scClient.restoreQualityProfile(renamedXml)
-    builtInProfileMapping.SET(profile.language, profile.name + " (SonarQube Migrated)")
+    builtInProfileMapping.SET(profile.language, profile.name + " (SonarQube Server Migrated)")
 
   // --- Set defaults ---
   FOR EACH profile IN customProfiles WHERE profile.isDefault:
@@ -1013,7 +1013,7 @@ FUNCTION migrateProjectPermissions(project, scClient):
 ## 14. Organization Mapping & CSV Generation
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Maps SonarQube projects to SonarCloud organizations and generates editable CSV files.
+Maps SonarQube Server projects to SonarQube Cloud organizations and generates editable CSV files.
 
 ```
 FUNCTION mapProjectsToOrganizations(allProjects, projectBindings, sonarcloudOrgs):
@@ -1088,7 +1088,7 @@ FUNCTION applyCsvOverrides(csvData, extractedData, resourceMappings, orgAssignme
 ## 15. Version Router and Pipeline Selection
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Detects SonarQube version at runtime and loads the correct version-specific pipeline.
+Detects SonarQube Server version at runtime and loads the correct version-specific pipeline.
 
 ```
 FUNCTION detectAndRoute(sonarqubeConfig):

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -1,7 +1,7 @@
 # Regression Testing Protocol
 <!-- updated: 2026-05-07 -->
 
-A reusable protocol for verifying bug fixes and features against a live SonarQube → SonarCloud migration. This protocol is **issue-driven** — you MUST fully understand the GitHub issue before designing any test, and your test plan must be explicitly derived from the issue's symptoms, root cause, and fix.
+A reusable protocol for verifying bug fixes and features against a live SonarQube Server → SonarQube Cloud migration. This protocol is **issue-driven** — you MUST fully understand the GitHub issue before designing any test, and your test plan must be explicitly derived from the issue's symptoms, root cause, and fix.
 
 ---
 
@@ -33,7 +33,7 @@ For the GitHub issue you are regression testing, you must be able to answer ALL 
 
 From the issue understanding in 0.1, write a **specific regression test plan** BEFORE touching any code. This plan must include:
 
-- **Which SonarQube project to use** — pick the project that best reproduces the issue (e.g., Angular Framework for hotspots because it has ~409 hotspots)
+- **Which SonarQube Server project to use** — pick the project that best reproduces the issue (e.g., Angular Framework for hotspots because it has ~409 hotspots)
 - **What test data to create** — do you need to bulk-tag issues, add comments, transition statuses to trigger the pre-filter? How many?
 - **What to verify after migration** — specific API queries, specific counts, specific spot-checks
 - **What the pass criteria are** — concrete numbers, not vague "looks right"
@@ -77,7 +77,7 @@ Find ALL code paths that touch the same data or API calls as the fix:
 8. **Worker thread lifecycle**: Are workers properly joined before the process exits? Are they cleaned up on error?
 
 ### API Contract Compliance
-9. **HTTP method**: Does the code use GET/POST/PUT/DELETE exactly as the SonarQube/SonarCloud API specifies?
+9. **HTTP method**: Does the code use GET/POST/PUT/DELETE exactly as the SonarQube Server/SonarQube Cloud API specifies?
 10. **Endpoint path**: Is the URL exactly right — no missing/misplaced path segments, no incorrect query params?
 11. **Request body/params**: Are field names, types, and encoding exactly correct? Compare character-by-character against the real API docs or actual observed API traces.
 12. **Auth**: Are tokens passed correctly (Authorization header vs query param)? Are tokens refreshed if expired?

--- a/docs/scenario-multi-org.md
+++ b/docs/scenario-multi-org.md
@@ -1,9 +1,9 @@
-# Migrate Everything to Multiple SonarCloud Organizations
+# Migrate Everything to Multiple SonarQube Cloud Organizations
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
 <!-- Last updated: Apr 21, 2026 -->
 
-Use this when you want to migrate **all projects and configuration** from your SonarQube server to **multiple** SonarCloud organizations — for example, when different teams or business units each have their own SonarCloud org.
+Use this when you want to migrate **all projects and configuration** from your SonarQube Server to **multiple** SonarQube Cloud organizations — for example, when different teams or business units each have their own SonarQube Cloud org.
 
 ---
 
@@ -31,13 +31,13 @@ CloudVoyager uses DevOps platform bindings (GitHub, GitLab, etc.) to automatical
 ## Prerequisites
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-1. **Admin access** to your SonarQube server
-2. **Admin access** to **each** target SonarCloud organization
-3. **API tokens** for SonarQube and for each SonarCloud organization
+1. **Admin access** to your SonarQube Server
+2. **Admin access** to **each** target SonarQube Cloud organization
+3. **API tokens** for SonarQube Server and for each SonarQube Cloud organization
 
 > **How to get your tokens:**
-> - **SonarQube:** Go to `My Account > Security > Generate Tokens` in your SonarQube web UI
-> - **SonarCloud:** Go to `My Account > Security > Generate Tokens` at [sonarcloud.io](https://sonarcloud.io) — you need a token with admin permissions for **each** target org
+> - **SonarQube Server:** Go to `My Account > Security > Generate Tokens` in your SonarQube Server web UI
+> - **SonarQube Cloud:** Go to `My Account > Security > Generate Tokens` at [sonarcloud.io](https://sonarcloud.io) — you need a token with admin permissions for **each** target org
 
 ---
 
@@ -104,19 +104,19 @@ See [`examples/migrate-config.example.json`](../examples/migrate-config.example.
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `sonarqube.url` | Yes | Full URL of your SonarQube server |
-| `sonarqube.token` | Yes | SonarQube admin API token |
+| `sonarqube.url` | Yes | Full URL of your SonarQube Server |
+| `sonarqube.token` | Yes | SonarQube Server admin API token |
 | `sonarcloud.enterprise.key` | No | Enterprise key — required for portfolio migration (uses Enterprise V2 API) |
-| `sonarcloud.organizations[].key` | Yes | SonarCloud organization key |
-| `sonarcloud.organizations[].token` | Yes | SonarCloud admin API token for this org |
-| `sonarcloud.organizations[].url` | No | SonarCloud URL (default: `https://sonarcloud.io`) |
+| `sonarcloud.organizations[].key` | Yes | SonarQube Cloud organization key |
+| `sonarcloud.organizations[].token` | Yes | SonarQube Cloud admin API token for this org |
+| `sonarcloud.organizations[].url` | No | SonarQube Cloud URL (default: `https://sonarcloud.io`) |
 | `migrate.outputDir` | No | Directory for mapping CSVs and reports (default: `./migration-output`) |
 
-> **Tip:** You can set the SonarQube token via the `SONARQUBE_TOKEN` environment variable. SonarCloud tokens must be specified per-org in the config.
+> **Tip:** You can set the SonarQube Server token via the `SONARQUBE_TOKEN` environment variable. SonarQube Cloud tokens must be specified per-org in the config.
 
-> **Project key conflict resolution:** By default, the tool uses the **original SonarQube project key** on SonarCloud. If the key is already taken by another SonarCloud organization, the tool automatically falls back to a prefixed key (`{org-key}_{sonarqube-project-key}`) and logs a warning. This is especially common in multi-org migrations where different orgs may have projects with overlapping keys. All key conflicts are listed in the migration report.
+> **Project key conflict resolution:** By default, the tool uses the **original SonarQube Server project key** on SonarQube Cloud. If the key is already taken by another SonarQube Cloud organization, the tool automatically falls back to a prefixed key (`{org-key}_{sonarqube-project-key}`) and logs a warning. This is especially common in multi-org migrations where different orgs may have projects with overlapping keys. All key conflicts are listed in the migration report.
 
-> **Enterprise key for portfolios:** Portfolios in SonarCloud are enterprise-wide, not per-organization. To migrate portfolios, add `sonarcloud.enterprise.key` to your config. Without it, portfolio migration is skipped. The tool uses the Enterprise V2 API to create portfolios after all organizations have been migrated.
+> **Enterprise key for portfolios:** Portfolios in SonarQube Cloud are enterprise-wide, not per-organization. To migrate portfolios, add `sonarcloud.enterprise.key` to your config. Without it, portfolio migration is skipped. The tool uses the Enterprise V2 API to create portfolios after all organizations have been migrated.
 
 **Example config with enterprise key:**
 ```json
@@ -139,7 +139,7 @@ We recommend a 3-step migration: dry run, migrate without metadata, then sync me
 ### Step 3a: Dry run — verify everything
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-A dry run extracts all data and generates mapping CSVs so you can review **which projects go to which org**, without changing anything in SonarCloud:
+A dry run extracts all data and generates mapping CSVs so you can review **which projects go to which org**, without changing anything in SonarQube Cloud:
 
 ```bash
 ./cloudvoyager migrate -c migrate-config.json --dry-run
@@ -156,9 +156,9 @@ Run the actual migration with metadata sync disabled and auto-tuned performance.
 ./cloudvoyager migrate -c migrate-config.json --verbose --skip-issue-metadata-sync --skip-hotspot-metadata-sync --auto-tune
 ```
 
-Skipping metadata during the main migration avoids SonarCloud rate limiting (503 errors) that can occur during high-volume issue/hotspot sync.
+Skipping metadata during the main migration avoids SonarQube Cloud rate limiting (503 errors) that can occur during high-volume issue/hotspot sync.
 
-> **Note:** By default, the tool does not wait for each project's analysis to complete on SonarCloud before moving on to the next project. This speeds up large migrations significantly. Add `--wait` if you need to block until each analysis finishes.
+> **Note:** By default, the tool does not wait for each project's analysis to complete on SonarQube Cloud before moving on to the next project. This speeds up large migrations significantly. Add `--wait` if you need to block until each analysis finishes.
 
 ### Step 3c: Sync metadata separately
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -188,7 +188,7 @@ After syncing metadata, run the verification command to confirm everything was m
 ./cloudvoyager verify -c migrate-config.json --verbose
 ```
 
-This performs read-only checks comparing SonarQube and SonarCloud data and generates a detailed pass/fail report in `./verification-output/`. You can also verify specific components:
+This performs read-only checks comparing SonarQube Server and SonarQube Cloud data and generates a detailed pass/fail report in `./verification-output/`. You can also verify specific components:
 
 ```bash
 # Verify only issue and hotspot metadata
@@ -226,7 +226,7 @@ Each project within an organization goes through 11 individually-checkpointed st
 ### Parallel project extraction
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-During the extraction phase, the tool fetches branches for all projects concurrently using bounded parallelism (`mapConcurrent`). The concurrency level is controlled by `performance.sourceExtraction.concurrency` in the config or by `--concurrency` on the CLI. This significantly speeds up the data-gathering phase for large SonarQube instances.
+During the extraction phase, the tool fetches branches for all projects concurrently using bounded parallelism (`mapConcurrent`). The concurrency level is controlled by `performance.sourceExtraction.concurrency` in the config or by `--concurrency` on the CLI. This significantly speeds up the data-gathering phase for large SonarQube Server instances.
 
 ---
 
@@ -269,7 +269,7 @@ Use defaults — no `performance` section needed.
 }
 ```
 
-Keep `hotspotSync.concurrency` low (3–5) to avoid SonarCloud rate limits. See the [Configuration Reference](configuration.md#performance-settings) for all options.
+Keep `hotspotSync.concurrency` low (3–5) to avoid SonarQube Cloud rate limits. See the [Configuration Reference](configuration.md#performance-settings) for all options.
 
 ---
 
@@ -291,7 +291,7 @@ Keep `hotspotSync.concurrency` low (3–5) to avoid SonarCloud rate limits. See 
 | `reports/executive-summary.md` | High-level executive summary |
 | `reports/performance-report.md` | Performance metrics breakdown |
 | `reports/*.pdf` | PDF versions of the above reports (best-effort) |
-| `quality-profiles/quality-profile-diff.json` | Per-language diff of active rules between SonarQube and SonarCloud |
+| `quality-profiles/quality-profile-diff.json` | Per-language diff of active rules between SonarQube Server and SonarQube Cloud |
 
 Server info (version, plugins, settings, webhooks) is saved to `{outputDir}/server-info/` as JSON files.
 Per-project state files are saved to `{outputDir}/state/` for incremental transfer tracking.
@@ -318,7 +318,7 @@ When you run `./cloudvoyager verify`, reports are written to `./verification-out
 | `--dry-run` | Extract data and generate mappings without migrating |
 | `--skip-issue-metadata-sync` | Skip syncing issue statuses, comments, assignments, tags |
 | `--skip-hotspot-metadata-sync` | Skip syncing hotspot statuses and comments |
-| `--skip-quality-profile-sync` | Skip syncing quality profiles (projects use default SonarCloud profiles) |
+| `--skip-quality-profile-sync` | Skip syncing quality profiles (projects use default SonarQube Cloud profiles) |
 | `--only <components>` | Only migrate specific components (comma-separated). Valid: `scan-data`, `scan-data-all-branches`, `portfolios`, `quality-gates`, `quality-profiles`, `permission-templates`, `permissions`, `issue-metadata`, `hotspot-metadata`, `project-settings` |
 | `--auto-tune` | Auto-detect CPU and RAM and set optimal performance values |
 | `--concurrency <n>` | Override max concurrency for I/O operations |
@@ -334,7 +334,7 @@ When you run `./cloudvoyager verify`, reports are written to `./verification-out
 ## Limitations
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-- Historical metrics (the charts in each project's **Activity** tab in SonarQube) cannot be migrated. All actual issues and hotspots are migrated — only the historical trend data is lost.
+- Historical metrics (the charts in each project's **Activity** tab in SonarQube Server) cannot be migrated. All actual issues and hotspots are migrated — only the historical trend data is lost.
 
 ---
 

--- a/docs/scenario-single-org.md
+++ b/docs/scenario-single-org.md
@@ -1,9 +1,9 @@
-# Migrate Everything to One SonarCloud Organization
+# Migrate Everything to One SonarQube Cloud Organization
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
 <!-- Last updated: Apr 21, 2026 -->
 
-Use this when you want to migrate **all projects and configuration** from your SonarQube server to a **single** SonarCloud organization.
+Use this when you want to migrate **all projects and configuration** from your SonarQube Server to a **single** SonarQube Cloud organization.
 
 ---
 
@@ -26,13 +26,13 @@ Use this when you want to migrate **all projects and configuration** from your S
 ## Prerequisites
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-1. **Admin access** to your SonarQube server
-2. **Admin access** to your SonarCloud organization
-3. **API tokens** for both SonarQube and SonarCloud
+1. **Admin access** to your SonarQube Server
+2. **Admin access** to your SonarQube Cloud organization
+3. **API tokens** for both SonarQube Server and SonarQube Cloud
 
 > **How to get your tokens:**
-> - **SonarQube:** Go to `My Account > Security > Generate Tokens` in your SonarQube web UI
-> - **SonarCloud:** Go to `My Account > Security > Generate Tokens` at [sonarcloud.io](https://sonarcloud.io)
+> - **SonarQube Server:** Go to `My Account > Security > Generate Tokens` in your SonarQube Server web UI
+> - **SonarQube Cloud:** Go to `My Account > Security > Generate Tokens` at [sonarcloud.io](https://sonarcloud.io)
 
 ---
 
@@ -84,18 +84,18 @@ Create a file called `migrate-config.json`:
 
 See [`examples/migrate-config.example.json`](../examples/migrate-config.example.json) for a ready-to-use template with all optional fields (rate limiting, performance tuning, etc.).
 
-> **Project keys and names:** Each project's display name is automatically carried over from SonarQube. By default, the tool uses the **original SonarQube project key** on SonarCloud. If the key is already taken by another SonarCloud organization, the tool falls back to a prefixed key (`{org-key}_{sonarqube-project-key}`) and logs a warning. Any key conflicts are listed in the migration report.
+> **Project keys and names:** Each project's display name is automatically carried over from SonarQube Server. By default, the tool uses the **original SonarQube Server project key** on SonarQube Cloud. If the key is already taken by another SonarQube Cloud organization, the tool falls back to a prefixed key (`{org-key}_{sonarqube-project-key}`) and logs a warning. Any key conflicts are listed in the migration report.
 
 ### Config fields
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `sonarqube.url` | Yes | Full URL of your SonarQube server |
-| `sonarqube.token` | Yes | SonarQube admin API token |
-| `sonarcloud.organizations[].key` | Yes | SonarCloud organization key |
-| `sonarcloud.organizations[].token` | Yes | SonarCloud admin API token |
-| `sonarcloud.organizations[].url` | No | SonarCloud URL (default: `https://sonarcloud.io`) |
+| `sonarqube.url` | Yes | Full URL of your SonarQube Server |
+| `sonarqube.token` | Yes | SonarQube Server admin API token |
+| `sonarcloud.organizations[].key` | Yes | SonarQube Cloud organization key |
+| `sonarcloud.organizations[].token` | Yes | SonarQube Cloud admin API token |
+| `sonarcloud.organizations[].url` | No | SonarQube Cloud URL (default: `https://sonarcloud.io`) |
 | `migrate.outputDir` | No | Directory for mapping CSVs and reports (default: `./migration-output`) |
 
 > **Tip:** You can set tokens via environment variables (`SONARQUBE_TOKEN` and `SONARCLOUD_TOKEN`) instead of putting them in the config file.
@@ -108,7 +108,7 @@ We recommend a 3-step migration: dry run, migrate without metadata, then sync me
 ### Step 3a: Dry run — verify everything
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-A dry run extracts all data and generates mapping CSVs so you can review what will be migrated, without changing anything in SonarCloud:
+A dry run extracts all data and generates mapping CSVs so you can review what will be migrated, without changing anything in SonarQube Cloud:
 
 ```bash
 ./cloudvoyager migrate -c migrate-config.json --dry-run
@@ -125,9 +125,9 @@ Run the actual migration with metadata sync disabled and auto-tuned performance.
 ./cloudvoyager migrate -c migrate-config.json --verbose --skip-issue-metadata-sync --skip-hotspot-metadata-sync --auto-tune
 ```
 
-Skipping metadata during the main migration avoids SonarCloud rate limiting (503 errors) that can occur during high-volume issue/hotspot sync.
+Skipping metadata during the main migration avoids SonarQube Cloud rate limiting (503 errors) that can occur during high-volume issue/hotspot sync.
 
-> **Note:** By default, the tool does not wait for each project's analysis to complete on SonarCloud before moving on to the next project. This speeds up large migrations significantly. Add `--wait` if you need to block until each analysis finishes.
+> **Note:** By default, the tool does not wait for each project's analysis to complete on SonarQube Cloud before moving on to the next project. This speeds up large migrations significantly. Add `--wait` if you need to block until each analysis finishes.
 
 ### Step 3c: Sync metadata separately
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -157,7 +157,7 @@ After syncing metadata, run the verification command to confirm everything was m
 ./cloudvoyager verify -c migrate-config.json --verbose
 ```
 
-This performs read-only checks comparing SonarQube and SonarCloud data and generates a detailed pass/fail report in `./verification-output/`. You can also verify specific components:
+This performs read-only checks comparing SonarQube Server and SonarQube Cloud data and generates a detailed pass/fail report in `./verification-output/`. You can also verify specific components:
 
 ```bash
 # Verify only issue and hotspot metadata
@@ -209,7 +209,7 @@ The `--dry-run` flag generates 9 CSV files in `{outputDir}/mappings/`. Each CSV 
 | `portfolio-mappings.csv` | Portfolios with member projects (parent/child rows) |
 | `template-mappings.csv` | Permission templates with per-permission rows (parent/child) |
 | `global-permissions.csv` | Group-to-permission assignments |
-| `user-mappings.csv` | SonarQube-to-SonarCloud user login mapping for issue assignment |
+| `user-mappings.csv` | SonarQube Server-to-SonarQube Cloud user login mapping for issue assignment |
 
 See the [Dry-Run CSV Reference](dry-run-csv-reference.md) for full column schemas and editing examples.
 
@@ -254,7 +254,7 @@ Use defaults — no `performance` section needed.
 }
 ```
 
-Keep `hotspotSync.concurrency` low (3–5) to avoid SonarCloud rate limits. See the [Configuration Reference](configuration.md#performance-settings) for all options.
+Keep `hotspotSync.concurrency` low (3–5) to avoid SonarQube Cloud rate limits. See the [Configuration Reference](configuration.md#performance-settings) for all options.
 
 ---
 
@@ -276,7 +276,7 @@ Keep `hotspotSync.concurrency` low (3–5) to avoid SonarCloud rate limits. See 
 | `reports/executive-summary.md` | High-level executive summary |
 | `reports/performance-report.md` | Performance metrics breakdown |
 | `reports/*.pdf` | PDF versions of the above reports (best-effort) |
-| `quality-profiles/quality-profile-diff.json` | Per-language diff of active rules between SonarQube and SonarCloud |
+| `quality-profiles/quality-profile-diff.json` | Per-language diff of active rules between SonarQube Server and SonarQube Cloud |
 
 Server info (version, plugins, settings, webhooks) is saved to `{outputDir}/server-info/` as JSON files.
 Per-project state files are saved to `{outputDir}/state/` for incremental transfer tracking.
@@ -303,7 +303,7 @@ When you run `./cloudvoyager verify`, reports are written to `./verification-out
 | `--dry-run` | Extract data and generate mappings without migrating |
 | `--skip-issue-metadata-sync` | Skip syncing issue statuses, comments, assignments, tags |
 | `--skip-hotspot-metadata-sync` | Skip syncing hotspot statuses and comments |
-| `--skip-quality-profile-sync` | Skip syncing quality profiles (projects use default SonarCloud profiles) |
+| `--skip-quality-profile-sync` | Skip syncing quality profiles (projects use default SonarQube Cloud profiles) |
 | `--only <components>` | Only migrate specific components (comma-separated). Valid: `scan-data`, `scan-data-all-branches`, `portfolios`, `quality-gates`, `quality-profiles`, `permission-templates`, `permissions`, `issue-metadata`, `hotspot-metadata`, `project-settings` |
 | `--auto-tune` | Auto-detect CPU and RAM and set optimal performance values |
 | `--concurrency <n>` | Override max concurrency for I/O operations |
@@ -319,7 +319,7 @@ When you run `./cloudvoyager verify`, reports are written to `./verification-out
 ## Limitations
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-- Historical metrics (the charts in each project's **Activity** tab in SonarQube) cannot be migrated. All actual issues and hotspots are migrated — only the historical trend data is lost.
+- Historical metrics (the charts in each project's **Activity** tab in SonarQube Server) cannot be migrated. All actual issues and hotspots are migrated — only the historical trend data is lost.
 
 ---
 

--- a/docs/scenario-single-project.md
+++ b/docs/scenario-single-project.md
@@ -3,7 +3,7 @@
 
 <!-- Last updated: Apr 21, 2026 -->
 
-Use this when you want to migrate **one specific project** from SonarQube to SonarCloud.
+Use this when you want to migrate **one specific project** from SonarQube Server to SonarQube Cloud.
 
 This does **not** migrate org-level settings like quality gates, quality profiles, groups, or permissions — for that, see [Migrate Everything to One Org](scenario-single-org.md).
 
@@ -21,7 +21,7 @@ This does **not** migrate org-level settings like quality gates, quality profile
 | **Metrics & measures** | Project and component-level measures (coverage, complexity, etc.) |
 | **SCM changesets** | Per-file changeset info (author, date, revision) |
 | **Active rules** | Quality profile rules filtered by languages used in the project |
-| **Issue metadata** | Status history (full changelog replay), comments, assignments, `metadata-synchronized` tag, and a link back to the original SonarQube issue URL |
+| **Issue metadata** | Status history (full changelog replay), comments, assignments, `metadata-synchronized` tag, and a link back to the original SonarQube Server issue URL |
 | **Hotspot metadata** | Hotspot statuses, comments, and source links |
 
 > **Not included:** Quality gates, quality profiles, groups, permissions, portfolios, project settings, tags, links, DevOps bindings, and new code definitions. Use the [`migrate` command](scenario-single-org.md) to transfer these.
@@ -31,13 +31,13 @@ This does **not** migrate org-level settings like quality gates, quality profile
 ## Prerequisites
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-1. **Admin access** to your SonarQube server
-2. **Admin access** to your SonarCloud organization
-3. **API tokens** for both SonarQube and SonarCloud
+1. **Admin access** to your SonarQube Server
+2. **Admin access** to your SonarQube Cloud organization
+3. **API tokens** for both SonarQube Server and SonarQube Cloud
 
 > **How to get your tokens:**
-> - **SonarQube:** Go to `My Account > Security > Generate Tokens` in your SonarQube web UI
-> - **SonarCloud:** Go to `My Account > Security > Generate Tokens` at [sonarcloud.io](https://sonarcloud.io)
+> - **SonarQube Server:** Go to `My Account > Security > Generate Tokens` in your SonarQube Server web UI
+> - **SonarQube Cloud:** Go to `My Account > Security > Generate Tokens` at [sonarcloud.io](https://sonarcloud.io)
 
 ---
 
@@ -82,7 +82,7 @@ Create a file called `config.json`:
 }
 ```
 
-> **Where to find your project key:** In SonarQube, go to your project's **Project Information** page — the key is shown there. You can use the same key for SonarCloud, or choose a new one.
+> **Where to find your project key:** In SonarQube Server, go to your project's **Project Information** page — the key is shown there. You can use the same key for SonarQube Cloud, or choose a new one.
 
 See [`examples/config.example.json`](../examples/config.example.json) for a ready-to-use template with all optional fields (rate limiting, performance tuning, etc.).
 
@@ -91,13 +91,13 @@ See [`examples/config.example.json`](../examples/config.example.json) for a read
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `sonarqube.url` | Yes | Full URL of your SonarQube server |
-| `sonarqube.token` | Yes | SonarQube API token (starts with `sqp_` on newer versions) |
-| `sonarqube.projectKey` | Yes (for `transfer`) | Project key in SonarQube |
-| `sonarcloud.url` | No | SonarCloud URL (default: `https://sonarcloud.io`) |
-| `sonarcloud.token` | Yes | SonarCloud API token |
-| `sonarcloud.organization` | Yes | SonarCloud organization key |
-| `sonarcloud.projectKey` | Yes (for `transfer`) | Project key to use in SonarCloud |
+| `sonarqube.url` | Yes | Full URL of your SonarQube Server |
+| `sonarqube.token` | Yes | SonarQube Server API token (starts with `sqp_` on newer versions) |
+| `sonarqube.projectKey` | Yes (for `transfer`) | Project key in SonarQube Server |
+| `sonarcloud.url` | No | SonarQube Cloud URL (default: `https://sonarcloud.io`) |
+| `sonarcloud.token` | Yes | SonarQube Cloud API token |
+| `sonarcloud.organization` | Yes | SonarQube Cloud organization key |
+| `sonarcloud.projectKey` | Yes (for `transfer`) | Project key to use in SonarQube Cloud |
 
 > **Tip:** You can set tokens via environment variables (`SONARQUBE_TOKEN` and `SONARCLOUD_TOKEN`) instead of putting them in the config file.
 
@@ -142,7 +142,7 @@ Add a `transfer` section to control incremental mode, batch size, and checkpoint
 ./cloudvoyager test -c config.json
 ```
 
-You should see a success message for both SonarQube and SonarCloud. If not, double-check your URLs and tokens.
+You should see a success message for both SonarQube Server and SonarQube Cloud. If not, double-check your URLs and tokens.
 
 ## Step 4: Run the transfer
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -151,9 +151,9 @@ You should see a success message for both SonarQube and SonarCloud. If not, doub
 ./cloudvoyager transfer -c config.json --verbose
 ```
 
-That's it! The tool uploads the report and returns immediately — it does not wait for SonarCloud to finish processing. Your project data will appear in SonarCloud once the analysis completes in the background.
+That's it! The tool uploads the report and returns immediately — it does not wait for SonarQube Cloud to finish processing. Your project data will appear in SonarQube Cloud once the analysis completes in the background.
 
-> **Tip:** If you want the command to block until SonarCloud finishes processing, add `--wait`.
+> **Tip:** If you want the command to block until SonarQube Cloud finishes processing, add `--wait`.
 
 ---
 
@@ -217,7 +217,7 @@ To discard progress and start fresh, use `--force-restart`:
 ### Upload deduplication
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-On resume after a crash, the tool checks whether a Compute Engine (CE) task already exists for the current session before uploading. This prevents duplicate scanner reports from being submitted to SonarCloud. The check uses the `scm_revision_id` (git commit hash) included in each report.
+On resume after a crash, the tool checks whether a Compute Engine (CE) task already exists for the current session before uploading. This prevents duplicate scanner reports from being submitted to SonarQube Cloud. The check uses the `scm_revision_id` (git commit hash) included in each report.
 
 ### Lock file handling
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -247,7 +247,7 @@ An advisory lock file prevents multiple CloudVoyager instances from running agai
 ## Limitations
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-- Historical metrics (the charts in each project's **Activity** tab in SonarQube) cannot be migrated. All actual issues and hotspots are migrated — only the historical trend data is lost.
+- Historical metrics (the charts in each project's **Activity** tab in SonarQube Server) cannot be migrated. All actual issues and hotspots are migrated — only the historical trend data is lost.
 
 ---
 

--- a/docs/technical-details.md
+++ b/docs/technical-details.md
@@ -1,6 +1,6 @@
 # 🔬 Technical Details
 
-<!-- Last updated: Apr 22, 2026 (batch-distributor in pipeline flow diagram, backdating strategy docs, scmRevisionId per-batch note, issue batching 5K per date bucket, issue sync pre-filter optimization, SC indexing wait, SonarCloud 10K issue slicing, githubactions language support, SQC US instance, enterprise key optional, search-slicer for SQC, fallback rule repositories, protobuf details, external issues, enum values, error hierarchy, state management, API gotchas, CE retry, issue status mapping, checkpoint extraction, CSV filtering) -->
+<!-- Last updated: Apr 22, 2026 (batch-distributor in pipeline flow diagram, backdating strategy docs, scmRevisionId per-batch note, issue batching 5K per date bucket, issue sync pre-filter optimization, SC indexing wait, SonarQube Cloud 10K issue slicing, githubactions language support, SQC US instance, enterprise key optional, search-slicer for SQC, fallback rule repositories, protobuf details, external issues, enum values, error hierarchy, state management, API gotchas, CE retry, issue status mapping, checkpoint extraction, CSV filtering) -->
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🗺️ Main Flow Sequence Diagram
@@ -13,8 +13,8 @@ sequenceDiagram
     actor User
     participant CLI as CLI (src/index.js)
     participant VR as VersionRouter
-    participant SQ as SonarQube
-    participant SC as SonarCloud
+    participant SQ as SonarQube Server
+    participant SC as SonarQube Cloud
     participant FS as File System
 
     rect rgb(30, 50, 80)
@@ -137,7 +137,7 @@ sequenceDiagram
 | ➕B | Protobuf encoding | `Generate a mermaid sequence diagram showing how CloudVoyager builds and encodes a scanner report ZIP using protobuf messages` |
 | ➕C | CE submission retry | `Generate a mermaid sequence diagram showing the CE submission retry mechanism in CloudVoyager including fallback polling` |
 | ➕D | Issue sync | `Generate a mermaid sequence diagram showing the full issue sync pipeline in CloudVoyager including pre-filter, SC indexing wait, and changelog replay` |
-| ➕E | Org mapping / CSVs | `Generate a mermaid sequence diagram showing how CloudVoyager maps SonarQube projects to SonarCloud organizations and generates dry-run CSV files` |
+| ➕E | Org mapping / CSVs | `Generate a mermaid sequence diagram showing how CloudVoyager maps SonarQube Server projects to SonarQube Cloud organizations and generates dry-run CSV files` |
 | ➕F | Quality profiles | `Generate a mermaid sequence diagram for CloudVoyager quality profile migration including backup XML, rename of built-in profiles, and diff report` |
 | ➕G | Batch distribution | `Generate a mermaid sequence diagram showing how CloudVoyager batch-distributor splits large issue sets into ≤5K batches with backdated analysis dates and sequential CE uploads` |
 
@@ -175,7 +175,7 @@ context-props.pb                  # Empty (matches real scanner)
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🔄 CE Submission Retry Mechanism
 
-Report submission to SonarCloud's Compute Engine (`/api/ce/submit`) uses a robust retry strategy (implemented in `ce-submitter.js` within each pipeline):
+Report submission to SonarQube Cloud's Compute Engine (`/api/ce/submit`) uses a robust retry strategy (implemented in `ce-submitter.js` within each pipeline):
 
 1. **Submit** the report ZIP via `POST /api/ce/submit` with a 60-second response timeout
 2. **On timeout** (no server response): fall back to `/api/ce/activity` polling — check for a matching CE task 5 times at 3-second intervals
@@ -196,7 +196,7 @@ The form data is buffered before sending (not streamed) to avoid runtime-specifi
 | **Severity** | UNSET=0, INFO=1, MINOR=2, MAJOR=3, CRITICAL=4, BLOCKER=5 |
 | **IssueType** | CODE_SMELL=1, BUG=2, VULNERABILITY=3, SECURITY_HOTSPOT=4 |
 
-**CRITICAL**: `cleanCodeAttribute` in `ExternalIssue` and `AdHocRule` must be encoded as a protobuf enum (varint), NOT a string. Despite the `.proto` file showing `optional string`, the real scanner uses enum encoding. SonarCloud CE silently ignores external issues if `cleanCodeAttribute` is string-encoded.
+**CRITICAL**: `cleanCodeAttribute` in `ExternalIssue` and `AdHocRule` must be encoded as a protobuf enum (varint), NOT a string. Despite the `.proto` file showing `optional string`, the real scanner uses enum encoding. SonarQube Cloud CE silently ignores external issues if `cleanCodeAttribute` is string-encoded.
 
 ### Field Name Convention
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -221,26 +221,26 @@ Measures use typed value fields based on metric type:
 
 - Active rules are filtered by languages actually used in the project, resulting in ~84% reduction in payload size
 - Rule keys are stripped of the repository prefix (e.g., `S7788` not `jsarchitecture:S7788`)
-- Quality profile keys are mapped to SonarCloud profile keys (not SonarQube keys)
+- Quality profile keys are mapped to SonarQube Cloud profile keys (not SonarQube Server keys)
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🧱 Component Structure
 
-Components use a flat structure - all files are direct children of the project component (no directory components). Line counts are derived from actual source file content rather than SonarQube measures API values.
+Components use a flat structure - all files are direct children of the project component (no directory components). Line counts are derived from actual source file content rather than SonarQube Server measures API values.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🔖 SCM Revision Tracking
 
-The tool includes `scm_revision_id` (git commit hash) in metadata. SonarCloud uses this to detect and reject duplicate reports, enabling proper analysis history tracking.
+The tool includes `scm_revision_id` (git commit hash) in metadata. SonarQube Cloud uses this to detect and reject duplicate reports, enabling proper analysis history tracking.
 
-**Batch uploads**: When issue batching is active (>5,000 issues), each batch receives a unique `scmRevisionId` generated via `randomBytes(20).toString('hex')` instead of the original git commit hash. This prevents the SonarCloud CE from deduplicating successive batch uploads as identical reports. See [Issue Batching for Upload](#-issue-batching-for-upload-5k-per-date-bucket) for details.
+**Batch uploads**: When issue batching is active (>5,000 issues), each batch receives a unique `scmRevisionId` generated via `randomBytes(20).toString('hex')` instead of the original git commit hash. This prevents the SonarQube Cloud CE from deduplicating successive batch uploads as identical reports. See [Issue Batching for Upload](#-issue-batching-for-upload-5k-per-date-bucket) for details.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🌿 Branch Sync
 
-By default, every branch discovered in SonarQube is transferred to SonarCloud (main branch first, then non-main branches). Each branch produces its own scanner report with branch-specific issues, measures, sources, and SCM data.
+By default, every branch discovered in SonarQube Server is transferred to SonarQube Cloud (main branch first, then non-main branches). Each branch produces its own scanner report with branch-specific issues, measures, sources, and SCM data.
 
-**Branch name resolution:** The main branch name is fetched from SonarCloud (via `getMainBranchName()` API) rather than using the SonarQube branch name. This avoids mismatches where SonarQube uses "main" but SonarCloud expects "master" (or vice versa). Non-main branches use their original SonarQube branch name and reference the main branch for new-code comparison.
+**Branch name resolution:** The main branch name is fetched from SonarQube Cloud (via `getMainBranchName()` API) rather than using the SonarQube Server branch name. This avoids mismatches where SonarQube Server uses "main" but SonarQube Cloud expects "master" (or vice versa). Non-main branches use their original SonarQube Server branch name and reference the main branch for new-code comparison.
 
 **Incremental mode:** Completed branches are tracked in the state file. On subsequent runs, already-synced branches are skipped automatically. Use `reset` to re-transfer all branches.
 
@@ -249,7 +249,7 @@ By default, every branch discovered in SonarQube is transferred to SonarCloud (m
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 📄 API Pagination
 
-SonarQube client handles pagination automatically via `getPaginated` method with a default page size of 500 items. All paginated results are concatenated into single arrays.
+SonarQube Server client handles pagination automatically via `getPaginated` method with a default page size of 500 items. All paginated results are concatenated into single arrays.
 
 **APIs with max `ps=100`** (not the default 500):
 - `/api/permissions/groups`
@@ -266,9 +266,9 @@ The extractors handle these lower limits automatically.
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 📦 Accurate Issue Creation Date Backdating
 
-SonarCloud's CE assigns creation dates to NEW issues from SCM blame data. `backdateChangesets()` rewrites each file's changeset protobuf so that the CE assigns each issue its original SonarQube creation date.
+SonarQube Cloud's CE assigns creation dates to NEW issues from SCM blame data. `backdateChangesets()` rewrites each file's changeset protobuf so that the CE assigns each issue its original SonarQube Server creation date.
 
-**How it works:** The function reads each issue's `creationDate` field (preserved from SonarQube extraction) and maps it to the issue's `textRange` lines in the file's changeset data. The CE takes MAX(date) across an issue's line range, so using "oldest wins" for overlapping lines ensures accurate dates. A safety split handles days with >5K issues.
+**How it works:** The function reads each issue's `creationDate` field (preserved from SonarQube Server extraction) and maps it to the issue's `textRange` lines in the file's changeset data. The CE takes MAX(date) across an issue's line range, so using "oldest wins" for overlapping lines ensures accurate dates. A safety split handles days with >5K issues.
 
 ### Algorithm (3 Phases)
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -285,7 +285,7 @@ SonarCloud's CE assigns creation dates to NEW issues from SCM blame data. `backd
 | Per-line dating (not per-file) | Enables multiple issues with different creation dates in the same file |
 | Oldest date wins for overlapping lines | CE takes MAX across line range — older date on shared lines doesn't inflate newer issues that have their own non-overlapping lines |
 | Non-issue lines get oldest date | Prevents accidental MAX inflation for multi-line issues spanning non-issue lines |
-| Safety split at 5,000/day | 50% margin under SonarCloud's 10K ES visualization cap per date bucket |
+| Safety split at 5,000/day | 50% margin under SonarQube Cloud's 10K ES visualization cap per date bucket |
 | No file splitting in safety split | A file's issues stay together on the same synthetic date |
 | All projects backdated | No early return for small projects — every project gets accurate dates |
 
@@ -307,14 +307,14 @@ All 6 pipeline `transfer-branch` entry points call `backdateChangesets(extracted
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🔍 Search Slicing for 10K+ Issues
 
-SonarQube's `/api/issues/search` endpoint returns a maximum of 10,000 results regardless of pagination. Projects with more than 10,000 issues would silently lose data during extraction.
+SonarQube Server's `/api/issues/search` endpoint returns a maximum of 10,000 results regardless of pagination. Projects with more than 10,000 issues would silently lose data during extraction.
 
 **Solution:** `src/shared/utils/search-slicer/` implements a date-window bisection algorithm:
 
 1. **Probe** — `probe-total.js` (in each pipeline's `api-client/helpers/`) sends a lightweight request (`ps=1, p=1`) to get the total issue count for a query without fetching data.
-2. **Partition** — If the total exceeds 10,000, the full SonarQube era (`2006-01-01` → now) is divided into **12 equal-width time windows** via `build-date-windows.js`. A fixed epoch is used instead of probing the date range — probing via `getPaginated(ps=1)` would loop page-by-page through all issues and itself hit the Elasticsearch 10K limit on large projects.
+2. **Partition** — If the total exceeds 10,000, the full SonarQube Server era (`2006-01-01` → now) is divided into **12 equal-width time windows** via `build-date-windows.js`. A fixed epoch is used instead of probing the date range — probing via `getPaginated(ps=1)` would loop page-by-page through all issues and itself hit the Elasticsearch 10K limit on large projects.
 3. **Bisect** — Any window that still exceeds 10,000 is **recursively halved** at the midpoint timestamp (via `split-midpoint.js`) until every window is under the limit. This binary subdivision guarantees convergence for any realistic issue distribution.
-4. **Guard** — If a window cannot be split further (both halves land on the same millisecond boundary, e.g. a mass-import scenario where all issues share the same creation timestamp), the window is fetched directly. This is an unavoidable SonarQube API limitation; it affects only projects where thousands of issues share an identical millisecond timestamp.
+4. **Guard** — If a window cannot be split further (both halves land on the same millisecond boundary, e.g. a mass-import scenario where all issues share the same creation timestamp), the window is fetched directly. This is an unavoidable SonarQube Server API limitation; it affects only projects where thousands of issues share an identical millisecond timestamp.
 5. **Fetch** — Each window is fetched independently using standard pagination (`ps=500`) with `createdAfter` / `createdBefore` API parameters scoping results to that window.
 6. **Merge & deduplicate** — `deduplicate-results.js` merges results from all windows and removes duplicates by `item.key || item.id` to handle boundary overlaps where an issue's creation timestamp falls on a window edge.
 
@@ -326,13 +326,13 @@ SonarQube's `/api/issues/search` endpoint returns a maximum of 10,000 results re
 | `fetch-window.js` | Fetches one window; recursively bisects if it exceeds the limit |
 | `slice-by-creation-date.js` | Partitions epoch→now into 12 windows, calls `fetchWindow` for each |
 | `build-date-windows.js` | Builds evenly-spaced `{ start, end }` window objects |
-| `split-midpoint.js` | Computes the SonarQube-compatible datetime at the midpoint between two timestamps |
-| `format-sonarqube-date.js` | Formats timestamps as `YYYY-MM-DDTHH:MM:SS+0000` (SonarQube rejects `.XXXZ` milliseconds) |
+| `split-midpoint.js` | Computes the SonarQube Server-compatible datetime at the midpoint between two timestamps |
+| `format-sonarqube-date.js` | Formats timestamps as `YYYY-MM-DDTHH:MM:SS+0000` (SonarQube Server rejects `.XXXZ` milliseconds) |
 | `deduplicate-results.js` | Deduplicates merged results by `item.key \|\| item.id` |
 
 The slicing is transparent to callers — `issues-hotspots.js` in each pipeline calls `fetchWithSlicing`, which falls back to a normal paginated fetch when the total is under 10,000.
 
-**Applies to both SonarQube and SonarCloud.** The slicing workaround targets SonarQube's `/api/issues/search` and `/api/hotspots/search` endpoints, which enforce the 10K cap. The same `fetchWithSlicing` mechanism is also applied to SonarCloud's issue search during **issue sync** (i.e., when fetching SC issues to match against SQ issues). This prevents data loss on large SonarCloud organizations that have >10,000 issues per project.
+**Applies to both SonarQube Server and SonarQube Cloud.** The slicing workaround targets SonarQube Server's `/api/issues/search` and `/api/hotspots/search` endpoints, which enforce the 10K cap. The same `fetchWithSlicing` mechanism is also applied to SonarQube Cloud's issue search during **issue sync** (i.e., when fetching SC issues to match against SQ issues). This prevents data loss on large SonarQube Cloud organizations that have >10,000 issues per project.
 
 **Both commands use it:**
 - `transfer` — calls `getIssuesWithComments()` via `fetch-and-sync-issues.js`, which invokes `fetchWithSlicing` under the hood.
@@ -341,7 +341,7 @@ The slicing is transparent to callers — `issues-hotspots.js` in each pipeline 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🔄 Fallback Rule Repositories
 
-External-issue detection depends on knowing which rule repositories exist in SonarCloud. If the `/api/rules/repositories` call fails, the tool falls back to a built-in set of 44 known SonarCloud repositories (`src/shared/utils/fallback-repos/index.js`).
+External-issue detection depends on knowing which rule repositories exist in SonarQube Cloud. If the `/api/rules/repositories` call fails, the tool falls back to a built-in set of 44 known SonarQube Cloud repositories (`src/shared/utils/fallback-repos/index.js`).
 
 The fallback set includes the `githubactions` IaC analyzer (previously omitted by accident; added back in the Apr 2026 release). Without it, GitHub Actions rules were incorrectly treated as external issues.
 
@@ -358,28 +358,28 @@ The fallback set includes the `githubactions` IaC analyzer (previously omitted b
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🚦 Rate Limit Handling
 
-The SonarCloud API client supports a configurable two-layer strategy for rate limiting. Customize it via the `rateLimit` section in your config file.
+The SonarQube Cloud API client supports a configurable two-layer strategy for rate limiting. Customize it via the `rateLimit` section in your config file.
 
 1. **Exponential backoff retry** (`maxRetries`, `baseDelay`) — When a 503 or 429 response is received, the request is retried up to `maxRetries` times with exponentially increasing delays (baseDelay × 2^attempt). If all retries are exhausted, the error is propagated to the caller. Default: `3` retries.
 
-2. **Write request throttling** (`minRequestInterval`) — POST requests are spaced at least `minRequestInterval` ms apart via a request interceptor. This proactively reduces the chance of triggering SonarCloud's rate limits during high-volume operations like issue sync and hotspot sync. Default: `0` (no throttling).
+2. **Write request throttling** (`minRequestInterval`) — POST requests are spaced at least `minRequestInterval` ms apart via a request interceptor. This proactively reduces the chance of triggering SonarQube Cloud's rate limits during high-volume operations like issue sync and hotspot sync. Default: `0` (no throttling).
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🔌 External Issues (Plugin Migration)
 
-Issues from SonarQube plugins that are not available in SonarCloud (e.g., MuleSoft, ABAP) are automatically migrated as **external issues** using the `ExternalIssue` and `AdHocRule` protobuf messages.
+Issues from SonarQube Server plugins that are not available in SonarQube Cloud (e.g., MuleSoft, ABAP) are automatically migrated as **external issues** using the `ExternalIssue` and `AdHocRule` protobuf messages.
 
-**Auto-detection**: The tool compares SonarQube rule repositories against SonarCloud's available repositories via `getRuleRepositories()`. If a rule's repository is not present in SonarCloud, the issue is routed through the external issue path instead of the regular `Issue` path.
+**Auto-detection**: The tool compares SonarQube Server rule repositories against SonarQube Cloud's available repositories via `getRuleRepositories()`. If a rule's repository is not present in SonarQube Cloud, the issue is routed through the external issue path instead of the regular `Issue` path.
 
-**SonarQube 2025+ `external_` prefix handling**: SonarQube 2025+ returns external linter issues with an `external_` prefix in the rule key (e.g., `external_ruff:D200` instead of `ruff:D200`). The tool detects this prefix and always treats such rules as external, then strips the prefix before building the `ExternalIssue` protobuf message to avoid double-prefixing in SonarCloud.
+**SonarQube Server 2025+ `external_` prefix handling**: SonarQube Server 2025+ returns external linter issues with an `external_` prefix in the rule key (e.g., `external_ruff:D200` instead of `ruff:D200`). The tool detects this prefix and always treats such rules as external, then strips the prefix before building the `ExternalIssue` protobuf message to avoid double-prefixing in SonarQube Cloud.
 
 **How it works**:
 1. Rules with an `external_` prefix in SQ are always treated as external (regardless of SC repo list)
 2. The `external_` prefix is stripped from the engineId before encoding (SQ `external_ruff:D200` → engineId `ruff`, ruleId `D200`)
 3. Issues with unsupported rule repos (no `external_` prefix) are detected by comparing against SC repositories
 4. Each unique rule becomes an `AdHocRule` with name, description, severity, type, clean code attribute, and impacts
-5. External issues appear in SonarCloud as `external_{engineId}:{ruleId}` (e.g., `external_ruff:D200`, `external_mulesoft:MS058`)
-6. Ad-hoc rules do not appear in SonarCloud's rules search (expected behavior per SC docs)
+5. External issues appear in SonarQube Cloud as `external_{engineId}:{ruleId}` (e.g., `external_ruff:D200`, `external_mulesoft:MS058`)
+6. Ad-hoc rules do not appear in SonarQube Cloud's rules search (expected behavior per SC docs)
 
 **Requirements**: Each `ExternalIssue` and `AdHocRule` must include:
 - `cleanCodeAttribute` — encoded as protobuf enum (varint), not string (see Protobuf Encoding section)
@@ -391,23 +391,23 @@ Issues from SonarQube plugins that are not available in SonarCloud (e.g., MuleSo
 
 The `migrate` command syncs issue metadata after the scanner report is uploaded. The sync pipeline runs in several stages:
 
-1. **Pre-filter** — Batch-fetches SQ changelogs for all issues and discards any issue that has no human-authored changes (see below). This avoids redundant API calls to SonarCloud for issues that are still in their pristine `OPEN` state.
-2. **Wait for SC indexing** — If SonarCloud returns 0 issues immediately after a first-time upload, the syncer retries with exponential backoff (initial delay 10 s, max 60 s, up to 10 attempts) until the CE analysis is fully indexed. This handles the race condition introduced by Issue #91 where the analysis report was uploaded but SonarCloud hadn't yet indexed its issues.
-3. **Match** — Searches for a matching issue in SonarCloud by rule, component, and line number.
-4. **Replay changelog** — Fetches the SonarQube issue changelog and replays all status transitions in order (Open → Confirmed → False Positive, etc.).
+1. **Pre-filter** — Batch-fetches SQ changelogs for all issues and discards any issue that has no human-authored changes (see below). This avoids redundant API calls to SonarQube Cloud for issues that are still in their pristine `OPEN` state.
+2. **Wait for SC indexing** — If SonarQube Cloud returns 0 issues immediately after a first-time upload, the syncer retries with exponential backoff (initial delay 10 s, max 60 s, up to 10 attempts) until the CE analysis is fully indexed. This handles the race condition introduced by Issue #91 where the analysis report was uploaded but SonarQube Cloud hadn't yet indexed its issues.
+3. **Match** — Searches for a matching issue in SonarQube Cloud by rule, component, and line number.
+4. **Replay changelog** — Fetches the SonarQube Server issue changelog and replays all status transitions in order (Open → Confirmed → False Positive, etc.).
 5. **Assignee** — Sets the assignee (supports user mapping from SQ login to SC login).
-6. **Comments** — Copies comments, skipping any that begin with `[Migrated from SonarQube]` to avoid double-migration.
+6. **Comments** — Copies comments, skipping any that begin with `[Migrated from SonarQube Server]` to avoid double-migration.
 7. **Tags** — Sets tags.
 
 ### Pre-filter: `hasManualChanges` (`src/shared/utils/issue-sync/`)
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Before touching SonarCloud, the syncer applies a pre-filter that only keeps issues with human-authored changes:
+Before touching SonarQube Cloud, the syncer applies a pre-filter that only keeps issues with human-authored changes:
 
 | Check | Condition |
 |-------|-----------|
 | Human changelog entry | At least one changelog entry with a non-empty `user` field |
-| Manual comments | At least one comment not prefixed with `[Migrated from SonarQube]` |
+| Manual comments | At least one comment not prefixed with `[Migrated from SonarQube Server]` |
 | Custom tags | `issue.tags` array is non-empty |
 | Manual assignee | `issue.assignee` is set |
 | Updated after creation | `updateDate !== creationDate` (catch-all safety net) |
@@ -439,7 +439,7 @@ Total concurrent API calls: 20 workers × 5 internal = **100** (vs 20 with singl
 - **Max attempts**: 10 (configurable via `options.maxRetries`)
 - **Transient errors**: fetch errors during a retry are caught and logged; the function returns `[]` after exhausting all retries
 
-**SonarQube version differences**:
+**SonarQube Server version differences**:
 - SQ 9.9 statuses: `OPEN`, `CONFIRMED`, `REOPENED`, `RESOLVED`, `CLOSED`
 - SQ 10.4+: `OPEN`, `CONFIRMED`, `FALSE_POSITIVE`, `ACCEPTED`, `FIXED`
 - Available transitions: `confirm`, `unconfirm`, `reopen`, `resolve`, `falsepositive`, `wontfix`, `accept`
@@ -461,9 +461,9 @@ Hotspots are converted to `Issue` format for the scanner report (with `type=SECU
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🔄 Issue Status Transition Mapping
 
-Each pipeline includes an `issue-status-mapper.js` that maps SonarQube issue changelog entries to SonarCloud transitions:
+Each pipeline includes an `issue-status-mapper.js` that maps SonarQube Server issue changelog entries to SonarQube Cloud transitions:
 
-| SonarQube Status/Resolution | SonarCloud Transition |
+| SonarQube Server Status/Resolution | SonarQube Cloud Transition |
 |-----------------------------|----------------------|
 | `FALSE-POSITIVE` (resolution or status) | `falsepositive` |
 | `WONTFIX` (resolution or status) | `wontfix` |
@@ -481,10 +481,10 @@ The mapper handles both SQ < 10.4 (where `FALSE-POSITIVE` and `WONTFIX` appear a
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🔑 Project Key Resolution
 
-SonarCloud requires globally unique project keys across all organizations. When migrating projects, the tool uses the following strategy:
+SonarQube Cloud requires globally unique project keys across all organizations. When migrating projects, the tool uses the following strategy:
 
-1. **Try the original SonarQube project key** — check if it's available globally on SonarCloud via `/api/components/show`
-2. **If available** — use the original key as-is, so the SonarCloud project key matches SonarQube
+1. **Try the original SonarQube Server project key** — check if it's available globally on SonarQube Cloud via `/api/components/show`
+2. **If available** — use the original key as-is, so the SonarQube Cloud project key matches SonarQube Server
 3. **If taken by another organization** — fall back to `{org}_{key}` (e.g., `my-org_my-project`) and log a warning
 4. **If already owned by the target organization** — use the original key (the project was likely created in a previous migration run)
 
@@ -493,7 +493,7 @@ Key conflicts are reported in the migration summary and in the `reports/migratio
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🗺️ Organization Mapping
 
-The `migrate` command maps projects to target SonarCloud organizations based on their DevOps platform bindings. Projects with the same ALM binding are grouped together. Mapping CSVs are generated for review before execution (via `--dry-run`).
+The `migrate` command maps projects to target SonarQube Cloud organizations based on their DevOps platform bindings. Projects with the same ALM binding are grouped together. Mapping CSVs are generated for review before execution (via `--dry-run`).
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🔍 Dry-Run & Editable CSV Workflow
@@ -501,36 +501,36 @@ The `migrate` command maps projects to target SonarCloud organizations based on 
 The `--dry-run` flag generates 8 exhaustive CSV files covering projects, organizations, groups, quality profiles, quality gates, portfolios, permission templates, and global permissions. Each CSV includes an `Include` column (defaulting to `yes`) that users can edit to filter what gets migrated.
 
 **Pipeline integration:**
-1. `migrate --dry-run` extracts data from SonarQube, generates CSVs, then stops
+1. `migrate --dry-run` extracts data from SonarQube Server, generates CSVs, then stops
 2. User reviews/edits CSVs (set `Include=no` to exclude resources from migration)
-3. `migrate` (without `--dry-run`) detects existing CSVs, reads them into memory **before** wiping the output directory, re-extracts from SonarQube, then applies CSV overrides via `applyCsvOverrides()` which returns filtered copies using `structuredClone`
+3. `migrate` (without `--dry-run`) detects existing CSVs, reads them into memory **before** wiping the output directory, re-extracts from SonarQube Server, then applies CSV overrides via `applyCsvOverrides()` which returns filtered copies using `structuredClone`
 
-Quality gate CSVs use a flat one-row-per-gate pattern — users can include or exclude entire gates, but conditions are always migrated as-is from SonarQube. Portfolio and permission template CSVs use a parent/child pattern for their member/permission rows.
+Quality gate CSVs use a flat one-row-per-gate pattern — users can include or exclude entire gates, but conditions are always migrated as-is from SonarQube Server. Portfolio and permission template CSVs use a parent/child pattern for their member/permission rows.
 
 See [dry-run-csv-reference.md](dry-run-csv-reference.md) for full CSV schema documentation.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 📋 Quality Profile Migration
 
-Quality profiles are migrated using SonarQube's backup/restore XML format, which preserves all rule configurations, severity overrides, and parameter values. Profile permissions (user and group access) are migrated separately via the permissions API.
+Quality profiles are migrated using SonarQube Server's backup/restore XML format, which preserves all rule configurations, severity overrides, and parameter values. Profile permissions (user and group access) are migrated separately via the permissions API.
 
-Both **custom and built-in** profiles are migrated. Built-in profiles (e.g., "Sonar way") cannot be overwritten on SonarCloud, so they are restored as custom profiles with a "(SonarQube Migrated)" suffix (e.g., "Sonar way (SonarQube Migrated)"). These migrated profiles are automatically assigned to each project to ensure the same rules are active as in SonarQube.
+Both **custom and built-in** profiles are migrated. Built-in profiles (e.g., "Sonar way") cannot be overwritten on SonarQube Cloud, so they are restored as custom profiles with a "(SonarQube Server Migrated)" suffix (e.g., "Sonar way (SonarQube Server Migrated)"). These migrated profiles are automatically assigned to each project to ensure the same rules are active as in SonarQube Server.
 
-To skip quality profile migration entirely and use each language's existing default SonarCloud profile, pass `--skip-quality-profile-sync`.
+To skip quality profile migration entirely and use each language's existing default SonarQube Cloud profile, pass `--skip-quality-profile-sync`.
 
 **API gotchas**:
 - `/api/qualityprofiles/backup` requires `language` + `qualityProfile` (name), not `profileKey`
 - `/api/qualityprofiles/search_users` requires `language` + `qualityProfile` (name)
 - Built-in profiles: permission APIs return 400 (expected, handle gracefully)
 
-After profile migration, a **quality profile diff report** (`quality-profiles/quality-profile-diff.json`) is written to the output directory. This report compares active rules per language between SonarQube and SonarCloud, listing:
-- **Missing rules** — rules active in SonarQube but not available in SonarCloud (may cause fewer issues)
-- **Added rules** — rules available in SonarCloud but not in SonarQube (may create new issues)
+After profile migration, a **quality profile diff report** (`quality-profiles/quality-profile-diff.json`) is written to the output directory. This report compares active rules per language between SonarQube Server and SonarQube Cloud, listing:
+- **Missing rules** — rules active in SonarQube Server but not available in SonarQube Cloud (may cause fewer issues)
+- **Added rules** — rules available in SonarQube Cloud but not in SonarQube Server (may create new issues)
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🚧 Quality Gate Migration
 
-Quality gates are created with their full condition definitions (metric, operator, threshold). The SonarQube API uses gate `name` (not `id`) for all operations. Built-in gates are skipped since they already exist in SonarCloud.
+Quality gates are created with their full condition definitions (metric, operator, threshold). The SonarQube Server API uses gate `name` (not `id`) for all operations. Built-in gates are skipped since they already exist in SonarQube Cloud.
 
 **API gotchas**:
 - `/api/qualitygates/list` returns no `id` field, only `name`
@@ -573,7 +573,7 @@ Each transfer creates a checkpoint journal file alongside the state file:
 
 - **Phase tracking**: Each extraction phase (project metadata, metrics, components, rules, issues, hotspots, measures, sources, etc.) is tracked individually
 - **Branch tracking**: Per-branch completion status with CE task IDs for upload deduplication
-- **Session fingerprint**: SonarQube version, URL, and project key are recorded to detect environment changes between runs
+- **Session fingerprint**: SonarQube Server version, URL, and project key are recorded to detect environment changes between runs
 
 ### State Management Components
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -606,7 +606,7 @@ If the main state file is corrupted, the system falls back to the `.backup` file
 
 ### Extraction Caching
 
-Completed extraction phases are cached as gzipped JSON in `<outputDir>/cache/extractions/<projectKey>/`. On resume, cached phases are loaded from disk instead of re-fetching from SonarQube. Cache files include integrity metadata and auto-purge after 7 days (configurable via `transfer.checkpoint.cacheMaxAgeDays`).
+Completed extraction phases are cached as gzipped JSON in `<outputDir>/cache/extractions/<projectKey>/`. On resume, cached phases are loaded from disk instead of re-fetching from SonarQube Server. Cache files include integrity metadata and auto-purge after 7 days (configurable via `transfer.checkpoint.cacheMaxAgeDays`).
 
 ### Upload Deduplication
 
@@ -658,7 +658,7 @@ The `csv-entity-filters.js` module in `src/shared/mapping/` provides dry-run CSV
 | `applyGlobalPermissionsCsv` | Global permissions | Group Name + Permission + Include |
 | `applyTemplateMappingsCsv` | Permission templates | Template Name + Permission Key + Include |
 | `applyPortfolioMappingsCsv` | Portfolios | Portfolio Key + Member Project Key + Include |
-| `applyUserMappingsCsv` | User mappings | SonarQube Login + SonarCloud Login + Include |
+| `applyUserMappingsCsv` | User mappings | SonarQube Server Login + SonarQube Cloud Login + Include |
 
 All filters use the `Include` column from the CSV (default: `yes`). Setting `Include=no` excludes the entity from migration.
 
@@ -672,9 +672,9 @@ For non-standard environments (e.g. staging), the Desktop app's **Advanced Setti
 <!-- Updated: Apr 18, 2026 -->
 ## 🔑 Enterprise Key & Portfolio Skipping
 
-The SonarCloud enterprise key (`sonarcloud.enterprise.key`) is **optional** — its absence no longer aborts the migration. When the key is missing, portfolio migration is gracefully skipped via `handleMissingEnterpriseKey()` (`src/shared/utils/portfolio-skip.js`):
+The SonarQube Cloud enterprise key (`sonarcloud.enterprise.key`) is **optional** — its absence no longer aborts the migration. When the key is missing, portfolio migration is gracefully skipped via `handleMissingEnterpriseKey()` (`src/shared/utils/portfolio-skip.js`):
 
-- If portfolios were extracted from SonarQube, a `WARN` log is emitted and `results.portfoliosSkipped` is incremented.
+- If portfolios were extracted from SonarQube Server, a `WARN` log is emitted and `results.portfoliosSkipped` is incremented.
 - If no portfolios exist, an `INFO` log is emitted and migration proceeds normally.
 
 The `portfoliosSkipped` count is included in the migration summary and migration reports.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -307,6 +307,15 @@ The migrator now restores built-in profiles as custom profiles (e.g., "Sonar way
 
 If you'd prefer to skip quality profile migration entirely and use each language's default SonarCloud profile instead, use `--skip-quality-profile-sync`.
 
+<!-- <subsection-updated last-updated="2026-05-08T00:00:00Z" updated-by="Claude" /> -->
+## 🧪 Source Issues in `IN_SANDBOX` Are Migrated as `OPEN` (Issue #136)
+
+SonarQube 2025+ introduces an `IN_SANDBOX` issue status — used for issues raised by sandboxed AI rules that have not yet been promoted to the standard catalog. SonarCloud does not have an equivalent state, so these issues are migrated as `OPEN` on the destination.
+
+This is a known limitation, not a bug. There is no SonarCloud transition that maps to `IN_SANDBOX`, so the migrator leaves the migrated issue in its default `OPEN` state and the rest of the metadata sync (assignment, comments, tags) still applies. Once the underlying sandbox rule graduates and exists on both servers, you can re-evaluate the issues on SonarCloud.
+
+If you want to filter these out of the destination project, you can manually triage them post-migration on SonarCloud.
+
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 📄 SonarQube API Pagination Limits
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,7 +18,7 @@ After every `migrate` run (whether it succeeds, partially succeeds, or crashes),
 1. **Open `reports/migration-report.txt`** — it's structured top-down so you can quickly find problems:
 
    - **SUMMARY** — overall counts (succeeded / partial / failed)
-   - **SERVER-WIDE STEPS** — did extraction from SonarQube work?
+   - **SERVER-WIDE STEPS** — did extraction from SonarQube Server work?
    - **ORGANIZATION** — did org-level setup (groups, gates, profiles) work?
    - **FAILED / PARTIAL PROJECTS (DETAILED)** — step-by-step breakdown for every project that had issues, showing exactly which step failed and why
    - **ALL PROJECTS** — compact one-line-per-project list with failed step names
@@ -125,7 +125,7 @@ grep "SKIP\|skipping" migration.log
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ### Re-running after failures
 
-The migration can be re-run safely. Projects that already exist in SonarCloud will be updated (not duplicated). To fix specific failures:
+The migration can be re-run safely. Projects that already exist in SonarQube Cloud will be updated (not duplicated). To fix specific failures:
 
 - **Rate limit errors on hotspot sync** — re-run with `--skip-issue-metadata-sync` (issues already synced) and increase rate limit config
 - **Report upload failures** — check the specific error, fix the root cause, and re-run
@@ -156,10 +156,10 @@ If the checkpoint journal becomes corrupt (e.g., due to a system crash during a 
 ./cloudvoyager transfer -c config.json --verbose --force-restart
 ```
 
-### SonarQube Version Mismatch on Resume
+### SonarQube Server Version Mismatch on Resume
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-If you upgrade SonarQube between pause and resume, the tool warns about a version mismatch in the session fingerprint. By default, this is a warning only — the transfer continues. To enforce strict version matching:
+If you upgrade SonarQube Server between pause and resume, the tool warns about a version mismatch in the session fingerprint. By default, this is a warning only — the transfer continues. To enforce strict version matching:
 
 ```json
 {
@@ -176,7 +176,7 @@ With `strictResume: true`, a version mismatch will fail the transfer and require
 ### Source Code Changed Between Pause and Resume
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-If source code in SonarQube changes between pause and resume (e.g., new analysis uploaded), already-cached extraction phases will use stale data. Use `--force-fresh-extract` to re-extract all data while keeping the checkpoint journal:
+If source code in SonarQube Server changes between pause and resume (e.g., new analysis uploaded), already-cached extraction phases will use stale data. Use `--force-fresh-extract` to re-extract all data while keeping the checkpoint journal:
 
 ```bash
 ./cloudvoyager transfer -c config.json --verbose --force-fresh-extract
@@ -226,33 +226,33 @@ This only affects building the binary. Tests, linting, and `npm run build` work 
 ## 🔐 Authentication Errors
 - Verify your tokens have the correct permissions
 - Check that tokens haven't expired
-- Ensure the project key exists in SonarQube
-- Verify the organization key is correct in SonarCloud
+- Ensure the project key exists in SonarQube Server
+- Verify the organization key is correct in SonarQube Cloud
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## ⚠️ Generic "Issue whilst processing" Error
 
-This vague SonarCloud error can be caused by:
-- **Branch name mismatch** - SonarQube and SonarCloud have different main branch names. The tool handles this automatically via `getMainBranchName()`, but verify your SonarCloud project's branch configuration
+This vague SonarQube Cloud error can be caused by:
+- **Branch name mismatch** - SonarQube Server and SonarQube Cloud have different main branch names. The tool handles this automatically via `getMainBranchName()`, but verify your SonarQube Cloud project's branch configuration
 - **Line count mismatch** - Source file line counts don't match component metadata. The tool uses actual source content line counts to avoid this
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
-## ❌ Report Rejected by SonarCloud
+## ❌ Report Rejected by SonarQube Cloud
 - **Empty ScmInfo** - Ensure `changesetIndexByLine` is populated for ADDED files (array of zeros, one per line)
-- **Issue gap field** - The `gap` field should not be included in issues (it's scanner-computed, not from SonarQube)
-- **Duplicate report** - SonarCloud rejects reports with the same `scm_revision_id`. Use a different commit or update the source project
+- **Issue gap field** - The `gap` field should not be included in issues (it's scanner-computed, not from SonarQube Server)
+- **Duplicate report** - SonarQube Cloud rejects reports with the same `scm_revision_id`. Use a different commit or update the source project
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🔑 Project Key Conflicts
 
-SonarCloud requires globally unique project keys across all organizations. By default, CloudVoyager uses the **original SonarQube project key** when creating projects on SonarCloud. If the key is already taken by another SonarCloud organization, the tool automatically falls back to a prefixed key (`{org}_{key}`) and logs a warning.
+SonarQube Cloud requires globally unique project keys across all organizations. By default, CloudVoyager uses the **original SonarQube Server project key** when creating projects on SonarQube Cloud. If the key is already taken by another SonarQube Cloud organization, the tool automatically falls back to a prefixed key (`{org}_{key}`) and logs a warning.
 
 Key conflicts are reported in three places:
 - **Console logs** — a warning is logged immediately when a conflict is detected during migration
 - **Migration summary** — a "Project key conflicts" section at the end of the run lists all affected projects
 - **Migration report** — the `reports/migration-report.txt` includes a "PROJECT KEY CONFLICTS" section, and `reports/migration-report.json` includes a `projectKeyWarnings` array
 
-If you see key conflicts, the affected projects were still migrated successfully — they just use a different key than the original SonarQube key. You can rename them later via the SonarCloud API (`/api/projects/update_key`) if the conflicting key becomes available.
+If you see key conflicts, the affected projects were still migrated successfully — they just use a different key than the original SonarQube Server key. You can rename them later via the SonarQube Cloud API (`/api/projects/update_key`) if the conflicting key becomes available.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🌐 Connection Timeouts
@@ -263,7 +263,7 @@ If you see key conflicts, the affected projects were still migrated successfully
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🚦 Rate Limiting (503 / 429 Errors)
 
-SonarCloud may return 503 or 429 errors when too many API requests are made in a short period, especially during issue and hotspot sync on large projects.
+SonarQube Cloud may return 503 or 429 errors when too many API requests are made in a short period, especially during issue and hotspot sync on large projects.
 
 By default, CloudVoyager retries rate-limited requests up to 3 times with exponential backoff. You can tune this via the `rateLimit` section in your config file:
 
@@ -289,9 +289,9 @@ If you still encounter rate limit errors after all retries are exhausted, consid
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🏷️ Project Names Showing as Project Keys
 
-If projects in SonarCloud show the project key as the display name instead of the original human-readable name from SonarQube, the project was likely created by an older version of CloudVoyager. The current version automatically carries over the original project name from SonarQube when creating projects in SonarCloud.
+If projects in SonarQube Cloud show the project key as the display name instead of the original human-readable name from SonarQube Server, the project was likely created by an older version of CloudVoyager. The current version automatically carries over the original project name from SonarQube Server when creating projects in SonarQube Cloud.
 
-To fix already-migrated projects, you can rename them manually in SonarCloud via **Project Settings > General Settings > Project Name**, or delete and re-migrate the project.
+To fix already-migrated projects, you can rename them manually in SonarQube Cloud via **Project Settings > General Settings > Project Name**, or delete and re-migrate the project.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🚧 Quality Gate / Profile Permission Errors (400)
@@ -299,27 +299,27 @@ To fix already-migrated projects, you can rename them manually in SonarCloud via
 When migrating quality gates or profiles, permission APIs may return 400 errors for built-in gates/profiles. This is expected — built-in resources don't support custom permissions. The migrators handle this gracefully and skip these entries.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
-## 📊 Issue Counts Differ Between SonarQube and SonarCloud
+## 📊 Issue Counts Differ Between SonarQube Server and SonarQube Cloud
 
-If you see different issue counts (Security, Reliability, Maintainability) after migration, this is usually caused by **different active rules** between the SonarQube and SonarCloud quality profiles.
+If you see different issue counts (Security, Reliability, Maintainability) after migration, this is usually caused by **different active rules** between the SonarQube Server and SonarQube Cloud quality profiles.
 
-The migrator now restores built-in profiles as custom profiles (e.g., "Sonar way (SonarQube Migrated)") and assigns them to projects. However, some rules may not exist on SonarCloud (e.g., rules from third-party plugins). Check `quality-profiles/quality-profile-diff.json` in the output directory to see which rules are missing or added per language.
+The migrator now restores built-in profiles as custom profiles (e.g., "Sonar way (SonarQube Server Migrated)") and assigns them to projects. However, some rules may not exist on SonarQube Cloud (e.g., rules from third-party plugins). Check `quality-profiles/quality-profile-diff.json` in the output directory to see which rules are missing or added per language.
 
-If you'd prefer to skip quality profile migration entirely and use each language's default SonarCloud profile instead, use `--skip-quality-profile-sync`.
+If you'd prefer to skip quality profile migration entirely and use each language's default SonarQube Cloud profile instead, use `--skip-quality-profile-sync`.
 
 <!-- <subsection-updated last-updated="2026-05-08T00:00:00Z" updated-by="Claude" /> -->
 ## 🧪 Source Issues in `IN_SANDBOX` Are Migrated as `OPEN` (Issue #136)
 
-SonarQube 2025+ introduces an `IN_SANDBOX` issue status — used for issues raised by sandboxed AI rules that have not yet been promoted to the standard catalog. SonarCloud does not have an equivalent state, so these issues are migrated as `OPEN` on the destination.
+SonarQube Server 2025+ introduces an `IN_SANDBOX` issue status — used for issues raised by sandboxed AI rules that have not yet been promoted to the standard catalog. SonarQube Cloud does not have an equivalent state, so these issues are migrated as `OPEN` on the destination.
 
-This is a known limitation, not a bug. There is no SonarCloud transition that maps to `IN_SANDBOX`, so the migrator leaves the migrated issue in its default `OPEN` state and the rest of the metadata sync (assignment, comments, tags) still applies. Once the underlying sandbox rule graduates and exists on both servers, you can re-evaluate the issues on SonarCloud.
+This is a known limitation, not a bug. There is no SonarQube Cloud transition that maps to `IN_SANDBOX`, so the migrator leaves the migrated issue in its default `OPEN` state and the rest of the metadata sync (assignment, comments, tags) still applies. Once the underlying sandbox rule graduates and exists on both servers, you can re-evaluate the issues on SonarQube Cloud.
 
-If you want to filter these out of the destination project, you can manually triage them post-migration on SonarCloud.
+If you want to filter these out of the destination project, you can manually triage them post-migration on SonarQube Cloud.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
-## 📄 SonarQube API Pagination Limits
+## 📄 SonarQube Server API Pagination Limits
 
-Some SonarQube APIs enforce a maximum page size of 100 (not 500):
+Some SonarQube Server APIs enforce a maximum page size of 100 (not 500):
 - `/api/permissions/groups`
 - `/api/project_tags/search`
 - `/api/qualityprofiles/search_users`
@@ -330,7 +330,7 @@ The extractors handle this automatically, but if you see pagination-related erro
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 🔤 Quality Gates Use Names, Not IDs
 
-The SonarQube quality gates API uses `name` for all operations (`/api/qualitygates/show`, `/api/qualitygates/select`), not `id`. If you see "not found" errors related to quality gates, check that you're using the gate name.
+The SonarQube Server quality gates API uses `name` for all operations (`/api/qualitygates/show`, `/api/qualitygates/select`), not `id`. If you see "not found" errors related to quality gates, check that you're using the gate name.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 💾 Out of Memory / Heap Allocation Errors
@@ -375,7 +375,7 @@ Or manually increase concurrency via CLI flags:
 
 For persistent config, add a `performance` section to your config file. See the [Configuration Reference](configuration.md#performance-settings) for all options.
 
-Keep `hotspotSync.concurrency` low (3–5) to avoid SonarCloud rate limits.
+Keep `hotspotSync.concurrency` low (3–5) to avoid SonarQube Cloud rate limits.
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 📦 Large Reports
@@ -436,7 +436,7 @@ You can also sync just one type of metadata at a time:
 
 > **Import bug fixes (v1.3):** Earlier versions had missing imports in `issue-details.js`, `hotspot-details.js`, and `format-pdf/index.js` that could cause report generation to fail with `ReferenceError` or produce incomplete output. These have been fixed in v1.3. If you encountered report generation errors on a prior version, upgrade and re-run `verify`.
 
-After migration, use the `verify` command to generate a detailed pass/fail comparison of SonarQube vs SonarCloud data:
+After migration, use the `verify` command to generate a detailed pass/fail comparison of SonarQube Server vs SonarQube Cloud data:
 
 ```bash
 ./cloudvoyager verify -c migrate-config.json --verbose
@@ -456,7 +456,7 @@ The console also prints a summary with per-project breakdowns and overall pass/f
 
 | Status | Meaning |
 |--------|---------|
-| **pass** | SonarQube and SonarCloud data match |
+| **pass** | SonarQube Server and SonarQube Cloud data match |
 | **fail** | Differences detected that should have been migrated |
 | **warning** | Unsyncable differences (expected — see below) |
 | **skipped** | Check was skipped (e.g., project not found in SC) |
@@ -465,12 +465,12 @@ The console also prints a summary with per-project breakdowns and overall pass/f
 ### Issue assignment failures
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-If issue assignments are failing during migration, the most likely cause is a **login mismatch** between SonarQube and SonarCloud. SonarQube uses local logins (e.g., `john.doe`) while SonarCloud typically uses SSO/GitHub logins (e.g., `john-doe-github`).
+If issue assignments are failing during migration, the most likely cause is a **login mismatch** between SonarQube Server and SonarQube Cloud. SonarQube Server uses local logins (e.g., `john.doe`) while SonarQube Cloud typically uses SSO/GitHub logins (e.g., `john-doe-github`).
 
 **Fix:** Use the `user-mappings.csv` generated during `--dry-run` to map SQ logins to SC logins:
 
 1. Run `--dry-run` to generate `migration-output/mappings/user-mappings.csv`
-2. Fill in the `SonarCloud Login` column for each user
+2. Fill in the `SonarQube Cloud Login` column for each user
 3. Set `Include=no` for service accounts or users who should not have issues assigned
 4. Run the actual migration — mappings are applied automatically
 
@@ -481,7 +481,7 @@ See [Dry-Run CSV Reference — user-mappings.csv](dry-run-csv-reference.md#user-
 ### Unsyncable items (expected differences)
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Some differences are expected because the SonarCloud API does not support syncing them:
+Some differences are expected because the SonarQube Cloud API does not support syncing them:
 
 | Item | Why it's unsyncable |
 |------|-------------------|
@@ -516,9 +516,9 @@ CloudVoyager uses a hierarchy of custom error classes (defined in `src/shared/ut
 |-------------|-----------|----------------|
 | **CloudVoyagerError** | 500 | Base class — all errors below extend this |
 | **ConfigurationError** | 400 | Invalid config file, missing required fields, schema validation failure |
-| **SonarQubeAPIError** | varies | SonarQube API returned an error (includes `endpoint` for debugging) |
-| **SonarCloudAPIError** | varies | SonarCloud API returned an error (includes `endpoint` for debugging) |
-| **AuthenticationError** | 401 | Invalid or expired token for SonarQube or SonarCloud |
+| **SonarQubeAPIError** | varies | SonarQube Server API returned an error (includes `endpoint` for debugging) |
+| **SonarCloudAPIError** | varies | SonarQube Cloud API returned an error (includes `endpoint` for debugging) |
+| **AuthenticationError** | 401 | Invalid or expired token for SonarQube Server or SonarQube Cloud |
 | **ProtobufEncodingError** | 500 | Failed to encode data into protobuf format (may include `data` payload) |
 | **StateError** | 500 | Corrupt state file, failed atomic write, or state inconsistency |
 | **ValidationError** | 400 | Data validation failure (includes `errors` array with details) |
@@ -547,8 +547,8 @@ When resuming from a checkpoint journal, the tool validates a session fingerprin
 
 | Field Changed | Behavior |
 |---------------|----------|
-| SonarQube version | **Warning** logged, resume continues |
-| SonarQube URL | **Warning** logged, resume continues |
+| SonarQube Server version | **Warning** logged, resume continues |
+| SonarQube Server URL | **Warning** logged, resume continues |
 | CloudVoyager version | **Warning** logged, resume continues |
 | Project key | **Throws StaleResumeError** — hard fail, requires `--force-restart` |
 
@@ -559,14 +559,14 @@ With `strictResume: true` in config, any fingerprint warning becomes a hard fail
 ## 🗃️ Extraction Cache TTL
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-Extraction caches are stored as **gzipped JSON** files in the `cache/` directory. Files older than **7 days** (configurable via `cacheMaxAgeDays`) are automatically purged. Use `--force-fresh-extract` to discard all caches and re-extract from SonarQube.
+Extraction caches are stored as **gzipped JSON** files in the `cache/` directory. Files older than **7 days** (configurable via `cacheMaxAgeDays`) are automatically purged. Use `--force-fresh-extract` to discard all caches and re-extract from SonarQube Server.
 
 ---
 
 ## 🔄 Upload Deduplication on Resume
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-The checkpoint journal records successful CE task uploads per branch (task ID + timestamp). On resume, if a branch was already uploaded successfully, the upload is skipped. This prevents duplicate CE tasks in SonarCloud after a crash between upload and journal save.
+The checkpoint journal records successful CE task uploads per branch (task ID + timestamp). On resume, if a branch was already uploaded successfully, the upload is skipped. This prevents duplicate CE tasks in SonarQube Cloud after a crash between upload and journal save.
 
 ---
 
@@ -585,22 +585,22 @@ Between pipeline phases, the tool checks the shutdown flag and throws a `Gracefu
 ## 🔤 External Linter Issues Missing After Migration (SQ 2025+)
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-SonarQube 2025+ stores external linter rules (Ruff, Pylint, ESLint, Checkstyle, etc.) with an `external_` prefix in the rule key (e.g., `external_ruff:D200`). If you see zero Ruff/Pylint/etc. issues in SonarCloud after migration, ensure you are running CloudVoyager v1.2.0+ which correctly handles this prefix. Older versions misclassify these as native issues, causing SonarCloud to silently drop them.
+SonarQube Server 2025+ stores external linter rules (Ruff, Pylint, ESLint, Checkstyle, etc.) with an `external_` prefix in the rule key (e.g., `external_ruff:D200`). If you see zero Ruff/Pylint/etc. issues in SonarQube Cloud after migration, ensure you are running CloudVoyager v1.2.0+ which correctly handles this prefix. Older versions misclassify these as native issues, causing SonarQube Cloud to silently drop them.
 
 ---
 
 ## 🔤 External Issue `cleanCodeAttribute` Must Be Enum
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-When migrating issues from SonarQube plugins not available in SonarCloud (e.g., MuleSoft), the tool creates external issues. A critical encoding detail:
+When migrating issues from SonarQube Server plugins not available in SonarQube Cloud (e.g., MuleSoft), the tool creates external issues. A critical encoding detail:
 
 - The `cleanCodeAttribute` field in the protobuf `AdHocRule` message must be encoded as a **protobuf enum (varint)**, not a string.
-- Despite the proto definition showing `optional string`, SonarCloud's CE silently ignores external issues if `cleanCodeAttribute` is string-encoded.
+- Despite the proto definition showing `optional string`, SonarQube Cloud's CE silently ignores external issues if `cleanCodeAttribute` is string-encoded.
 - Valid enum values: `CONVENTIONAL=1`, `FORMATTED=2`, `IDENTIFIABLE=3`, `CLEAR=4`, `COMPLETE=5`, `EFFICIENT=6`, `LOGICAL=7`, `DISTINCT=8`, `FOCUSED=9`, `MODULAR=10`, `TESTED=11`, `LAWFUL=12`, `RESPECTFUL=13`, `TRUSTWORTHY=14`.
 
 ---
 
-## 🕘 SonarQube 9.9 Issue Statuses
+## 🕘 SonarQube Server 9.9 Issue Statuses
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
 SQ 9.9 LTS uses the legacy issue status model with only 5 statuses:
@@ -614,23 +614,23 @@ The modern statuses (`FALSE_POSITIVE`, `ACCEPTED`, `FIXED`) do **not** exist in 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 📊 Projects with 10,000+ Issues
 
-SonarQube's `/api/issues/search` endpoint caps results at 10,000 due to an Elasticsearch hard limit.
+SonarQube Server's `/api/issues/search` endpoint caps results at 10,000 due to an Elasticsearch hard limit.
 
-> **Note (v1.3+):** Large-project issue handling now has two complementary mechanisms. The **search slicer** handles retrieval of >10K issues from SonarQube by splitting the date range into windows that each stay under the 10K API limit. The **SCM date backdating** (`backdateChangesets`) preserves each issue's original SonarQube creation date in SonarCloud by writing per-line blame dates into the changeset protobuf. A safety split ensures no single calendar day exceeds 5K issues (50% margin under the 10K ES visualization cap). Together, these two features ensure that projects of any size are fully extracted from SonarQube and fully visible in SonarCloud with accurate historical creation dates.
+> **Note (v1.3+):** Large-project issue handling now has two complementary mechanisms. The **search slicer** handles retrieval of >10K issues from SonarQube Server by splitting the date range into windows that each stay under the 10K API limit. The **SCM date backdating** (`backdateChangesets`) preserves each issue's original SonarQube Server creation date in SonarQube Cloud by writing per-line blame dates into the changeset protobuf. A safety split ensures no single calendar day exceeds 5K issues (50% margin under the 10K ES visualization cap). Together, these two features ensure that projects of any size are fully extracted from SonarQube Server and fully visible in SonarQube Cloud with accurate historical creation dates.
 
 ### Error: `10001th result asked`
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-**Symptom:** Transfer or migration fails with `SonarQube API error (400): Can return only the first 10000 results. 10001th result asked.`
+**Symptom:** Transfer or migration fails with `SonarQube Server API error (400): Can return only the first 10000 results. 10001th result asked.`
 
 **Fix (v1.2.1+):** The date-range probe that triggered this error has been replaced with a fixed epoch (`2006-01-01` → now) range. No configuration needed — re-run the transfer or migration.
 
 ### Error: `Date cannot be parsed as either a date or date+time`
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-**Symptom:** Transfer fails with `SonarQube API error (400): Date '2007-09-08T21:21:02.125Z' cannot be parsed as either a date or date+time` when slicing activates.
+**Symptom:** Transfer fails with `SonarQube Server API error (400): Date '2007-09-08T21:21:02.125Z' cannot be parsed as either a date or date+time` when slicing activates.
 
-**Cause:** JavaScript's `toISOString()` produces milliseconds (`.125Z`). SonarQube's `createdAfter`/`createdBefore` API parameters require `+0000` format without milliseconds.
+**Cause:** JavaScript's `toISOString()` produces milliseconds (`.125Z`). SonarQube Server's `createdAfter`/`createdBefore` API parameters require `+0000` format without milliseconds.
 
 **Fix (v1.2.1+):** Date window boundaries now use `+0000` format. Re-run the transfer or migration.
 
@@ -639,22 +639,22 @@ SonarQube's `/api/issues/search` endpoint caps results at 10,000 due to an Elast
 
 The search slicer algorithm:
 1. Detects when total issues exceed 10K
-2. Divides the full SonarQube era into 12 equal-width time windows
+2. Divides the full SonarQube Server era into 12 equal-width time windows
 3. Recursively bisects any window that still exceeds 10K
-4. Stops bisecting only if a window cannot be split further (same-millisecond boundary — an unavoidable SonarQube API limitation for mass-import scenarios where all issues share one identical timestamp)
+4. Stops bisecting only if a window cannot be split further (same-millisecond boundary — an unavoidable SonarQube Server API limitation for mass-import scenarios where all issues share one identical timestamp)
 
-**Verification:** Run `./cloudvoyager verify -c migrate-config.json --only issue-metadata` to compare issue counts between SonarQube and SonarCloud.
+**Verification:** Run `./cloudvoyager verify -c migrate-config.json --only issue-metadata` to compare issue counts between SonarQube Server and SonarQube Cloud.
 
 ---
 
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 ## 📦 Issue Creation Date Accuracy
 
-CloudVoyager preserves each issue's original SonarQube creation date in SonarCloud by rewriting SCM changeset blame dates in the protobuf report. This is automatic and transparent — no user configuration needed.
+CloudVoyager preserves each issue's original SonarQube Server creation date in SonarQube Cloud by rewriting SCM changeset blame dates in the protobuf report. This is automatic and transparent — no user configuration needed.
 
-> **How it works (v1.3.1+):** `backdateChangesets()` reads each issue's `creationDate` field from SonarQube and maps it to the issue's `textRange` lines in the file's changeset data. The CE takes MAX(date) across an issue's line range to determine its creation date, so per-line dating with "oldest wins" for overlapping lines preserves accurate dates. A safety split handles calendar days with >5K issues.
+> **How it works (v1.3.1+):** `backdateChangesets()` reads each issue's `creationDate` field from SonarQube Server and maps it to the issue's `textRange` lines in the file's changeset data. The CE takes MAX(date) across an issue's line range to determine its creation date, so per-line dating with "oldest wins" for overlapping lines preserves accurate dates. A safety split handles calendar days with >5K issues.
 
-### Issue creation dates don't match SonarQube
+### Issue creation dates don't match SonarQube Server
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
 Check that the migration was run with v1.3.1+. Earlier versions used arbitrary 30-day-spaced batch dates instead of original creation dates. Re-transfer affected projects to get accurate dates.
@@ -662,12 +662,12 @@ Check that the migration was run with v1.3.1+. Earlier versions used arbitrary 3
 ### Issue counts look correct in the API but not in the UI
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-SonarCloud's Elasticsearch caps visualization at 10K per date bucket. With accurate creation dates, issues are naturally distributed across their original dates. The safety split ensures no single day exceeds 5K issues. If you see this problem, verify the migration used v1.3.1+.
+SonarQube Cloud's Elasticsearch caps visualization at 10K per date bucket. With accurate creation dates, issues are naturally distributed across their original dates. The safety split ensures no single day exceeds 5K issues. If you see this problem, verify the migration used v1.3.1+.
 
 ### Warning: "N issues on DATE exceed 5K cap"
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-**Expected behavior.** This means a single calendar day had more than 5,000 issues with the same creation date. The safety split automatically sub-groups them into ≤5K batches with 1-day-spaced synthetic dates. The sub-groups will appear as separate adjacent dates in SonarCloud's creation date facet.
+**Expected behavior.** This means a single calendar day had more than 5,000 issues with the same creation date. The safety split automatically sub-groups them into ≤5K batches with 1-day-spaced synthetic dates. The sub-groups will appear as separate adjacent dates in SonarQube Cloud's creation date facet.
 
 ### Can I change the safety split threshold?
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -676,19 +676,19 @@ The threshold is hardcoded at 5,000 (50% safety margin under the 10K ES visualiz
 
 ---
 
-## 🔌 Third-Party Issues Not Appearing in SonarCloud
+## 🔌 Third-Party Issues Not Appearing in SonarQube Cloud
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-External (third-party) issues from SonarQube plugins not available in SonarCloud (e.g., MuleSoft, ABAP) may be silently dropped if the rule-repository detection fails.
+External (third-party) issues from SonarQube Server plugins not available in SonarQube Cloud (e.g., MuleSoft, ABAP) may be silently dropped if the rule-repository detection fails.
 
-**Symptom:** Issues from third-party plugins are missing in SonarCloud after migration, even though they exist in SonarQube.
+**Symptom:** Issues from third-party plugins are missing in SonarQube Cloud after migration, even though they exist in SonarQube Server.
 
 **Possible causes:**
-1. The SonarCloud `/api/rules/repositories` endpoint was unreachable during migration (network issue, token scope).
+1. The SonarQube Cloud `/api/rules/repositories` endpoint was unreachable during migration (network issue, token scope).
 2. The rule key does not contain a colon separator (malformed rule).
 3. The live repository set returned empty due to a transient API error.
 
-**Fix (v1.2+):** CloudVoyager now retries the repository API 3 times with exponential backoff and falls back to a built-in set of 43 known SonarCloud repositories. Rules without a colon are handled gracefully. If you migrated before v1.2, re-run the migration for affected projects.
+**Fix (v1.2+):** CloudVoyager now retries the repository API 3 times with exponential backoff and falls back to a built-in set of 43 known SonarQube Cloud repositories. Rules without a colon are handled gracefully. If you migrated before v1.2, re-run the migration for affected projects.
 
 **Debugging:** Enable `--verbose` and search the log for `FALLBACK_SONARCLOUD_REPOS` or `getRuleRepositories` to confirm whether the fallback was used.
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -3,7 +3,7 @@
 
 <!-- Updated: Apr 21, 2026 -->
 
-After running a migration, use the `verify` command to compare your SonarQube instance against SonarCloud and confirm that all data was transferred correctly. The verification pipeline is implemented in `src/shared/verification/verify-pipeline.js` and is entirely **read-only** — it does not modify any data on either SonarQube or SonarCloud.
+After running a migration, use the `verify` command to compare your SonarQube Server instance against SonarQube Cloud and confirm that all data was transferred correctly. The verification pipeline is implemented in `src/shared/verification/verify-pipeline.js` and is entirely **read-only** — it does not modify any data on either SonarQube Server or SonarQube Cloud.
 
 ```bash
 # Verify everything
@@ -82,7 +82,7 @@ Compares quality profile **definitions** (not assignments — those are per-proj
 | What | How |
 |------|-----|
 | Profile existence | SQ profiles matched to SC by `language + name` |
-| Migration suffix | SC profiles named `"X (SonarQube Migrated)"` are treated as equivalent to SQ `"X"` |
+| Migration suffix | SC profiles named `"X (SonarQube Server Migrated)"` are treated as equivalent to SQ `"X"` |
 | Active rule count | Compared for **custom profiles only** |
 | Built-in profiles | Rule count differences **skipped** — platform versions have different rule sets |
 | Unsupported languages | Profiles for SQ-only languages (e.g., `mulesoft`) are **skipped** — SC doesn't have the language |
@@ -110,7 +110,7 @@ Compares group-level permissions at the organization level.
 | What | How |
 |------|-----|
 | Permission sets | For each SQ group, checks that all SQ permissions exist in SC |
-| SC-unsupported perms | `applicationcreator` and `portfoliocreator` are **excluded** — these are SonarQube Enterprise permissions that don't exist in SonarCloud |
+| SC-unsupported perms | `applicationcreator` and `portfoliocreator` are **excluded** — these are SonarQube Server Enterprise permissions that don't exist in SonarQube Cloud |
 | Extra SC permissions | Allowed (e.g., SC may auto-grant `scan`) |
 
 **Pass** if all SQ group permissions (minus unsupported ones) exist in SC.
@@ -166,7 +166,7 @@ The most detailed check. Compares all issues between SQ and SC.
 | **Status** | Normalized from `status + resolution` (OPEN, FIXED, FALSE-POSITIVE, WONTFIX) |
 | **Assignment** | Direct comparison of assignee |
 | **Status history** | Fetches changelogs from both SQ and SC, extracts status transitions, and verifies that all SQ transitions appear in SC in order. Issues with no status changes are skipped |
-| **Comments** | Counts SC comments containing `[Migrated from SonarQube]` marker; flags if fewer than SQ comment count |
+| **Comments** | Counts SC comments containing `[Migrated from SonarQube Server]` marker; flags if fewer than SQ comment count |
 | **Tags** | Only flags if SQ tags are **missing** from SC; SC adding extra tags (e.g., `type-dependent`) is expected |
 | **External issue tags** | **Skipped entirely** — SC external issues don't preserve tags |
 | **Rule not in SC** | If a rule has zero presence in SC (no matches at all), unmatched issues for that rule are **excluded** from the failure count — it's a platform difference, not a migration failure |
@@ -189,7 +189,7 @@ Compares security hotspots between SQ and SC.
 |------|-----|
 | **Matching** | Hotspots matched by `ruleKey + filePath + lineNumber` |
 | **Status** | Normalized — `REVIEWED:SAFE`, `REVIEWED:ACKNOWLEDGED`, `REVIEWED:FIXED`, or `TO_REVIEW` |
-| **Comments** | Fetches SC hotspot details and counts `[Migrated from SonarQube]` comments |
+| **Comments** | Fetches SC hotspot details and counts `[Migrated from SonarQube Server]` comments |
 | **Assignments** | Tracked as "unsyncable" (hotspot API doesn't support assignment sync) |
 | **Rule not in SC** | Same as issues — if a rule has zero presence in SC hotspots (e.g., reclassified from hotspot to issue, or rule unavailable), unmatched hotspots are **excluded** from the failure count |
 
@@ -227,7 +227,7 @@ Checks which quality profile is assigned per language.
 | What | How |
 |------|-----|
 | Profile assignment | Compared by language |
-| Migration suffix | `"Sonar way (SonarQube Migrated)"` treated as equivalent to `"Sonar way"` |
+| Migration suffix | `"Sonar way (SonarQube Server Migrated)"` treated as equivalent to `"Sonar way"` |
 | Unsupported languages | Languages not in SC (e.g., `mulesoft`) are **skipped** |
 
 **Pass** if all SC-supported language profiles match.
@@ -338,7 +338,7 @@ Each check produces one of these statuses:
 ## Platform Differences (Gotchas)
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-These are known differences between SonarQube and SonarCloud that the verification system handles automatically. They are **not** migration failures.
+These are known differences between SonarQube Server and SonarQube Cloud that the verification system handles automatically. They are **not** migration failures.
 
 ### Rule Availability
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -358,14 +358,14 @@ When SQ has issues from plugins not available in SC (e.g., MuleSoft), the migrat
 
 | Platform | Rule key |
 |----------|----------|
-| SonarQube | `mulesoft:MS058` |
-| SonarCloud | `external_mulesoft:MS058` |
+| SonarQube Server | `mulesoft:MS058` |
+| SonarQube Cloud | `external_mulesoft:MS058` |
 
 The verifier normalizes rule keys by stripping the `external_` prefix before matching.
 
 **Important:** External issues in SC do **not** preserve tags from SQ. Tag comparison is skipped entirely for external issues.
 
-**Improved in v1.2:** External issue detection is now more reliable. If the SonarCloud `/api/rules/repositories` API is unreachable during migration, the tool falls back to a built-in set of 43 known repositories (with 3 retries and exponential backoff). Rules without a colon separator and empty repository prefixes are also handled gracefully. If verification shows missing external issues from a pre-v1.2 migration, re-run the migration for affected projects.
+**Improved in v1.2:** External issue detection is now more reliable. If the SonarQube Cloud `/api/rules/repositories` API is unreachable during migration, the tool falls back to a built-in set of 43 known repositories (with 3 retries and exponential backoff). Rules without a colon separator and empty repository prefixes are also handled gracefully. If verification shows missing external issues from a pre-v1.2 migration, re-run the migration for affected projects.
 
 ### Branch Naming
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
@@ -375,11 +375,11 @@ SQ and SC may have different default branch names (e.g., SQ uses `main`, SC uses
 ### Quality Profile Naming
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-The migration creates profiles with a `(SonarQube Migrated)` suffix to avoid colliding with SC's built-in profiles:
+The migration creates profiles with a `(SonarQube Server Migrated)` suffix to avoid colliding with SC's built-in profiles:
 
-| SonarQube | SonarCloud |
+| SonarQube Server | SonarQube Cloud |
 |-----------|------------|
-| `Sonar way` | `Sonar way (SonarQube Migrated)` |
+| `Sonar way` | `Sonar way (SonarQube Server Migrated)` |
 
 The verifier strips this suffix before comparing.
 
@@ -388,10 +388,10 @@ The verifier strips this suffix before comparing.
 
 Built-in quality gates ("Sonar way", "Sonar way for AI Code") and built-in profiles ("Sonar way" for each language) are managed by the platform. Their conditions and rule counts naturally differ between SQ and SC versions. The verifier skips detailed comparison for these.
 
-### SonarCloud-Unsupported Permissions
+### SonarQube Cloud-Unsupported Permissions
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-These SonarQube Enterprise permissions don't exist in SonarCloud and are excluded from comparison:
+These SonarQube Server Enterprise permissions don't exist in SonarQube Cloud and are excluded from comparison:
 
 - `applicationcreator` — create Applications (Enterprise feature)
 - `portfoliocreator` — create Portfolios (Enterprise feature)
@@ -414,9 +414,9 @@ SQ may have plugins that add languages not available in SC (e.g., MuleSoft's `mu
 ### Batch-Distributed Issues and Multiple Analysis Dates
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
-When a branch has more than 5,000 issues, the migration uses **batch distribution** to split those issues into chunks of up to 5,000 and assigns each chunk a separate `analysis_date` (computed by stepping backwards one day per batch from the original analysis date). This means a single branch that had one analysis in SonarQube may appear in SonarCloud with issues spread across multiple `analysis_date` values.
+When a branch has more than 5,000 issues, the migration uses **batch distribution** to split those issues into chunks of up to 5,000 and assigns each chunk a separate `analysis_date` (computed by stepping backwards one day per batch from the original analysis date). This means a single branch that had one analysis in SonarQube Server may appear in SonarQube Cloud with issues spread across multiple `analysis_date` values.
 
-**This is expected behavior, not a verification failure.** The batch distribution is a migration-time strategy to stay within SonarCloud's import limits and does not affect the correctness of the migrated data.
+**This is expected behavior, not a verification failure.** The batch distribution is a migration-time strategy to stay within SonarQube Cloud's import limits and does not affect the correctness of the migrated data.
 
 The verification pipeline compares **total issue counts and attributes** (rule, file, line, status, comments, tags, etc.) across the entire branch — it does not compare per-date counts. As a result, batch distribution should never cause false verification failures. If verification reports an issue-count mismatch, the cause is not the batching itself but a genuine migration gap.
 
@@ -446,7 +446,7 @@ SQ and SC may classify the same rule with different types (BUG vs CODE_SMELL) or
 
 ---
 
-## SonarQube API Gotchas
+## SonarQube Server API Gotchas
 <!-- <subsection-updated last-updated="2026-05-07T02:15:00Z" updated-by="Claude" /> -->
 
 These API quirks affect both migration and verification:


### PR DESCRIPTION
## Summary

Closes #136. Documentation-only PR with three commits:

1. **`581942c` — Document IN_SANDBOX → OPEN limitation (Issue #136).** SonarQube Server 2025+ introduces the `IN_SANDBOX` issue status (sandboxed AI rules). SonarQube Cloud has no equivalent state, so the migrator leaves these issues `OPEN` on the destination. Added a section in `docs/troubleshooting.md` and a note in `docs/key-capabilities.md` Section 7's status-mapping list. No code change — there is no SonarQube Cloud transition that maps to `IN_SANDBOX`.
2. **`1bca622` — Polish README intro wording.** Tighten the lead paragraph: use modern product names ("SonarQube Server"/"SonarQube Cloud"), say "migrates" instead of "copies", and drop the reverse-engineering sentence (still covered in `docs/key-capabilities.md` Section 2).
3. **`6d71b25` — Global rename across docs.** Rename `SonarQube` → `SonarQube Server` and `SonarCloud` → `SonarQube Cloud` across `README.md` and every file under `docs/`. Mechanical Perl pass with negative-lookahead regexes that preserve identifiers (`SonarQubeClient`, `createSonarCloudClient`, `VersionAwareSonarQubeClient`), URLs (`sonarcloud.io`, `sonarqube.us`), already-correct compounds, and lowercase strings. Follow-up cleanup collapsed 11 "SonarQube Server server" duplications back to "SonarQube Server".

25 files / 641 lines changed in commit 3.

## Test plan

- [x] `grep` confirms no naked `SonarQube` or `SonarCloud` references remain in `README.md` / `docs/*.md` (only compound terms, code identifiers, and URLs).
- [x] `grep` confirms no `SonarQube Server Server` / `SonarQube Cloud Cloud` artifacts.
- [x] Spot-checked headers and internal references — no broken anchor links.
- [ ] Visual review of the rendered docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that do not affect runtime behavior; main risk is minor confusion from terminology/compatibility wording changes.
> 
> **Overview**
> Updates documentation to consistently use current product naming (**SonarQube Server** and **SonarQube Cloud**) across `README.md` and the `docs/` set, including examples, tables, and error taxonomy references.
> 
> Adds/clarifies migration guidance: documents that source issues in `IN_SANDBOX` (SQ Server 2025+) are migrated as `OPEN` because SQC has no equivalent transition, and updates the README to state supported SonarQube Server version compatibility (9.9+ with tested ranges noted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d71b25d1f8458c94e7e31edf9ca30af21732368. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->