### PR TITLE
perf: raise default issue/hotspot sync concurrency to 50

### DIFF
--- a/desktop/src/renderer/js/screens/advanced-settings/renderer.js
+++ b/desktop/src/renderer/js/screens/advanced-settings/renderer.js
@@ -72,8 +72,8 @@ window.AdvancedSettingsScreen = {
           ${ConfigForm.numberField('perf-memory', 'Memory limit (MB)', perf.maxMemoryMB, { min: 0, max: 32768, hint: '0 = let the system decide' })}
           ${ConfigForm.numberField('perf-source', 'Source file extraction concurrency', perf.sourceExtraction?.concurrency ?? 50, { min: 1, max: 100, hint: 'Max concurrent source file fetches from SonarQube' })}
           ${ConfigForm.numberField('perf-hotspot', 'Hotspot extraction concurrency', perf.hotspotExtraction?.concurrency ?? 50, { min: 1, max: 100, hint: 'Max concurrent hotspot detail fetches from SonarQube' })}
-          ${ConfigForm.numberField('perf-issue-sync', 'Issue sync concurrency', perf.issueSync?.concurrency ?? 20, { min: 1, max: 50, hint: 'Max concurrent issue metadata sync operations to SonarCloud' })}
-          ${ConfigForm.numberField('perf-hotspot-sync', 'Hotspot sync concurrency', perf.hotspotSync?.concurrency ?? 20, { min: 1, max: 50, hint: 'Max concurrent hotspot sync operations to SonarCloud' })}
+          ${ConfigForm.numberField('perf-issue-sync', 'Issue sync concurrency', perf.issueSync?.concurrency ?? 50, { min: 1, max: 100, hint: 'Max concurrent issue metadata sync operations to SonarCloud' })}
+          ${ConfigForm.numberField('perf-hotspot-sync', 'Hotspot sync concurrency', perf.hotspotSync?.concurrency ?? 50, { min: 1, max: 100, hint: 'Max concurrent hotspot sync operations to SonarCloud' })}
           ${ConfigForm.numberField('perf-project', 'Project migration concurrency', perf.projectMigration?.concurrency ?? 8, { min: 1, max: 16, hint: 'Max concurrent project migrations' })}
           ${ConfigForm.numberField('perf-verify', 'Project verification concurrency', perf.projectVerification?.concurrency ?? 3, { min: 1, max: 16, hint: 'Max concurrent project verifications' })}
         </div>

--- a/desktop/src/renderer/js/screens/transfer-config.js
+++ b/desktop/src/renderer/js/screens/transfer-config.js
@@ -172,8 +172,8 @@ window.TransferConfigScreen = {
           ${ConfigForm.numberField('perf-memory', 'Max Memory (MB)', perf.maxMemoryMB, { min: 0, max: 32768, hint: 'Max heap size in MB. 0 = let the system decide. CLI flag: --max-memory' })}
           ${ConfigForm.numberField('perf-source', 'Source file extraction concurrency', perf.sourceExtraction?.concurrency ?? 50, { min: 1, max: 100, hint: 'Max concurrent source file fetches from SonarQube' })}
           ${ConfigForm.numberField('perf-hotspot', 'Hotspot extraction concurrency', perf.hotspotExtraction?.concurrency ?? 50, { min: 1, max: 100, hint: 'Max concurrent hotspot detail fetches from SonarQube' })}
-          ${ConfigForm.numberField('perf-issue-sync', 'Issue sync concurrency', perf.issueSync?.concurrency ?? 20, { min: 1, max: 50, hint: 'Max concurrent issue metadata sync operations to SonarCloud' })}
-          ${ConfigForm.numberField('perf-hotspot-sync', 'Hotspot sync concurrency', perf.hotspotSync?.concurrency ?? 20, { min: 1, max: 50, hint: 'Max concurrent hotspot sync operations to SonarCloud' })}
+          ${ConfigForm.numberField('perf-issue-sync', 'Issue sync concurrency', perf.issueSync?.concurrency ?? 50, { min: 1, max: 100, hint: 'Max concurrent issue metadata sync operations to SonarCloud' })}
+          ${ConfigForm.numberField('perf-hotspot-sync', 'Hotspot sync concurrency', perf.hotspotSync?.concurrency ?? 50, { min: 1, max: 100, hint: 'Max concurrent hotspot sync operations to SonarCloud' })}
           ${ConfigForm.numberField('perf-project', 'Project Concurrency', perf.projectMigration?.concurrency ?? 8, { min: 1, max: 16, hint: 'Max concurrent project migrations. CLI flag: --project-concurrency' })}
           ${ConfigForm.numberField('perf-verify', 'Verification Concurrency', perf.projectVerification?.concurrency ?? 3, { min: 1, max: 16, hint: 'Max concurrent project verifications' })}
         </div>
@@ -206,8 +206,8 @@ window.TransferConfigScreen = {
     this.config.performance.maxMemoryMB = numVal('perf-memory', 8192);
     this.config.performance.sourceExtraction = { concurrency: numVal('perf-source', 50) };
     this.config.performance.hotspotExtraction = { concurrency: numVal('perf-hotspot', 50) };
-    this.config.performance.issueSync = { concurrency: numVal('perf-issue-sync', 20) };
-    this.config.performance.hotspotSync = { concurrency: numVal('perf-hotspot-sync', 20) };
+    this.config.performance.issueSync = { concurrency: numVal('perf-issue-sync', 50) };
+    this.config.performance.hotspotSync = { concurrency: numVal('perf-hotspot-sync', 50) };
     this.config.performance.projectMigration = { concurrency: numVal('perf-project', 8) };
     this.config.performance.projectVerification = { concurrency: numVal('perf-verify', 3) };
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -233,8 +233,8 @@ Controls CPU, memory, and concurrency tuning. Add a `performance` section to any
     "maxMemoryMB": 8192,
     "sourceExtraction": { "concurrency": 50 },
     "hotspotExtraction": { "concurrency": 50 },
-    "issueSync": { "concurrency": 20 },
-    "hotspotSync": { "concurrency": 20 },
+    "issueSync": { "concurrency": 50 },
+    "hotspotSync": { "concurrency": 50 },
     "projectMigration": { "concurrency": 8 }
   }
 }
@@ -247,8 +247,8 @@ Controls CPU, memory, and concurrency tuning. Add a `performance` section to any
 | `maxMemoryMB` | `8192` | Max heap size in MB. Set to `0` for Node.js default. The tool auto-restarts with the increased heap size when needed. |
 | `sourceExtraction.concurrency` | `50` | Max concurrent source file fetches from SonarQube Server (1–50) |
 | `hotspotExtraction.concurrency` | `50` | Max concurrent hotspot detail fetches from SonarQube Server (1–50) |
-| `issueSync.concurrency` | `20` | Max concurrent issue metadata sync operations to SonarQube Cloud (1–20) |
-| `hotspotSync.concurrency` | `20` | Max concurrent hotspot sync operations to SonarQube Cloud (1–20) |
+| `issueSync.concurrency` | `50` | Max concurrent issue metadata sync operations to SonarQube Cloud (1–100) |
+| `hotspotSync.concurrency` | `50` | Max concurrent hotspot sync operations to SonarQube Cloud (1–100) |
 | `projectMigration.concurrency` | `8` | Max concurrent project migrations (1–8) |
 
 **Auto-tune defaults:** When `autoTune` is enabled (or `--auto-tune` CLI flag is used), the following values are calculated based on your hardware:

--- a/examples/migrate-config.example.json
+++ b/examples/migrate-config.example.json
@@ -44,8 +44,8 @@
     "maxMemoryMB": 0,
     "sourceExtraction": { "concurrency": 10 },
     "hotspotExtraction": { "concurrency": 10 },
-    "issueSync": { "concurrency": 5 },
-    "hotspotSync": { "concurrency": 3 },
+    "issueSync": { "concurrency": 50 },
+    "hotspotSync": { "concurrency": 50 },
     "projectMigration": { "concurrency": 1 }
   }
 }

--- a/src/commands/migrate/helpers/build-migrate-perf-config.js
+++ b/src/commands/migrate/helpers/build-migrate-perf-config.js
@@ -6,7 +6,7 @@ export function buildMigratePerfConfig(config, options) {
   return resolvePerformanceConfig({
     ...config.performance,
     ...(options.autoTune && { autoTune: true }),
-    ...(options.concurrency && { maxConcurrency: options.concurrency, sourceExtraction: { concurrency: options.concurrency }, hotspotExtraction: { concurrency: options.concurrency }, issueSync: { concurrency: options.concurrency }, hotspotSync: { concurrency: Math.min(options.concurrency, 3) } }),
+    ...(options.concurrency && { maxConcurrency: options.concurrency, sourceExtraction: { concurrency: options.concurrency }, hotspotExtraction: { concurrency: options.concurrency }, issueSync: { concurrency: options.concurrency }, hotspotSync: { concurrency: options.concurrency } }),
     ...(options.maxMemory && { maxMemoryMB: options.maxMemory }),
     ...(options.projectConcurrency && { projectMigration: { concurrency: options.projectConcurrency } })
   });

--- a/src/pipelines/sq-10.0/sonarcloud/migrators/hotspot-sync/index.js
+++ b/src/pipelines/sq-10.0/sonarcloud/migrators/hotspot-sync/index.js
@@ -14,7 +14,7 @@ export { mapHotspotChangelogDiffToAction, extractHotspotTransitionsFromChangelog
 // -------- Sync Hotspots --------
 
 export async function syncHotspots(projectKey, sqHotspots, client, options = {}) {
-  const concurrency = options.concurrency || 3;
+  const concurrency = options.concurrency || 50;
   const stats = createEmptyHotspotStats();
 
   if (options.sqClient && options.sonarqubeProjectKey) {

--- a/src/pipelines/sq-10.0/sonarcloud/migrators/issue-sync/index.js
+++ b/src/pipelines/sq-10.0/sonarcloud/migrators/issue-sync/index.js
@@ -15,7 +15,7 @@ export { mapChangelogDiffToTransition, extractTransitionsFromChangelog } from '.
 // -------- Sync Issues Orchestrator --------
 
 export async function syncIssues(projectKey, sqIssues, client, options = {}) {
-  const concurrency = options.concurrency || 5;
+  const concurrency = options.concurrency || 50;
   const sqClient = options.sqClient || null;
   const userMappings = options.userMappings || null;
   const stats = createEmptyStats();

--- a/src/pipelines/sq-10.0/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-hotspots.js
+++ b/src/pipelines/sq-10.0/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-hotspots.js
@@ -10,7 +10,7 @@ export async function fetchAndSyncHotspots(opts) {
     performanceConfig = {} } = opts;
 
   const extractConcurrency = performanceConfig?.hotspotExtraction?.concurrency || 10;
-  const syncConcurrency = performanceConfig?.hotspotSync?.concurrency || 3;
+  const syncConcurrency = performanceConfig?.hotspotSync?.concurrency || 50;
 
   logger.info('Extracting SonarQube hotspots with details...');
   const sqHotspots = await extractHotspots(sonarQubeClient, null, {

--- a/src/pipelines/sq-10.0/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-issues.js
+++ b/src/pipelines/sq-10.0/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-issues.js
@@ -8,7 +8,7 @@ export async function fetchAndSyncIssues(opts) {
   const { sonarQubeClient, sonarCloudClient, projectKey,
     performanceConfig = {} } = opts;
 
-  const concurrency = performanceConfig?.issueSync?.concurrency || 5;
+  const concurrency = performanceConfig?.issueSync?.concurrency || 50;
 
   logger.info('Fetching SonarQube issues with comments...');
   const sqIssues = await sonarQubeClient.getIssuesWithComments();

--- a/src/pipelines/sq-10.4/sonarcloud/migrators/hotspot-sync/helpers/sync-hotspots.js
+++ b/src/pipelines/sq-10.4/sonarcloud/migrators/hotspot-sync/helpers/sync-hotspots.js
@@ -10,7 +10,7 @@ import { syncSingleHotspot } from './sync-single-hotspot.js';
 
 // Sync hotspot statuses, assignments, and comments from SonarQube to SonarCloud.
 export async function syncHotspots(projectKey, sqHotspots, client, options = {}) {
-  const concurrency = options.concurrency || 3;
+  const concurrency = options.concurrency || 50;
   const stats = createSyncStats();
 
   if (options.sqClient && options.sonarqubeProjectKey) {

--- a/src/pipelines/sq-10.4/sonarcloud/migrators/issue-sync/helpers/sync-issues.js
+++ b/src/pipelines/sq-10.4/sonarcloud/migrators/issue-sync/helpers/sync-issues.js
@@ -15,7 +15,7 @@ import logger from '../../../../../../shared/utils/logger.js';
  * Pre-filters SQ issues to only those with manual changes for efficiency.
  */
 export async function syncIssues(projectKey, sqIssues, client, options = {}) {
-  const concurrency = options.concurrency || 5;
+  const concurrency = options.concurrency || 50;
   const sqClient = options.sqClient || null;
   const userMappings = options.userMappings || null;
   const stats = createSyncStats();

--- a/src/pipelines/sq-10.4/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-hotspots.js
+++ b/src/pipelines/sq-10.4/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-hotspots.js
@@ -10,7 +10,7 @@ export async function fetchAndSyncHotspots(opts) {
     performanceConfig = {} } = opts;
 
   const extractConcurrency = performanceConfig?.hotspotExtraction?.concurrency || 10;
-  const syncConcurrency = performanceConfig?.hotspotSync?.concurrency || 3;
+  const syncConcurrency = performanceConfig?.hotspotSync?.concurrency || 50;
 
   logger.info('Extracting SonarQube hotspots with details...');
   const sqHotspots = await extractHotspots(sonarQubeClient, null, {

--- a/src/pipelines/sq-10.4/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-issues.js
+++ b/src/pipelines/sq-10.4/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-issues.js
@@ -8,7 +8,7 @@ export async function fetchAndSyncIssues(opts) {
   const { sonarQubeClient, sonarCloudClient, projectKey,
     performanceConfig = {} } = opts;
 
-  const concurrency = performanceConfig?.issueSync?.concurrency || 5;
+  const concurrency = performanceConfig?.issueSync?.concurrency || 50;
 
   logger.info('Fetching SonarQube issues with comments...');
   const sqIssues = await sonarQubeClient.getIssuesWithComments();

--- a/src/pipelines/sq-2025/sonarcloud/migrators/hotspot-sync/index.js
+++ b/src/pipelines/sq-2025/sonarcloud/migrators/hotspot-sync/index.js
@@ -13,7 +13,7 @@ export { mapHotspotChangelogDiffToAction, extractHotspotTransitionsFromChangelog
 
 /** Sync hotspot statuses, comments, and source links from SQ to SC. */
 export async function syncHotspots(projectKey, sqHotspots, client, options = {}) {
-  const concurrency = options.concurrency || 3;
+  const concurrency = options.concurrency || 50;
   const stats = { matched: 0, statusChanged: 0, commented: 0, metadataSyncCommented: 0, sourceLinked: 0, failed: 0 };
 
   if (options.sqClient && options.sonarqubeProjectKey) {

--- a/src/pipelines/sq-2025/sonarcloud/migrators/issue-sync/index.js
+++ b/src/pipelines/sq-2025/sonarcloud/migrators/issue-sync/index.js
@@ -21,7 +21,7 @@ export { extractTransitionsFromChangelog } from './helpers/extract-transitions.j
  * Pre-filters SQ issues to only those with manual changes for efficiency.
  */
 export async function syncIssues(projectKey, sqIssues, client, options = {}) {
-  const concurrency = options.concurrency || 5;
+  const concurrency = options.concurrency || 50;
   const sqClient = options.sqClient || null;
   const userMappings = options.userMappings || null;
   const stats = createSyncStats();

--- a/src/pipelines/sq-2025/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-hotspots.js
+++ b/src/pipelines/sq-2025/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-hotspots.js
@@ -10,7 +10,7 @@ export async function fetchAndSyncHotspots(opts) {
     performanceConfig = {} } = opts;
 
   const extractConcurrency = performanceConfig?.hotspotExtraction?.concurrency || 10;
-  const syncConcurrency = performanceConfig?.hotspotSync?.concurrency || 3;
+  const syncConcurrency = performanceConfig?.hotspotSync?.concurrency || 50;
 
   logger.info('Extracting SonarQube hotspots with details...');
   const sqHotspots = await extractHotspots(sonarQubeClient, null, {

--- a/src/pipelines/sq-2025/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-issues.js
+++ b/src/pipelines/sq-2025/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-issues.js
@@ -8,7 +8,7 @@ export async function fetchAndSyncIssues(opts) {
   const { sonarQubeClient, sonarCloudClient, projectKey,
     performanceConfig = {} } = opts;
 
-  const concurrency = performanceConfig?.issueSync?.concurrency || 5;
+  const concurrency = performanceConfig?.issueSync?.concurrency || 50;
 
   logger.info('Fetching SonarQube issues with comments...');
   const sqIssues = await sonarQubeClient.getIssuesWithComments();

--- a/src/pipelines/sq-9.9/sonarcloud/migrators/hotspot-sync/helpers/sync-hotspots.js
+++ b/src/pipelines/sq-9.9/sonarcloud/migrators/hotspot-sync/helpers/sync-hotspots.js
@@ -9,7 +9,7 @@ import { syncHotspotComments } from './sync-hotspot-comments.js';
 // -------- Sync Hotspots from SonarQube to SonarCloud --------
 
 export async function syncHotspots(projectKey, sqHotspots, client, options = {}) {
-  const concurrency = options.concurrency || 3;
+  const concurrency = options.concurrency || 50;
   const stats = { matched: 0, statusChanged: 0, commented: 0, metadataSyncCommented: 0, sourceLinked: 0, failed: 0 };
 
   if (options.sqClient && options.sonarqubeProjectKey) {

--- a/src/pipelines/sq-9.9/sonarcloud/migrators/issue-sync/helpers/sync-issues.js
+++ b/src/pipelines/sq-9.9/sonarcloud/migrators/issue-sync/helpers/sync-issues.js
@@ -13,7 +13,7 @@ import { syncIssueCommentsAndTags } from './sync-issue-comments-and-tags.js';
 // -------- Sync Issues from SonarQube to SonarCloud --------
 
 export async function syncIssues(projectKey, sqIssues, client, options = {}) {
-  const concurrency = options.concurrency || 5;
+  const concurrency = options.concurrency || 50;
   const sqClient = options.sqClient || null;
   const userMappings = options.userMappings || null;
   const stats = createEmptyStats();

--- a/src/pipelines/sq-9.9/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-hotspots.js
+++ b/src/pipelines/sq-9.9/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-hotspots.js
@@ -10,7 +10,7 @@ export async function fetchAndSyncHotspots(opts) {
     performanceConfig = {} } = opts;
 
   const extractConcurrency = performanceConfig?.hotspotExtraction?.concurrency || 10;
-  const syncConcurrency = performanceConfig?.hotspotSync?.concurrency || 3;
+  const syncConcurrency = performanceConfig?.hotspotSync?.concurrency || 50;
 
   logger.info('Extracting SonarQube hotspots with details...');
   const sqHotspots = await extractHotspots(sonarQubeClient, null, {

--- a/src/pipelines/sq-9.9/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-issues.js
+++ b/src/pipelines/sq-9.9/transfer-pipeline/helpers/sync-transfer-metadata/helpers/fetch-and-sync-issues.js
@@ -8,7 +8,7 @@ export async function fetchAndSyncIssues(opts) {
   const { sonarQubeClient, sonarCloudClient, projectKey,
     performanceConfig = {} } = opts;
 
-  const concurrency = performanceConfig?.issueSync?.concurrency || 5;
+  const concurrency = performanceConfig?.issueSync?.concurrency || 50;
 
   logger.info('Fetching SonarQube issues with comments...');
   const sqIssues = await sonarQubeClient.getIssuesWithComments();

--- a/src/shared/config/schema-shared/helpers/performance-schema.js
+++ b/src/shared/config/schema-shared/helpers/performance-schema.js
@@ -15,11 +15,11 @@ export const performanceSchema = {
     },
     issueSync: {
       type: 'object', additionalProperties: false,
-      properties: { concurrency: { type: 'integer', minimum: 1, maximum: 50, default: 20, description: 'Max concurrent issue metadata sync operations to SonarCloud' } }
+      properties: { concurrency: { type: 'integer', minimum: 1, maximum: 100, default: 50, description: 'Max concurrent issue metadata sync operations to SonarCloud' } }
     },
     hotspotSync: {
       type: 'object', additionalProperties: false,
-      properties: { concurrency: { type: 'integer', minimum: 1, maximum: 50, default: 20, description: 'Max concurrent hotspot sync operations to SonarCloud' } }
+      properties: { concurrency: { type: 'integer', minimum: 1, maximum: 100, default: 50, description: 'Max concurrent hotspot sync operations to SonarCloud' } }
     },
     projectMigration: {
       type: 'object', additionalProperties: false,

--- a/src/shared/utils/system-info/helpers/resolve-performance-config.js
+++ b/src/shared/utils/system-info/helpers/resolve-performance-config.js
@@ -5,7 +5,7 @@ export function resolvePerformanceConfig(perfConfig = {}) {
   const defaults = perfConfig.autoTune ? getAutoTuneDefaults() : {
     maxConcurrency: 64, maxMemoryMB: 8192,
     sourceExtraction: { concurrency: 50 }, hotspotExtraction: { concurrency: 50 },
-    issueSync: { concurrency: 20 }, hotspotSync: { concurrency: 20 },
+    issueSync: { concurrency: 50 }, hotspotSync: { concurrency: 50 },
     projectMigration: { concurrency: 8 }
   };
   return {


### PR DESCRIPTION
## Summary

Raise the default concurrency for issue and hotspot metadata sync from `20` to `50` across all 4 pipelines (sq-9.9, sq-10.0, sq-10.4, sq-2025). The previous defaults bottlenecked migrations on SonarQube Cloud API throughput rather than on round-trip latency — `issueSync` defaulted to 20, `hotspotSync` to 20 (and `5`/`3` in the older transfer-pipeline shortcuts).

The setting was already configurable; this PR keeps it that way and just shifts the floor up:

- **Migration config**: `performance.issueSync.concurrency` / `performance.hotspotSync.concurrency` (range now `1`–`100`).
- **Desktop UI**: Advanced Settings → "Issue sync concurrency" / "Hotspot sync concurrency" (max raised to `100`).
- **CLI**: `--concurrency N` applies to all sync stages, including hotspots — previously capped at `3` by an artifact (`Math.min(options.concurrency, 3)`), now lifted.

Auto-tune is unchanged — it still scales by CPU count by design.

## Files changed (23)

- Schema: `src/shared/config/schema-shared/helpers/performance-schema.js` (defaults + max).
- Runtime resolver: `src/shared/utils/system-info/helpers/resolve-performance-config.js`.
- Per-pipeline `syncIssues` / `syncHotspots` fallbacks (4 pipelines, 8 files).
- Transfer-pipeline `fetch-and-sync-{issues,hotspots}` fallbacks (4 pipelines, 8 files).
- CLI override: `src/commands/migrate/helpers/build-migrate-perf-config.js`.
- Desktop UI: `desktop/src/renderer/js/screens/{transfer-config,advanced-settings/renderer}.js`.
- Example config: `examples/migrate-config.example.json`.
- Docs: `docs/configuration.md`.

## Test plan

- [x] Full suite: 70 pre-existing failures on `main`, 70 with this change. Sorted-diff confirms identical failure set — zero regressions.
- [ ] Live regression on a reference project: confirm the default-50 doesn't trip rate-limit / 503 errors on SonarQube Cloud and that the sync phase wall-clock time drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises default parallelism for SonarCloud issue/hotspot metadata syncing, which can increase API load and expose rate-limit/503 behavior in real migrations. Changes are mostly default/validation updates but affect runtime concurrency across multiple pipelines and the CLI/UI defaults.
> 
> **Overview**
> **Increases default SonarCloud metadata sync concurrency** for both issues and hotspots to `50` across the app (including per-pipeline `syncIssues`/`syncHotspots` and transfer helpers), replacing prior lower fallbacks.
> 
> Updates config handling to match the new baseline: schema defaults and allowed max move to `1–100`, desktop UI fields default/max are adjusted accordingly, and the migrate CLI `--concurrency` override now applies the same value to hotspot sync (removing the previous low cap). Documentation and example configs are updated to reflect the new defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f5e4d8c4d48f23a8ff538f542f1fdbbcf08778e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->